### PR TITLE
feat : Notification 기능 구현

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/common/dto/BaseResponse.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/common/dto/BaseResponse.java
@@ -1,0 +1,19 @@
+package com.icandoit.boottalk.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+public class BaseResponse {
+
+  private String message;
+  private Object data;
+
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/controller/NotificationController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/controller/NotificationController.java
@@ -1,0 +1,111 @@
+package com.icandoit.boottalk.notification.controller;
+
+import com.icandoit.boottalk.notification.dto.NotificationRequest;
+import com.icandoit.boottalk.notification.dto.NotificationResponse.NotificationResponseDto;
+import com.icandoit.boottalk.notification.dto.NotificationResponse.Response;
+import com.icandoit.boottalk.notification.entity.Notification;
+import com.icandoit.boottalk.notification.service.NotificationService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/notification")
+@RequiredArgsConstructor
+public class NotificationController {
+
+	private final NotificationService notificationService;
+
+	@PostMapping
+	public ResponseEntity<?> createNotification(
+		@RequestBody NotificationRequest request
+	) {
+		try {
+			Notification notification = notificationService.save(request);
+			NotificationResponseDto responseDto = new NotificationResponseDto(notification);
+
+			return ResponseEntity.ok(new Response("알림이 성공적으로 생성되었습니다.", responseDto));
+		} catch (Exception e) {
+			return ResponseEntity.badRequest()
+				.body(new Response(e.getMessage(), null));
+		}
+	}
+
+	@GetMapping("/{notificationId}")
+	public ResponseEntity<?> getNotificationByNotificationId(
+		@PathVariable Long notificationId
+	) {
+		try {
+			Notification notification = notificationService.findById(notificationId);
+			NotificationResponseDto responseDto = new NotificationResponseDto(notification);
+			return ResponseEntity.ok(new Response("알림 조회에 성공했습니다.", responseDto));
+		} catch (Exception e) {
+			return ResponseEntity.badRequest()
+				.body(new Response(e.getMessage(), null));
+		}
+	}
+
+	@GetMapping("/my/{userId}")
+	public ResponseEntity<?> getNotificationByUserId(
+		@PathVariable Long userId,
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "10") int size
+	) {
+		try {
+			Pageable pageable = PageRequest.of(page, size);
+			Page<Notification> notificationPage = notificationService.findAllByUserId(userId,
+				pageable);
+			List<NotificationResponseDto> notificationResponseDtoList =
+				notificationPage.getContent().stream()
+					.map(NotificationResponseDto::new)
+					.toList();
+
+			return ResponseEntity.ok(
+				new Response("사용자의 알림 목록 전체 조회에 성공했습니다.", notificationResponseDtoList)
+			);
+		} catch (Exception e) {
+			return ResponseEntity.badRequest()
+				.body(new Response(e.getMessage(), null));
+		}
+	}
+
+	@PutMapping("/{notificationId}")
+	public ResponseEntity<?> updateNotification(
+		@PathVariable Long notificationId,
+		@RequestBody NotificationRequest request
+	) {
+		try {
+			Notification updatedNotification = notificationService.update(notificationId, request);
+			NotificationResponseDto responseDto = new NotificationResponseDto(updatedNotification);
+			return ResponseEntity.ok(new Response("알림 수정에 성공했습니다.", responseDto));
+		} catch (Exception e) {
+			return ResponseEntity.badRequest()
+				.body(new Response(e.getMessage(), null));
+		}
+	}
+
+	@DeleteMapping("/{notificationId}")
+	public ResponseEntity<?> deleteNotification(
+		@PathVariable Long notificationId
+	) {
+		try {
+			notificationService.delete(notificationId);
+			return ResponseEntity.ok(new Response("알림 삭제에 성공했습니다.", null));
+		} catch (Exception e) {
+			return ResponseEntity.badRequest()
+				.body(new Response("알림 삭제에 실패했습니다.", null));
+		}
+	}
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/dto/NotificationRequest.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/dto/NotificationRequest.java
@@ -1,0 +1,18 @@
+package com.icandoit.boottalk.notification.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class NotificationRequest {
+	private Long userId;
+	private String type;
+	private String message;
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/dto/NotificationResponse.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/dto/NotificationResponse.java
@@ -1,0 +1,44 @@
+package com.icandoit.boottalk.notification.dto;
+
+import com.icandoit.boottalk.common.dto.BaseResponse;
+import com.icandoit.boottalk.notification.entity.Notification;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+public class NotificationResponse {
+
+	@Getter
+	@Setter
+	@EqualsAndHashCode(callSuper = true)
+	public static class Response extends BaseResponse {
+
+		public Response(String Message) {
+			super(Message, null);
+		}
+
+		public Response(String message, Object data) {
+			super(message, data);
+		}
+	}
+
+	@Getter
+	@Setter
+	public static class NotificationResponseDto {
+
+		private Long id;
+		private Long userId;
+		private String type;
+		private String message;
+		private boolean isRead;
+
+		public NotificationResponseDto(Notification notification) {
+			this.id = notification.getId();
+			this.userId = notification.getUser().getUserId();
+			this.type = String.valueOf(notification.getType());
+			this.message = notification.getMessage();
+			this.isRead = notification.isRead();
+		}
+	}
+
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/entity/Notification.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/entity/Notification.java
@@ -1,0 +1,47 @@
+package com.icandoit.boottalk.notification.entity;
+
+import com.icandoit.boottalk.common.entity.BaseEntity;
+import com.icandoit.boottalk.user.domain.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Notification extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@JoinColumn(name = "user_id", nullable = false)
+	@ManyToOne(fetch = FetchType.LAZY)
+	private User user;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private NotificationType type;
+
+	@Column(nullable = false)
+	private String message;
+
+	@Column(nullable = false, columnDefinition = "boolean default false")
+	private boolean isRead;
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/entity/NotificationType.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/entity/NotificationType.java
@@ -1,0 +1,7 @@
+package com.icandoit.boottalk.notification.entity;
+
+public enum NotificationType {
+	CERTIFICATE,
+	COFFEE_CHAT_REQUEST,
+	COFFEE_CHAT_CONFIRMATION
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/repository/NotificationRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/repository/NotificationRepository.java
@@ -1,0 +1,11 @@
+package com.icandoit.boottalk.notification.repository;
+
+import com.icandoit.boottalk.notification.entity.Notification;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+	Page<Notification> findAllByUser_UserId(Long userId, Pageable pageable);
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/service/NotificationService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/service/NotificationService.java
@@ -1,0 +1,124 @@
+package com.icandoit.boottalk.notification.service;
+
+import com.icandoit.boottalk.notification.dto.NotificationRequest;
+import com.icandoit.boottalk.notification.entity.Notification;
+import com.icandoit.boottalk.notification.entity.NotificationType;
+import com.icandoit.boottalk.notification.repository.NotificationRepository;
+import com.icandoit.boottalk.user.domain.entity.User;
+import com.icandoit.boottalk.user.domain.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+	private final UserRepository userRepository;
+	private final NotificationRepository repository;
+
+	/**
+	 * 알림 저장
+	 *
+	 * @param request NotificationRequest DTO
+	 * @return Notification
+	 */
+	public Notification save(NotificationRequest request) {
+		Notification notification = createNotification(request);
+		return repository.save(notification);
+	}
+
+	/**
+	 * NotificationRequest -> Notification
+	 *
+	 * @param request NotificationRequestDto
+	 * @return Notification
+	 */
+	private Notification createNotification(NotificationRequest request) {
+		User user = findUserByUserId(request.getUserId());
+
+		NotificationType notificationType;
+
+		try {
+			notificationType = NotificationType.valueOf(request.getType());
+		} catch (IllegalArgumentException e) {
+			throw new IllegalArgumentException("유효하지 않은 Notification Type 입니다.");
+		}
+
+		return Notification.builder()
+			.user(user)
+			.type(notificationType)
+			.message(request.getMessage())
+			.build();
+	}
+
+
+	/**
+	 * Notification ID로 조회
+	 *
+	 * @param notificationId Notification_id
+	 * @return Optional<Notification>
+	 */
+	public Notification findById(Long notificationId) {
+		return findNotificationByNotificationId(notificationId);
+	}
+
+	/**
+	 * 사용자 ID에 해당하는 Notification 전체 조회
+	 *
+	 * @param userId   user_id
+	 * @param pageable pageable 정보
+	 * @return Page<Notification>
+	 */
+	public Page<Notification> findAllByUserId(Long userId, Pageable pageable) {
+		if(!userRepository.existsById(userId)) {
+			throw new IllegalArgumentException("해당 유저가 존재하지 않습니다.");
+		}
+
+		return repository.findAllByUser_UserId(userId, pageable);
+	}
+
+	/**
+	 * Notification 수정
+	 *
+	 * @param notificationId notification_id
+	 * @param request        Notification Request DTO
+	 * @return Notification
+	 */
+	public Notification update(Long notificationId, NotificationRequest request) {
+		Notification notification = findNotificationByNotificationId(notificationId);
+		User user = findUserByUserId(request.getUserId());
+
+		notification.setUser(user);
+		notification.setMessage(request.getMessage());
+
+		return repository.save(notification);
+	}
+
+	/**
+	 * 알림 삭제
+	 *
+	 * @param notificationId notification_id
+	 */
+	@Transactional
+	public void delete(Long notificationId) {
+		if (!repository.existsById(notificationId)) {
+			throw new IllegalArgumentException("해당 알림이 존재하지 않습니다.");
+		}
+
+		repository.deleteById(notificationId);
+	}
+
+	private User findUserByUserId(Long userId) {
+		return userRepository.findById(userId)
+			.orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));
+	}
+
+	private Notification findNotificationByNotificationId(Long notificationId) {
+		return repository.findById(notificationId)
+			.orElseThrow(() -> new IllegalArgumentException("해당 알림이 존재하지 않습니다."));
+
+	}
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/controller/ManageController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/controller/ManageController.java
@@ -3,7 +3,6 @@ package com.icandoit.boottalk.user.controller;
 import com.icandoit.boottalk.common.dto.BaseResponse;
 import com.icandoit.boottalk.user.domain.form.UpdateForm;
 import com.icandoit.boottalk.user.service.ManageService;
-import java.math.BigInteger;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -19,28 +18,29 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/users/my")
 public class ManageController {
 
-  private final ManageService manageService;
+	private final ManageService manageService;
 
-  @GetMapping
-  public ResponseEntity<BaseResponse> getUser(@RequestParam BigInteger userId) {
+	@GetMapping
+	public ResponseEntity<BaseResponse> getUser(@RequestParam Long userId) {
 
-    return ResponseEntity.ok(new BaseResponse("회원정보가 조회되었습니다.", manageService.getUser(userId)));
-  }
+		return ResponseEntity.ok(new BaseResponse("회원정보가 조회되었습니다.", manageService.getUser(userId)));
+	}
 
-  @PutMapping
-  public ResponseEntity<BaseResponse> updateUser(@RequestParam BigInteger userId, @RequestBody UpdateForm form) {
+	@PutMapping
+	public ResponseEntity<BaseResponse> updateUser(@RequestParam Long userId,
+		@RequestBody UpdateForm form) {
 
-    return ResponseEntity.ok(new BaseResponse("회원정보가 수정되었습니다.", manageService.updateUser(userId, form)));
-  }
+		return ResponseEntity.ok(
+			new BaseResponse("회원정보가 수정되었습니다.", manageService.updateUser(userId, form)));
+	}
 
-  @DeleteMapping
-  public ResponseEntity<BaseResponse> deleteUser(@RequestParam BigInteger userId) {
+	@DeleteMapping
+	public ResponseEntity<BaseResponse> deleteUser(@RequestParam Long userId) {
 
-    manageService.deleteUser(userId);
+		manageService.deleteUser(userId);
 
-    return ResponseEntity.ok(new BaseResponse("회원 탈퇴되었습니다.", null));
-  }
-
+		return ResponseEntity.ok(new BaseResponse("회원 탈퇴되었습니다.", null));
+	}
 
 
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/controller/ManageController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/controller/ManageController.java
@@ -1,0 +1,46 @@
+package com.icandoit.boottalk.user.controller;
+
+import com.icandoit.boottalk.common.dto.BaseResponse;
+import com.icandoit.boottalk.user.domain.form.UpdateForm;
+import com.icandoit.boottalk.user.service.ManageService;
+import java.math.BigInteger;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users/my")
+public class ManageController {
+
+  private final ManageService manageService;
+
+  @GetMapping
+  public ResponseEntity<BaseResponse> getUser(@RequestParam BigInteger userId) {
+
+    return ResponseEntity.ok(new BaseResponse("회원정보가 조회되었습니다.", manageService.getUser(userId)));
+  }
+
+  @PutMapping
+  public ResponseEntity<BaseResponse> updateUser(@RequestParam BigInteger userId, @RequestBody UpdateForm form) {
+
+    return ResponseEntity.ok(new BaseResponse("회원정보가 수정되었습니다.", manageService.updateUser(userId, form)));
+  }
+
+  @DeleteMapping
+  public ResponseEntity<BaseResponse> deleteUser(@RequestParam BigInteger userId) {
+
+    manageService.deleteUser(userId);
+
+    return ResponseEntity.ok(new BaseResponse("회원 탈퇴되었습니다.", null));
+  }
+
+
+
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/controller/SignUpController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/controller/SignUpController.java
@@ -1,0 +1,29 @@
+package com.icandoit.boottalk.user.controller;
+
+import com.icandoit.boottalk.common.dto.BaseResponse;
+import com.icandoit.boottalk.user.domain.form.SignUpForm;
+import com.icandoit.boottalk.user.service.SignUpService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users/signup")
+public class SignUpController {
+
+  private final SignUpService signUpService;
+
+  @PostMapping
+  public ResponseEntity<BaseResponse> signUp(@RequestBody SignUpForm form) {
+
+    signUpService.signUp(form);
+
+    return ResponseEntity.ok(new BaseResponse("회원가입이 완료되었습니다", null));
+  }
+
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/dto/UserDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/dto/UserDto.java
@@ -1,0 +1,31 @@
+package com.icandoit.boottalk.user.domain.dto;
+
+import com.icandoit.boottalk.user.domain.entity.User;
+import com.icandoit.boottalk.user.domain.type.DesiredCareer;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserDto {
+
+  private String name;
+  private String email;
+  private String profileImage;
+  private DesiredCareer desiredCareer;
+
+  public static UserDto from(User user) {
+    return UserDto.builder()
+        .name(user.getName())
+        .email(user.getEmail())
+        .profileImage(user.getProfileImage())
+        .desiredCareer(user.getDesiredCareer())
+        .build();
+  }
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/entity/User.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/entity/User.java
@@ -34,7 +34,6 @@ public class User extends BaseEntity {
   @Enumerated(EnumType.STRING)
   private DesiredCareer desiredCareer;
 
-  private int currentPoint;
   private Timestamp deletedAt;
 
   public static User from(SignUpForm form) {
@@ -44,7 +43,6 @@ public class User extends BaseEntity {
         .email(form.getEmail())
         .profileImage(form.getProfileImage())
         .desiredCareer(form.getDesiredCareer())
-        .currentPoint(0)
         .deletedAt(null)
         .build();
   }

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/entity/User.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/entity/User.java
@@ -1,0 +1,62 @@
+package com.icandoit.boottalk.user.domain.entity;
+
+import com.icandoit.boottalk.common.entity.BaseEntity;
+import com.icandoit.boottalk.user.domain.form.SignUpForm;
+import com.icandoit.boottalk.user.domain.form.UpdateForm;
+import com.icandoit.boottalk.user.domain.type.DesiredCareer;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import java.math.BigInteger;
+import java.sql.Timestamp;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class User extends BaseEntity {
+
+  @Id
+  private BigInteger userId;
+
+  private String name;
+  private String email;
+  private String profileImage;
+
+  @Enumerated(EnumType.STRING)
+  private DesiredCareer desiredCareer;
+
+  private int currentPoint;
+  private Timestamp deletedAt;
+
+  public static User from(SignUpForm form) {
+    return User.builder()
+        .userId(form.getUserId())
+        .name(form.getName())
+        .email(form.getEmail())
+        .profileImage(form.getProfileImage())
+        .desiredCareer(form.getDesiredCareer())
+        .currentPoint(0)
+        .deletedAt(null)
+        .build();
+  }
+
+  public User updateFrom(UpdateForm form) {
+    this.name = form.getName();
+    this.email = form.getEmail();
+    this.profileImage = form.getProfileImage();
+    this.desiredCareer = form.getDesiredCareer();
+
+    return this;
+  }
+
+
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/entity/User.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/entity/User.java
@@ -8,7 +8,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
-import java.math.BigInteger;
 import java.sql.Timestamp;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -24,37 +23,37 @@ import lombok.Setter;
 @Entity
 public class User extends BaseEntity {
 
-  @Id
-  private BigInteger userId;
+	@Id
+	private Long userId;
 
-  private String name;
-  private String email;
-  private String profileImage;
+	private String name;
+	private String email;
+	private String profileImage;
 
-  @Enumerated(EnumType.STRING)
-  private DesiredCareer desiredCareer;
+	@Enumerated(EnumType.STRING)
+	private DesiredCareer desiredCareer;
 
-  private Timestamp deletedAt;
+	private Timestamp deletedAt;
 
-  public static User from(SignUpForm form) {
-    return User.builder()
-        .userId(form.getUserId())
-        .name(form.getName())
-        .email(form.getEmail())
-        .profileImage(form.getProfileImage())
-        .desiredCareer(form.getDesiredCareer())
-        .deletedAt(null)
-        .build();
-  }
+	public static User from(SignUpForm form) {
+		return User.builder()
+			.userId(form.getUserId())
+			.name(form.getName())
+			.email(form.getEmail())
+			.profileImage(form.getProfileImage())
+			.desiredCareer(form.getDesiredCareer())
+			.deletedAt(null)
+			.build();
+	}
 
-  public User updateFrom(UpdateForm form) {
-    this.name = form.getName();
-    this.email = form.getEmail();
-    this.profileImage = form.getProfileImage();
-    this.desiredCareer = form.getDesiredCareer();
+	public User updateFrom(UpdateForm form) {
+		this.name = form.getName();
+		this.email = form.getEmail();
+		this.profileImage = form.getProfileImage();
+		this.desiredCareer = form.getDesiredCareer();
 
-    return this;
-  }
+		return this;
+	}
 
 
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/form/SignUpForm.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/form/SignUpForm.java
@@ -1,0 +1,22 @@
+package com.icandoit.boottalk.user.domain.form;
+
+import com.icandoit.boottalk.user.domain.type.DesiredCareer;
+import java.math.BigInteger;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SignUpForm {
+  private BigInteger userId;
+  private String name;
+  private String email;
+  private String profileImage;
+  private DesiredCareer desiredCareer;
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/form/SignUpForm.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/form/SignUpForm.java
@@ -1,7 +1,6 @@
 package com.icandoit.boottalk.user.domain.form;
 
 import com.icandoit.boottalk.user.domain.type.DesiredCareer;
-import java.math.BigInteger;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,9 +13,10 @@ import lombok.Setter;
 @AllArgsConstructor
 @Builder
 public class SignUpForm {
-  private BigInteger userId;
-  private String name;
-  private String email;
-  private String profileImage;
-  private DesiredCareer desiredCareer;
+
+	private Long userId;
+	private String name;
+	private String email;
+	private String profileImage;
+	private DesiredCareer desiredCareer;
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/form/UpdateForm.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/form/UpdateForm.java
@@ -1,0 +1,21 @@
+package com.icandoit.boottalk.user.domain.form;
+
+import com.icandoit.boottalk.user.domain.type.DesiredCareer;
+import java.math.BigInteger;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UpdateForm {
+  private String name;
+  private String email;
+  private String profileImage;
+  private DesiredCareer desiredCareer;
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/repository/UserRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.icandoit.boottalk.user.domain.repository;
+
+import com.icandoit.boottalk.user.domain.entity.User;
+import java.math.BigInteger;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, BigInteger> {
+
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/repository/UserRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/repository/UserRepository.java
@@ -1,11 +1,10 @@
 package com.icandoit.boottalk.user.domain.repository;
 
 import com.icandoit.boottalk.user.domain.entity.User;
-import java.math.BigInteger;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface UserRepository extends JpaRepository<User, BigInteger> {
+public interface UserRepository extends JpaRepository<User, Long> {
 
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/type/DesiredCareer.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/type/DesiredCareer.java
@@ -1,0 +1,7 @@
+package com.icandoit.boottalk.user.domain.type;
+
+public enum DesiredCareer {
+  ENGINEER,
+  DESIGNER,
+  MANAGER
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/service/ManageService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/service/ManageService.java
@@ -1,0 +1,29 @@
+package com.icandoit.boottalk.user.service;
+
+import com.icandoit.boottalk.user.domain.dto.UserDto;
+import com.icandoit.boottalk.user.domain.form.SignUpForm;
+import com.icandoit.boottalk.user.domain.form.UpdateForm;
+import java.math.BigInteger;
+
+public interface ManageService {
+
+  /**
+   * 회원 조회
+   * @param userId
+   * @return
+   */
+  UserDto getUser(BigInteger userId);
+
+  /**
+   * 회원정보 수정
+   * @param form
+   * @return
+   */
+  UserDto updateUser(BigInteger userId ,UpdateForm form);
+
+  /**
+   * 회원탈퇴
+   * @param userId
+   */
+  void deleteUser(BigInteger userId);
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/service/ManageService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/service/ManageService.java
@@ -1,29 +1,30 @@
 package com.icandoit.boottalk.user.service;
 
 import com.icandoit.boottalk.user.domain.dto.UserDto;
-import com.icandoit.boottalk.user.domain.form.SignUpForm;
 import com.icandoit.boottalk.user.domain.form.UpdateForm;
-import java.math.BigInteger;
 
 public interface ManageService {
 
-  /**
-   * 회원 조회
-   * @param userId
-   * @return
-   */
-  UserDto getUser(BigInteger userId);
+	/**
+	 * 회원 조회
+	 *
+	 * @param userId
+	 * @return
+	 */
+	UserDto getUser(Long userId);
 
-  /**
-   * 회원정보 수정
-   * @param form
-   * @return
-   */
-  UserDto updateUser(BigInteger userId ,UpdateForm form);
+	/**
+	 * 회원정보 수정
+	 *
+	 * @param form
+	 * @return
+	 */
+	UserDto updateUser(Long userId, UpdateForm form);
 
-  /**
-   * 회원탈퇴
-   * @param userId
-   */
-  void deleteUser(BigInteger userId);
+	/**
+	 * 회원탈퇴
+	 *
+	 * @param userId
+	 */
+	void deleteUser(Long userId);
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/service/SignUpService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/service/SignUpService.java
@@ -1,0 +1,13 @@
+package com.icandoit.boottalk.user.service;
+
+import com.icandoit.boottalk.user.domain.form.SignUpForm;
+
+public interface SignUpService {
+  /**
+   * 회원 가입
+   * @param form
+   */
+  void signUp(SignUpForm form);
+
+
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/service/impl/ManageServiceImpl.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/service/impl/ManageServiceImpl.java
@@ -2,11 +2,9 @@ package com.icandoit.boottalk.user.service.impl;
 
 import com.icandoit.boottalk.user.domain.dto.UserDto;
 import com.icandoit.boottalk.user.domain.entity.User;
-import com.icandoit.boottalk.user.domain.form.SignUpForm;
 import com.icandoit.boottalk.user.domain.form.UpdateForm;
 import com.icandoit.boottalk.user.domain.repository.UserRepository;
 import com.icandoit.boottalk.user.service.ManageService;
-import java.math.BigInteger;
 import java.sql.Timestamp;
 import java.time.Instant;
 import lombok.RequiredArgsConstructor;
@@ -17,47 +15,47 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ManageServiceImpl implements ManageService {
 
-  private final UserRepository userRepository;
+	private final UserRepository userRepository;
 
-  @Override
-  @Transactional
-  public UserDto getUser(BigInteger userId) {
+	@Override
+	@Transactional
+	public UserDto getUser(Long userId) {
 
-    User user = validateUser(userId);
+		User user = validateUser(userId);
 
-    return UserDto.from(user);
-  }
+		return UserDto.from(user);
+	}
 
-  @Override
-  @Transactional
-  public UserDto updateUser(BigInteger userId,UpdateForm form) {
+	@Override
+	@Transactional
+	public UserDto updateUser(Long userId, UpdateForm form) {
 
-    User user = validateUser(userId);
+		User user = validateUser(userId);
 
-    return UserDto.from(userRepository.save(user.updateFrom(form)));
-  }
+		return UserDto.from(userRepository.save(user.updateFrom(form)));
+	}
 
-  @Override
-  @Transactional
-  public void deleteUser(BigInteger userId) {
+	@Override
+	@Transactional
+	public void deleteUser(Long userId) {
 
-    User user = validateUser(userId);
+		User user = validateUser(userId);
 
-    user.setDeletedAt(Timestamp.from(Instant.now()));
-    userRepository.save(user);
-  }
+		user.setDeletedAt(Timestamp.from(Instant.now()));
+		userRepository.save(user);
+	}
 
 
-  //유효한 회원인지 확인
-  private User validateUser(BigInteger userId) {
+	//유효한 회원인지 확인
+	private User validateUser(Long userId) {
 
-    User user = userRepository.findById(userId)
-        .orElseThrow(( ) -> new RuntimeException("조회된 회원 정보가 없습니다."));
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new RuntimeException("조회된 회원 정보가 없습니다."));
 
-    if (user.getDeletedAt() != null) {
-      throw new RuntimeException("탈퇴한 회원입니다.");
-    }
+		if (user.getDeletedAt() != null) {
+			throw new RuntimeException("탈퇴한 회원입니다.");
+		}
 
-    return user;
-  }
+		return user;
+	}
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/service/impl/ManageServiceImpl.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/service/impl/ManageServiceImpl.java
@@ -1,0 +1,63 @@
+package com.icandoit.boottalk.user.service.impl;
+
+import com.icandoit.boottalk.user.domain.dto.UserDto;
+import com.icandoit.boottalk.user.domain.entity.User;
+import com.icandoit.boottalk.user.domain.form.SignUpForm;
+import com.icandoit.boottalk.user.domain.form.UpdateForm;
+import com.icandoit.boottalk.user.domain.repository.UserRepository;
+import com.icandoit.boottalk.user.service.ManageService;
+import java.math.BigInteger;
+import java.sql.Timestamp;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ManageServiceImpl implements ManageService {
+
+  private final UserRepository userRepository;
+
+  @Override
+  @Transactional
+  public UserDto getUser(BigInteger userId) {
+
+    User user = validateUser(userId);
+
+    return UserDto.from(user);
+  }
+
+  @Override
+  @Transactional
+  public UserDto updateUser(BigInteger userId,UpdateForm form) {
+
+    User user = validateUser(userId);
+
+    return UserDto.from(userRepository.save(user.updateFrom(form)));
+  }
+
+  @Override
+  @Transactional
+  public void deleteUser(BigInteger userId) {
+
+    User user = validateUser(userId);
+
+    user.setDeletedAt(Timestamp.from(Instant.now()));
+    userRepository.save(user);
+  }
+
+
+  //유효한 회원인지 확인
+  private User validateUser(BigInteger userId) {
+
+    User user = userRepository.findById(userId)
+        .orElseThrow(( ) -> new RuntimeException("조회된 회원 정보가 없습니다."));
+
+    if (user.getDeletedAt() != null) {
+      throw new RuntimeException("탈퇴한 회원입니다.");
+    }
+
+    return user;
+  }
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/service/impl/SignUpServiceImpl.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/service/impl/SignUpServiceImpl.java
@@ -1,0 +1,37 @@
+package com.icandoit.boottalk.user.service.impl;
+
+import com.icandoit.boottalk.user.domain.entity.User;
+import com.icandoit.boottalk.user.domain.form.SignUpForm;
+import com.icandoit.boottalk.user.domain.repository.UserRepository;
+import com.icandoit.boottalk.user.service.SignUpService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SignUpServiceImpl implements SignUpService {
+
+  private final UserRepository userRepository;
+
+  @Override
+  @Transactional
+  public void signUp(SignUpForm form) {
+
+    User user = userRepository.findById(form.getUserId()).orElse(null);
+
+    // 이미 회원가입된 유저인 경우에는 예외처리
+    // 회원가입되었던 유저중에서 회원탈퇴한 회원이 다시 회원가입 시도하는 경우,
+    // 기존 회원정보 삭제 후 다시 새롭게 회원정보 입력
+    if (user != null) {
+      if (user.getDeletedAt() == null) {
+        throw new RuntimeException("이미 가입한 회원입니다.");
+      }
+      userRepository.delete(user);
+    }
+
+    userRepository.save(User.from(form));
+  }
+
+
+}


### PR DESCRIPTION
### 변경사항

**AS-IS**
- 알림 기능 미구현 상태

**TO-BE**
- NotificationController: 알림 CRUD 기능 제공 (생성, 조회, 수정, 삭제).

- NotificationService: 비즈니스 로직 처리 및 데이터 접근 서비스 구현.

- NotificationRepository: 데이터베이스 연동을 위한 JPA Repository 구현.

- NotificationRequest, NotificationResponseDto: 요청과 응답 데이터 객체 분리.

- Notification Entity: 데이터베이스 매핑 엔티티 정의.

### 테스트

- [x] API 테스트 
