### PR TITLE
Feat/bootcamp - 기본 구현 및 테스트

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/controller/BootcampController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/controller/BootcampController.java
@@ -1,0 +1,67 @@
+package com.icandoit.boottalk.bootcamp.controller;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.icandoit.boottalk.bootcamp.dto.BootcampResponse.BootcampResponseDto;
+import com.icandoit.boottalk.bootcamp.entity.Bootcamp;
+import com.icandoit.boottalk.bootcamp.service.BootcampService;
+import com.icandoit.boottalk.libs.dto.SuccessResponseDto;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/bootcamps")
+@RequiredArgsConstructor
+public class BootcampController {
+
+	private final BootcampService bootcampService;
+
+	/**
+	 * 모든 부트캠프 목록 조회 (페이징)
+	 *
+	 * @param page
+	 * @param size
+	 * @return ResponseEntity with SuccessResponseDto
+	 */
+	@GetMapping
+	public ResponseEntity<?> getAllBootcamps(
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "10") int size
+	) {
+		Pageable pageable = PageRequest.of(page, size);
+		Page<Bootcamp> bootcampPage = bootcampService.findAll(pageable);
+		List<BootcampResponseDto> bootcampResponseDtoList = BootcampResponseDto.from(bootcampPage.getContent());
+
+		return ResponseEntity.ok(
+			SuccessResponseDto.of("부트캠프 목록 조회 성공", bootcampResponseDtoList)
+		);
+	}
+
+	/**
+	 * 단일 부트캠프 조회
+	 *
+	 * @param bootcampId 부트캠프 ID
+	 * @return ResponseEntity with SuccessResponseDto
+	 */
+	@GetMapping("/{bootcampId}")
+	public ResponseEntity<?> getBootcamp(@PathVariable Long bootcampId) {
+		Bootcamp bootcamp = bootcampService.findById(bootcampId)
+			.orElseThrow(() -> new IllegalArgumentException("해당 부트캠프가 존재하지 않습니다."));
+
+		BootcampResponseDto responseDto = BootcampResponseDto.from(bootcamp);
+
+		return ResponseEntity.ok(
+			SuccessResponseDto.of("부트캠프 조회 성공", responseDto)
+		);
+	}
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/controller/BootcampController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/controller/BootcampController.java
@@ -26,15 +26,9 @@ public class BootcampController {
 
 	private final BootcampService bootcampService;
 
-	/**
-	 * 모든 부트캠프 목록 조회 (페이징)
-	 *
-	 * @param page
-	 * @param size
-	 * @return ResponseEntity with SuccessResponseDto
-	 */
+	// 부트캠프 목록 조회
 	@GetMapping
-	public ResponseEntity<?> getAllBootcamps(
+	public ResponseEntity<SuccessResponseDto<List<BootcampResponseDto>>> getAllBootcamps(
 		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "10") int size
 	) {
@@ -47,14 +41,9 @@ public class BootcampController {
 		);
 	}
 
-	/**
-	 * 단일 부트캠프 조회
-	 *
-	 * @param bootcampId 부트캠프 ID
-	 * @return ResponseEntity with SuccessResponseDto
-	 */
+	// 단일 부트캠프 조회
 	@GetMapping("/{bootcampId}")
-	public ResponseEntity<?> getBootcamp(@PathVariable Long bootcampId) {
+	public ResponseEntity<SuccessResponseDto<BootcampResponseDto>> getBootcamp(@PathVariable Long bootcampId) {
 		Bootcamp bootcamp = bootcampService.findById(bootcampId)
 			.orElseThrow(() -> new IllegalArgumentException("해당 부트캠프가 존재하지 않습니다."));
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/controller/BootcampController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/controller/BootcampController.java
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.RestController;
 import com.icandoit.boottalk.bootcamp.dto.BootcampResponse.BootcampResponseDto;
 import com.icandoit.boottalk.bootcamp.entity.Bootcamp;
 import com.icandoit.boottalk.bootcamp.service.BootcampService;
-import com.icandoit.boottalk.libs.dto.SuccessResponseDto;
 
 import lombok.RequiredArgsConstructor;
 
@@ -28,29 +27,21 @@ public class BootcampController {
 
 	// 부트캠프 목록 조회
 	@GetMapping
-	public ResponseEntity<SuccessResponseDto<List<BootcampResponseDto>>> getAllBootcamps(
+	public ResponseEntity<List<BootcampResponseDto>> getAllBootcamps(
 		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "10") int size
 	) {
+		// TODO : 페이징 처리 수정, 테스트 코드 작성, 필터 조회
 		Pageable pageable = PageRequest.of(page, size);
 		Page<Bootcamp> bootcampPage = bootcampService.findAll(pageable);
 		List<BootcampResponseDto> bootcampResponseDtoList = BootcampResponseDto.from(bootcampPage.getContent());
 
-		return ResponseEntity.ok(
-			SuccessResponseDto.of("부트캠프 목록 조회 성공", bootcampResponseDtoList)
-		);
+		return ResponseEntity.ok(bootcampResponseDtoList);
 	}
 
 	// 단일 부트캠프 조회
 	@GetMapping("/{bootcampId}")
-	public ResponseEntity<SuccessResponseDto<BootcampResponseDto>> getBootcamp(@PathVariable Long bootcampId) {
-		Bootcamp bootcamp = bootcampService.findById(bootcampId)
-			.orElseThrow(() -> new IllegalArgumentException("해당 부트캠프가 존재하지 않습니다."));
-
-		BootcampResponseDto responseDto = BootcampResponseDto.from(bootcamp);
-
-		return ResponseEntity.ok(
-			SuccessResponseDto.of("부트캠프 조회 성공", responseDto)
-		);
+	public ResponseEntity<BootcampResponseDto> getBootcamp(@PathVariable Long bootcampId) {
+		return ResponseEntity.ok(bootcampService.findById(bootcampId));
 	}
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/dto/BootcampResponse.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/dto/BootcampResponse.java
@@ -1,0 +1,55 @@
+package com.icandoit.boottalk.bootcamp.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.icandoit.boottalk.bootcamp.entity.Bootcamp;
+import com.icandoit.boottalk.bootcamp.entity.BootcampCategoryType;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class BootcampResponse {
+
+	@Getter
+	@Builder
+	public static class BootcampResponseDto {
+
+		private Long bootcampId;
+		private String trainingCenterName;
+		private String bootcampName;
+		private String bootcampRegion;
+		private Boolean bootcampCost;
+		private String bootcampLink;
+		private String bootcampCategory;
+		private int bootcampDegree;
+		private int bootcampCapacity;
+		private LocalDate bootcampStartDate;
+		private LocalDate bootcampEndDate;
+
+		public static BootcampResponseDto from(Bootcamp bootcamp) {
+			BootcampCategoryType bootcampCategoryType = bootcamp.getCategory();
+
+			return BootcampResponseDto.builder()
+				.bootcampId(bootcamp.getId())
+				.trainingCenterName(bootcamp.getTrainingCenter().getName())
+				.bootcampName(bootcamp.getName())
+				.bootcampRegion(bootcamp.getRegion())
+				.bootcampCost(bootcamp.isCost())
+				.bootcampLink(bootcamp.getLink())
+				.bootcampCategory(bootcampCategoryType.getKoreanNameByEnglishName(bootcampCategoryType.getKoreanName()))
+				.bootcampDegree(bootcamp.getDegree())
+				.bootcampCapacity(bootcamp.getCapacity())
+				.bootcampStartDate(bootcamp.getStartDate())
+				.bootcampEndDate(bootcamp.getEndDate())
+				.build();
+		}
+
+		public static List<BootcampResponseDto> from(List<Bootcamp> bootcamps) {
+			return bootcamps.stream()
+				.map(BootcampResponseDto::from)
+				.collect(Collectors.toList());
+		}
+	}
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/dto/BootcampResponse.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/dto/BootcampResponse.java
@@ -1,6 +1,7 @@
 package com.icandoit.boottalk.bootcamp.dto;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -20,7 +21,7 @@ public class BootcampResponse {
 		private String trainingCenterName;
 		private String bootcampName;
 		private String bootcampRegion;
-		private Boolean bootcampCost;
+		private boolean bootcampCost;
 		private String bootcampLink;
 		private String bootcampCategory;
 		private int bootcampDegree;
@@ -28,21 +29,26 @@ public class BootcampResponse {
 		private LocalDate bootcampStartDate;
 		private LocalDate bootcampEndDate;
 
+		private LocalDateTime createdAt;
+		private LocalDateTime updatedAt;
+
 		public static BootcampResponseDto from(Bootcamp bootcamp) {
-			BootcampCategoryType bootcampCategoryType = bootcamp.getCategory();
+			BootcampCategoryType bootcampCategoryType = bootcamp.getBootcampCategoryType();
 
 			return BootcampResponseDto.builder()
-				.bootcampId(bootcamp.getId())
-				.trainingCenterName(bootcamp.getTrainingCenter().getName())
-				.bootcampName(bootcamp.getName())
-				.bootcampRegion(bootcamp.getRegion())
-				.bootcampCost(bootcamp.isCost())
-				.bootcampLink(bootcamp.getLink())
-				.bootcampCategory(bootcampCategoryType.getKoreanNameByEnglishName(bootcampCategoryType.getKoreanName()))
-				.bootcampDegree(bootcamp.getDegree())
-				.bootcampCapacity(bootcamp.getCapacity())
-				.bootcampStartDate(bootcamp.getStartDate())
-				.bootcampEndDate(bootcamp.getEndDate())
+				.bootcampId(bootcamp.getBootcampId())
+				.trainingCenterName(bootcamp.getTrainingCenter().getTrainingCenterName())
+				.bootcampName(bootcamp.getBootcampName())
+				.bootcampRegion(bootcamp.getBootcampRegion())
+				.bootcampCost(bootcamp.isBootcampCost())
+				.bootcampLink(bootcamp.getBootcampLink())
+				.bootcampCategory(bootcampCategoryType.getKoreanName())
+				.bootcampDegree(bootcamp.getBootcampDegree())
+				.bootcampCapacity(bootcamp.getBootcampCapacity())
+				.bootcampStartDate(bootcamp.getBootcampStartDate())
+				.bootcampEndDate(bootcamp.getBootcampEndDate())
+				.createdAt(bootcamp.getCreatedAt())
+				.updatedAt(bootcamp.getUpdatedAt())
 				.build();
 		}
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/entity/Bootcamp.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/entity/Bootcamp.java
@@ -40,65 +40,49 @@ public class Bootcamp extends BaseEntity {
 	@NotNull(message = "트레이닝 센터는 필수 항목입니다.")
 	private TrainingCenter trainingCenter;
 
-	@Column(name = "bootcamp_name")
 	@NotNull(message = "부트캠프 이름은 필수 항목입니다.")
-	private String name;
+	private String bootcampName;
 
 	@Enumerated(EnumType.STRING)
-	@Column(name = "bootcamp_category_type")
 	@NotNull(message = "부트캠프 카테고리는 필수 항목입니다.")
-	private BootcampCategoryType category;
+	private BootcampCategoryType bootcampCategoryType;
 
-	@Column(name = "bootcamp_degree")
 	@NotNull(message = "부트캠프 기수는 필수 항목입니다.")
-	private int degree;
+	private int bootcampDegree;
 
-	@Column(name = "bootcamp_region")
 	@NotNull(message = "부트캠프 지역은 필수 항목입니다.")
-	private String region;
+	private String bootcampRegion;
 
-	@Column(name = "bootcamp_capacity")
 	@NotNull(message = "부트캠프 정원은 필수 항목입니다.")
-	private int capacity;
+	private int bootcampCapacity;
 
-	@Column(name = "bootcamp_cost")
 	@NotNull(message = "부트캠프 비용 정보는 필수 항목입니다.")
-	private boolean cost;
+	private boolean bootcampCost;
 
-	@Column(name = "bootcamp_start_date")
 	@NotNull(message = "부트캠프 시작일은 필수 항목입니다.")
-	private LocalDate startDate;
+	private LocalDate bootcampStartDate;
 
-	@Column(name = "bootcamp_end_date")
 	@NotNull(message = "부트캠프 종료일은 필수 항목입니다.")
-	private LocalDate endDate;
+	private LocalDate bootcampEndDate;
 
-	@Column(name = "bootcamp_link")
 	@NotNull(message = "부트캠프 링크는 필수 항목입니다.")
-	private String link;
+	private String bootcampLink;
 
-	/**
-	 * DTO 로부터 Bootcamp 엔티티를 생성하는 메서드
-	 *
-	 * @param dto BootcampResponseDto
-	 * @param trainingCenter TrainingCenter
-	 * @param categoryType BootcampCategoryType
-	 * @return Bootcamp 객체
-	 */
+	// DTO 로부터 Bootcamp 엔티티를 생성하는 메서드
 	public static Bootcamp of(
 		BootcampResponse.BootcampResponseDto dto, TrainingCenter trainingCenter, BootcampCategoryType categoryType
 	) {
 		return Bootcamp.builder()
 			.trainingCenter(trainingCenter)
-			.name(dto.getBootcampName())
-			.region(dto.getBootcampRegion())
-			.cost(dto.getBootcampCost())
-			.link(dto.getBootcampLink())
-			.category(categoryType)
-			.degree(dto.getBootcampDegree())
-			.capacity(dto.getBootcampCapacity())
-			.startDate(dto.getBootcampStartDate())
-			.endDate(dto.getBootcampEndDate())
+			.bootcampName(dto.getBootcampName())
+			.bootcampRegion(dto.getBootcampRegion())
+			.bootcampCost(dto.getBootcampCost())
+			.bootcampLink(dto.getBootcampLink())
+			.bootcampCategoryType(categoryType)
+			.bootcampDegree(dto.getBootcampDegree())
+			.bootcampCapacity(dto.getBootcampCapacity())
+			.bootcampStartDate(dto.getBootcampStartDate())
+			.bootcampEndDate(dto.getBootcampEndDate())
 			.build();
 	}
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/entity/Bootcamp.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/entity/Bootcamp.java
@@ -1,0 +1,104 @@
+package com.icandoit.boottalk.bootcamp.entity;
+
+import java.time.LocalDate;
+
+import com.icandoit.boottalk.bootcamp.dto.BootcampResponse;
+import com.icandoit.boottalk.libs.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "bootcamp")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Bootcamp extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "bootcamp_id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "training_center_id")
+	@NotNull(message = "트레이닝 센터는 필수 항목입니다.")
+	private TrainingCenter trainingCenter;
+
+	@Column(name = "bootcamp_name")
+	@NotNull(message = "부트캠프 이름은 필수 항목입니다.")
+	private String name;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "bootcamp_category_type")
+	@NotNull(message = "부트캠프 카테고리는 필수 항목입니다.")
+	private BootcampCategoryType category;
+
+	@Column(name = "bootcamp_degree")
+	@NotNull(message = "부트캠프 기수는 필수 항목입니다.")
+	private int degree;
+
+	@Column(name = "bootcamp_region")
+	@NotNull(message = "부트캠프 지역은 필수 항목입니다.")
+	private String region;
+
+	@Column(name = "bootcamp_capacity")
+	@NotNull(message = "부트캠프 정원은 필수 항목입니다.")
+	private int capacity;
+
+	@Column(name = "bootcamp_cost")
+	@NotNull(message = "부트캠프 비용 정보는 필수 항목입니다.")
+	private boolean cost;
+
+	@Column(name = "bootcamp_start_date")
+	@NotNull(message = "부트캠프 시작일은 필수 항목입니다.")
+	private LocalDate startDate;
+
+	@Column(name = "bootcamp_end_date")
+	@NotNull(message = "부트캠프 종료일은 필수 항목입니다.")
+	private LocalDate endDate;
+
+	@Column(name = "bootcamp_link")
+	@NotNull(message = "부트캠프 링크는 필수 항목입니다.")
+	private String link;
+
+	/**
+	 * DTO 로부터 Bootcamp 엔티티를 생성하는 메서드
+	 *
+	 * @param dto BootcampResponseDto
+	 * @param trainingCenter TrainingCenter
+	 * @param categoryType BootcampCategoryType
+	 * @return Bootcamp 객체
+	 */
+	public static Bootcamp of(
+		BootcampResponse.BootcampResponseDto dto, TrainingCenter trainingCenter, BootcampCategoryType categoryType
+	) {
+		return Bootcamp.builder()
+			.trainingCenter(trainingCenter)
+			.name(dto.getBootcampName())
+			.region(dto.getBootcampRegion())
+			.cost(dto.getBootcampCost())
+			.link(dto.getBootcampLink())
+			.category(categoryType)
+			.degree(dto.getBootcampDegree())
+			.capacity(dto.getBootcampCapacity())
+			.startDate(dto.getBootcampStartDate())
+			.endDate(dto.getBootcampEndDate())
+			.build();
+	}
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/entity/Bootcamp.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/entity/Bootcamp.java
@@ -2,7 +2,6 @@ package com.icandoit.boottalk.bootcamp.entity;
 
 import java.time.LocalDate;
 
-import com.icandoit.boottalk.bootcamp.dto.BootcampResponse;
 import com.icandoit.boottalk.libs.entity.BaseEntity;
 
 import jakarta.persistence.Column;
@@ -16,73 +15,71 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "bootcamp")
 @Getter
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "bootcamp")
 public class Bootcamp extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "bootcamp_id")
-	private Long id;
+	@Column(nullable = false)
+	private Long bootcampId;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "training_center_id")
-	@NotNull(message = "트레이닝 센터는 필수 항목입니다.")
+	@JoinColumn(name = "training_center_id", nullable = false)
 	private TrainingCenter trainingCenter;
 
-	@NotNull(message = "부트캠프 이름은 필수 항목입니다.")
+	@Column(nullable = false)
 	private String bootcampName;
 
 	@Enumerated(EnumType.STRING)
-	@NotNull(message = "부트캠프 카테고리는 필수 항목입니다.")
+	@Column(nullable = false)
 	private BootcampCategoryType bootcampCategoryType;
 
-	@NotNull(message = "부트캠프 기수는 필수 항목입니다.")
+	@Column(nullable = false)
 	private int bootcampDegree;
 
-	@NotNull(message = "부트캠프 지역은 필수 항목입니다.")
+	@Column(nullable = false)
 	private String bootcampRegion;
 
-	@NotNull(message = "부트캠프 정원은 필수 항목입니다.")
+	@Column(nullable = false)
 	private int bootcampCapacity;
 
-	@NotNull(message = "부트캠프 비용 정보는 필수 항목입니다.")
+	@Column(nullable = false)
 	private boolean bootcampCost;
 
-	@NotNull(message = "부트캠프 시작일은 필수 항목입니다.")
+	@Column(nullable = false)
 	private LocalDate bootcampStartDate;
 
-	@NotNull(message = "부트캠프 종료일은 필수 항목입니다.")
+	@Column(nullable = false)
 	private LocalDate bootcampEndDate;
 
-	@NotNull(message = "부트캠프 링크는 필수 항목입니다.")
+	@Column(nullable = false)
 	private String bootcampLink;
 
-	// DTO 로부터 Bootcamp 엔티티를 생성하는 메서드
 	public static Bootcamp of(
-		BootcampResponse.BootcampResponseDto dto, TrainingCenter trainingCenter, BootcampCategoryType categoryType
+		TrainingCenter trainingCenter, String name, BootcampCategoryType categoryType, int degree, String region,
+		int capacity, boolean cost, LocalDate startDate, LocalDate endDate, String link
 	) {
 		return Bootcamp.builder()
 			.trainingCenter(trainingCenter)
-			.bootcampName(dto.getBootcampName())
-			.bootcampRegion(dto.getBootcampRegion())
-			.bootcampCost(dto.getBootcampCost())
-			.bootcampLink(dto.getBootcampLink())
+			.bootcampName(name)
 			.bootcampCategoryType(categoryType)
-			.bootcampDegree(dto.getBootcampDegree())
-			.bootcampCapacity(dto.getBootcampCapacity())
-			.bootcampStartDate(dto.getBootcampStartDate())
-			.bootcampEndDate(dto.getBootcampEndDate())
+			.bootcampDegree(degree)
+			.bootcampRegion(region)
+			.bootcampCapacity(capacity)
+			.bootcampCost(cost)
+			.bootcampStartDate(startDate)
+			.bootcampEndDate(endDate)
+			.bootcampLink(link)
 			.build();
 	}
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/entity/BootcampCategoryType.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/entity/BootcampCategoryType.java
@@ -1,0 +1,46 @@
+package com.icandoit.boottalk.bootcamp.entity;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.icandoit.boottalk.bootcamp.exception.BootcampCustomException;
+import com.icandoit.boottalk.bootcamp.exception.BootcampErrorCode;
+
+import lombok.Getter;
+
+@Getter
+public enum BootcampCategoryType {
+	//TODO : 추후에 카테고리들 더 추가 해야 함
+	APPLICATION_SW_ENGINEERING("응용SW엔지니어링"),
+	SMART_EQUIPMENT_DESIGN("스마트설비설계"),
+	INFORMATION_SECURITY_MANAGEMENT("정보보호관리·운영"),
+	SW_PRODUCT_PLANNING("SW제품기획");
+
+	private final String koreanName;
+	private static final Map<String, String> englishToKoreanMap = new HashMap<>();
+	private static final Map<String, BootcampCategoryType> koreanToEnumMap = new HashMap<>();
+
+	BootcampCategoryType(String koreanName) {
+		this.koreanName = koreanName;
+	}
+
+	static {
+		for (BootcampCategoryType category : BootcampCategoryType.values()) {
+			englishToKoreanMap.put(category.name(), category.koreanName);
+			koreanToEnumMap.put(category.koreanName, category);
+		}
+
+	}
+
+	public String getKoreanNameByEnglishName(String englishName) {
+		return englishToKoreanMap.getOrDefault(englishName, "알 수 없음");
+	}
+
+	//TODO : 부트캠프 openAPI에서 가져올 때 사용 예정
+	public static BootcampCategoryType fromKoreanName(String koreanName) {
+		if(!koreanToEnumMap.containsKey(koreanName)) {
+			throw new BootcampCustomException(BootcampErrorCode.INVALID_CATEGORY_NAME);
+		}
+		return koreanToEnumMap.get(koreanName);
+	}
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/entity/TrainingCenter.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/entity/TrainingCenter.java
@@ -1,0 +1,33 @@
+package com.icandoit.boottalk.bootcamp.entity;
+
+import com.icandoit.boottalk.libs.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "training_center")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TrainingCenter extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "training_center_id")
+	private Long id;
+
+	@Column(name = "training_center_name", nullable = false)
+	@NotNull(message = "훈련기관 이름은 필수 항목입니다.")
+	private String name;
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/entity/TrainingCenter.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/entity/TrainingCenter.java
@@ -2,7 +2,6 @@ package com.icandoit.boottalk.bootcamp.entity;
 
 import com.icandoit.boottalk.libs.entity.BaseEntity;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -24,10 +23,20 @@ public class TrainingCenter extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "training_center_id")
 	private Long id;
 
-	@Column(name = "training_center_name", nullable = false)
 	@NotNull(message = "훈련기관 이름은 필수 항목입니다.")
 	private String name;
+
+	@NotNull(message = "훈련기관 연락처는 필수 항목입니다.")
+	private String phoneNumber;
+
+	@NotNull(message = "훈련기관 이메일은 필수 항목입니다.")
+	private String email;
+
+	@NotNull(message = "훈련기관 주소는 필수 항목입니다.")
+	private String address;
+
+	@NotNull(message = "훈련기관 이메일은 필수 항목입니다.")
+	private String url;
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/entity/TrainingCenter.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/entity/TrainingCenter.java
@@ -2,12 +2,12 @@ package com.icandoit.boottalk.bootcamp.entity;
 
 import com.icandoit.boottalk.libs.entity.BaseEntity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,20 +23,29 @@ public class TrainingCenter extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+	private Long trainingCenterId;
 
-	@NotNull(message = "훈련기관 이름은 필수 항목입니다.")
-	private String name;
+	@Column(nullable = false)
+	private String trainingCenterName;
 
-	@NotNull(message = "훈련기관 연락처는 필수 항목입니다.")
-	private String phoneNumber;
+	@Column(nullable = false)
+	private String trainingCenterPhoneNumber;
 
-	@NotNull(message = "훈련기관 이메일은 필수 항목입니다.")
-	private String email;
+	@Column(nullable = false)
+	private String trainingCenterEmail;
 
-	@NotNull(message = "훈련기관 주소는 필수 항목입니다.")
-	private String address;
+	@Column(nullable = false)
+	private String trainingCenterAddress;
 
-	@NotNull(message = "훈련기관 이메일은 필수 항목입니다.")
-	private String url;
+	@Column(nullable = false)
+	private String trainingCenterUrl;
+
+	public static TrainingCenter of(String name, String email, String address, String url) {
+		return TrainingCenter.builder()
+			.trainingCenterName(name)
+			.trainingCenterEmail(email)
+			.trainingCenterAddress(address)
+			.trainingCenterUrl(url)
+			.build();
+	}
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/exception/BootcampCustomException.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/exception/BootcampCustomException.java
@@ -1,0 +1,22 @@
+package com.icandoit.boottalk.bootcamp.exception;
+
+import com.icandoit.boottalk.libs.exception.CustomException;
+import com.icandoit.boottalk.libs.exception.ErrorCode;
+
+import lombok.Getter;
+
+@Getter
+public class BootcampCustomException extends CustomException {
+
+	private final BootcampErrorCode bootcampErrorCode;
+
+	public BootcampCustomException(BootcampErrorCode bootcampErrorCode) {
+		super(ErrorCode.INTERNAL_SERVER_ERROR);
+		this.bootcampErrorCode = bootcampErrorCode;
+	}
+
+	@Override
+	public String getMessage() {
+		return bootcampErrorCode.getMessage();
+	}
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/exception/BootcampErrorCode.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/exception/BootcampErrorCode.java
@@ -1,0 +1,20 @@
+package com.icandoit.boottalk.bootcamp.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum BootcampErrorCode {
+
+	/* 400 BAD_REQUEST */
+	INVALID_CATEGORY_NAME(400, "잘못된 카테고리 이름입니다."),
+	INVALID_BOOTCAMP_ID(400, "유효하지 않은 부트캠프 ID 입니다."),
+
+	/* 404 NOT_FOUND */
+	BOOTCAMP_NOT_FOUND(404, "요청한 부트캠프를 찾을 수 없습니다."),
+	TRAINING_CENTER_NOT_FOUND(404, "요청한 훈련 기관을 찾을 수 없습니다.");
+
+	private final Integer httpStatus;
+	private final String message;
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/repository/BootcampRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/repository/BootcampRepository.java
@@ -1,0 +1,8 @@
+package com.icandoit.boottalk.bootcamp.repository;
+
+import com.icandoit.boottalk.bootcamp.entity.Bootcamp;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BootcampRepository extends JpaRepository <Bootcamp, Long> {
+
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/repository/TrainingCenterRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/repository/TrainingCenterRepository.java
@@ -1,0 +1,12 @@
+package com.icandoit.boottalk.bootcamp.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.icandoit.boottalk.bootcamp.entity.TrainingCenter;
+
+public interface TrainingCenterRepository extends JpaRepository<TrainingCenter, Long> {
+
+	Optional<TrainingCenter> findByName(String tcName);
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/repository/TrainingCenterRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/repository/TrainingCenterRepository.java
@@ -1,12 +1,8 @@
 package com.icandoit.boottalk.bootcamp.repository;
 
-import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.icandoit.boottalk.bootcamp.entity.TrainingCenter;
 
 public interface TrainingCenterRepository extends JpaRepository<TrainingCenter, Long> {
-
-	Optional<TrainingCenter> findByName(String tcName);
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/BootcampService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/BootcampService.java
@@ -10,6 +10,7 @@ import com.icandoit.boottalk.bootcamp.entity.Bootcamp;
 import com.icandoit.boottalk.bootcamp.entity.BootcampCategoryType;
 import com.icandoit.boottalk.bootcamp.repository.BootcampRepository;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -18,37 +19,27 @@ public class BootcampService {
 
 	private final BootcampRepository bootcampRepository;
 
-	/**
-	 * 부트캠프 단일 조회
-	 *
-	 * @param id
-	 * @return bootcamp
-	 */
+	@Transactional
+	public Bootcamp save(Bootcamp bootcamp) {
+		return bootcampRepository.save(bootcamp);
+	}
+
+	// 부트캠프 단일 조회
 	public Optional<Bootcamp> findById(Long id) {
 		return bootcampRepository.findById(id);
 	}
 
-	/**
-	 * 부트캠프 목록 페이징 조회
-	 *
-	 * @param pageable
-	 * @return Page<Bootcamp>
-	 */
+	// 부트캠프 목록 페이징
 	public Page<Bootcamp> findAll(Pageable pageable) {
 		return bootcampRepository.findAll(pageable);
 	}
 
-	/**
-	 * 부트캠프 카테고리 영어로 된 값 한국어로 변환
-	 *
-	 * @param id
-	 * @return (한국어) 부트캠프 카테고리
-	 */
+	// 부트캠프 카테고리 영어로 된 값 한국어로 변환
 	public String getKoreanCategoryName(Long id) {
 		Optional<Bootcamp> bootcamp = bootcampRepository.findById(id);
 
 		if (bootcamp.isPresent()) {
-			BootcampCategoryType category = bootcamp.get().getCategory();
+			BootcampCategoryType category = bootcamp.get().getBootcampCategoryType();
 			return category.getKoreanNameByEnglishName(category.name());
 		}
 		return "해당 부트캠프가 존재하지 않음.";

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/BootcampService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/BootcampService.java
@@ -1,0 +1,56 @@
+package com.icandoit.boottalk.bootcamp.service;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import com.icandoit.boottalk.bootcamp.entity.Bootcamp;
+import com.icandoit.boottalk.bootcamp.entity.BootcampCategoryType;
+import com.icandoit.boottalk.bootcamp.repository.BootcampRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class BootcampService {
+
+	private final BootcampRepository bootcampRepository;
+
+	/**
+	 * 부트캠프 단일 조회
+	 *
+	 * @param id
+	 * @return bootcamp
+	 */
+	public Optional<Bootcamp> findById(Long id) {
+		return bootcampRepository.findById(id);
+	}
+
+	/**
+	 * 부트캠프 목록 페이징 조회
+	 *
+	 * @param pageable
+	 * @return Page<Bootcamp>
+	 */
+	public Page<Bootcamp> findAll(Pageable pageable) {
+		return bootcampRepository.findAll(pageable);
+	}
+
+	/**
+	 * 부트캠프 카테고리 영어로 된 값 한국어로 변환
+	 *
+	 * @param id
+	 * @return (한국어) 부트캠프 카테고리
+	 */
+	public String getKoreanCategoryName(Long id) {
+		Optional<Bootcamp> bootcamp = bootcampRepository.findById(id);
+
+		if (bootcamp.isPresent()) {
+			BootcampCategoryType category = bootcamp.get().getCategory();
+			return category.getKoreanNameByEnglishName(category.name());
+		}
+		return "해당 부트캠프가 존재하지 않음.";
+	}
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/BootcampService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/BootcampService.java
@@ -1,5 +1,8 @@
 package com.icandoit.boottalk.bootcamp.service;
 
+import static com.icandoit.boottalk.bootcamp.dto.BootcampResponse.*;
+import static com.icandoit.boottalk.bootcamp.exception.BootcampErrorCode.*;
+
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
@@ -7,7 +10,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import com.icandoit.boottalk.bootcamp.entity.Bootcamp;
-import com.icandoit.boottalk.bootcamp.entity.BootcampCategoryType;
+import com.icandoit.boottalk.bootcamp.exception.BootcampCustomException;
 import com.icandoit.boottalk.bootcamp.repository.BootcampRepository;
 
 import jakarta.transaction.Transactional;
@@ -25,23 +28,18 @@ public class BootcampService {
 	}
 
 	// 부트캠프 단일 조회
-	public Optional<Bootcamp> findById(Long id) {
-		return bootcampRepository.findById(id);
+	public BootcampResponseDto findById(Long id) {
+		Optional<Bootcamp> bootcamp = bootcampRepository.findById(id);
+
+		if (bootcamp.isEmpty()) {
+			throw new BootcampCustomException(BOOTCAMP_NOT_FOUND);
+		}
+
+		return BootcampResponseDto.from(bootcamp.get());
 	}
 
 	// 부트캠프 목록 페이징
 	public Page<Bootcamp> findAll(Pageable pageable) {
 		return bootcampRepository.findAll(pageable);
-	}
-
-	// 부트캠프 카테고리 영어로 된 값 한국어로 변환
-	public String getKoreanCategoryName(Long id) {
-		Optional<Bootcamp> bootcamp = bootcampRepository.findById(id);
-
-		if (bootcamp.isPresent()) {
-			BootcampCategoryType category = bootcamp.get().getBootcampCategoryType();
-			return category.getKoreanNameByEnglishName(category.name());
-		}
-		return "해당 부트캠프가 존재하지 않음.";
 	}
 }

--- a/boottalk/src/test/java/com/icandoit/boottalk/bootcamp/service/BootcampServiceTest.java
+++ b/boottalk/src/test/java/com/icandoit/boottalk/bootcamp/service/BootcampServiceTest.java
@@ -1,0 +1,124 @@
+package com.icandoit.boottalk.bootcamp.service;
+
+import static com.icandoit.boottalk.bootcamp.exception.BootcampErrorCode.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.icandoit.boottalk.bootcamp.dto.BootcampResponse.BootcampResponseDto;
+import com.icandoit.boottalk.bootcamp.entity.Bootcamp;
+import com.icandoit.boottalk.bootcamp.entity.BootcampCategoryType;
+import com.icandoit.boottalk.bootcamp.entity.TrainingCenter;
+import com.icandoit.boottalk.bootcamp.exception.BootcampCustomException;
+import com.icandoit.boottalk.bootcamp.repository.BootcampRepository;
+
+class BootcampServiceTest {
+
+	@InjectMocks
+	private BootcampService bootcampService;
+
+	@Mock
+	private BootcampRepository bootcampRepository;
+
+	private Bootcamp bootcamp;
+	private TrainingCenter trainingCenter;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+
+		trainingCenter = TrainingCenter.builder()
+			.trainingCenterName("기관명")
+			.trainingCenterAddress("기관 주소")
+			.trainingCenterEmail("example@test.com")
+			.trainingCenterPhoneNumber("010-1234-5678")
+			.trainingCenterUrl("www.trainingcenter.com")
+			.build();
+
+		bootcamp = Bootcamp.builder()
+			.bootcampId(1L)
+			.trainingCenter(trainingCenter)
+			.bootcampName("테스트 캠프")
+			.bootcampDegree(1)
+			.bootcampRegion("서울")
+			.bootcampCapacity(10)
+			.bootcampCost(true)
+			.bootcampStartDate(LocalDate.of(2025, 4, 1))
+			.bootcampEndDate(LocalDate.of(2025, 6, 30))
+			.bootcampLink("www.testcamp.com")
+			.bootcampCategoryType(BootcampCategoryType.APPLICATION_SW_ENGINEERING)
+			.build();
+	}
+
+	@Test
+	@DisplayName("부트캠프 저장 테스트")
+	void saveTest() {
+		//given
+		when(bootcampRepository.save(bootcamp)).thenReturn(bootcamp);
+
+		//when
+		Bootcamp savedBootcamp = bootcampService.save(bootcamp);
+
+		//then
+		assertEquals(savedBootcamp.getBootcampId(), bootcamp.getBootcampId());
+		assertEquals(savedBootcamp.getBootcampName(), bootcamp.getBootcampName());
+		assertEquals(savedBootcamp.getBootcampCategoryType(), bootcamp.getBootcampCategoryType());
+		assertEquals(savedBootcamp.getBootcampDegree(), bootcamp.getBootcampDegree());
+		assertEquals(savedBootcamp.getBootcampRegion(), bootcamp.getBootcampRegion());
+		assertEquals(savedBootcamp.getBootcampCapacity(), bootcamp.getBootcampCapacity());
+		assertEquals(savedBootcamp.isBootcampCost(), bootcamp.isBootcampCost());
+		assertEquals(savedBootcamp.getBootcampStartDate(), bootcamp.getBootcampStartDate());
+		assertEquals(savedBootcamp.getBootcampEndDate(), bootcamp.getBootcampEndDate());
+		assertEquals(savedBootcamp.getBootcampLink(), bootcamp.getBootcampLink());
+		assertEquals(savedBootcamp.getTrainingCenter().getTrainingCenterId(), trainingCenter.getTrainingCenterId());
+		verify(bootcampRepository, times(1)).save(bootcamp);
+	}
+
+	@Test
+	@DisplayName("부트캠프 ID 조회 테스트 - 성공")
+	void findByIdSuccess() {
+		//given
+		when(bootcampRepository.findById(1L)).thenReturn(Optional.of(bootcamp));
+
+		//when
+		BootcampResponseDto response = bootcampService.findById(1L);
+		BootcampCategoryType categoryType = BootcampCategoryType.fromKoreanName(response.getBootcampCategory());
+
+		//then
+		assertEquals(response.getBootcampId(), bootcamp.getBootcampId());
+		assertEquals(response.getBootcampName(), bootcamp.getBootcampName());
+		assertEquals(categoryType, bootcamp.getBootcampCategoryType());
+		assertEquals(response.getBootcampDegree(), bootcamp.getBootcampDegree());
+		assertEquals(response.getBootcampRegion(), bootcamp.getBootcampRegion());
+		assertEquals(response.getBootcampCapacity(), bootcamp.getBootcampCapacity());
+		assertEquals(response.isBootcampCost(), bootcamp.isBootcampCost());
+		assertEquals(response.getBootcampStartDate(), bootcamp.getBootcampStartDate());
+		assertEquals(response.getBootcampEndDate(), bootcamp.getBootcampEndDate());
+		assertEquals(response.getBootcampLink(), bootcamp.getBootcampLink());
+		verify(bootcampRepository, times(1)).findById(1L);
+	}
+
+	@Test
+	@DisplayName("부트캠프 ID 조회 실패 테스트 - 부트캠프 없음")
+	void findByIdFailedBootcampNotFound() {
+		//given
+		when(bootcampRepository.findById(999L)).thenReturn(Optional.empty());
+
+		//when & then
+		BootcampCustomException exception = assertThrows(BootcampCustomException.class,
+			() -> bootcampService.findById(999L)
+		);
+
+		assertEquals(exception.getBootcampErrorCode(), BOOTCAMP_NOT_FOUND);
+		verify(bootcampRepository, times(1)).findById(999L);
+	}
+}


### PR DESCRIPTION
### 변경사항

**AS-IS**
- 부트캠프 관련 API 미구현 상태
- 부트캠프 서비스 테스트 코드 미존재

**TO-BE**
- 부트캠프 도메인 기반 API 및 서비스 계층 구현
    - BootcampController 생성
        - GET /api/bootcamps: 부트캠프 목록 조회 (기본 페이징 처리 포함)
        - GET /api/bootcamps/{bootcampId}: 단일 부트캠프 조회
       
    - BootcampService 구현
        - findById(Long id): ID 기반 단일 조회 및 예외 처리
        - findAll(Pageable pageable): 페이징된 부트캠프 목록 조회
        - save(Bootcamp bootcamp): 저장 메서드 (단위 테스트용)

- 응답 DTO 구성
    - BootcampResponseDto 작성 (from(Bootcamp) 변환 메서드 포함)
    - 내부적으로 BootcampCategoryType의 한글 이름 변환 포함

- 도메인 정의
    - Bootcamp, TrainingCenter 엔티티 구현
    - BootcampCategoryType Enum 정의 및 한글 ↔ 영어 변환 기능 포함
    
- 예외 정의 및 처리
    - BootcampCustomException, BootcampErrorCode 정의
    - BOOTCAMP_NOT_FOUND, INVALID_CATEGORY_NAME 등의 상황 처리 가능

- Repository 인터페이스 정의
    - BootcampRepository, TrainingCenterRepository 생성

- 테스트 코드 추가 (BootcampServiceTest)
    - saveTest: 부트캠프 저장 로직 단위 테스트
    - findByIdSuccess: 존재하는 ID로 조회 성공 케이스 테스트
    - findByIdFailedBootcampNotFound: 존재하지 않는 ID 조회 시 예외 발생 확인
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
    - BootcampServiceTest 단위 테스트 Mock 객체를 활용 3종 구현 및 검증 완료
- [x] API 테스트 
    - postman으로 /api/bootcamps 및 /api/bootcamps/{id} 요청 정상 동작 확인
