### PR TITLE
Feat/bootcamp : Trainingcenter 조회 기능

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/batch/scheduler/BootcampFetchScheduler.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/batch/scheduler/BootcampFetchScheduler.java
@@ -1,6 +1,7 @@
 package com.icandoit.boottalk.batch.scheduler;
 
 import java.time.LocalDateTime;
+import java.util.Set;
 import java.util.UUID;
 
 import org.springframework.batch.core.Job;
@@ -9,6 +10,8 @@ import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+
+import com.icandoit.boottalk.bootcamp.service.Employ24ApiService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,6 +23,7 @@ public class BootcampFetchScheduler {
 
 	private final JobLauncher jobLauncher;
 	private final Job bootcampFetchJob;
+	private final Employ24ApiService employ24ApiService;
 
 	@Scheduled(cron = "0 0 0 * * *") // 매일 자정
 	public void runBootcampFetchJob() {
@@ -32,6 +36,10 @@ public class BootcampFetchScheduler {
 
 			jobLauncher.run(bootcampFetchJob, parameters);
 
+			Set<String> failedCategories = employ24ApiService.getFailedCategoryNames();
+			if (!failedCategories.isEmpty()) {
+				log.warn("배치 완료 후 저장 실패한 카테고리 목록: {}", failedCategories);
+			}
 			log.info("Bootcamp Fetch Batch 실행 완료");
 		} catch (Exception e) {
 			log.error("Bootcamp Fetch Batch 실행 실패", e);

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/controller/BootcampController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/controller/BootcampController.java
@@ -44,4 +44,8 @@ public class BootcampController {
 	public ResponseEntity<BootcampResponseDto> getBootcamp(@PathVariable Long bootcampId) {
 		return ResponseEntity.ok(bootcampService.findById(bootcampId));
 	}
+
+	// TODO : 검색 조회 (엔드 포인트 /search 진행 예정)
+
+	// TODO : 부트캠프 리뷰 조회 (엔드 포인트 /{bootcampId}/reviews)
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/controller/TrainingCenterController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/controller/TrainingCenterController.java
@@ -1,0 +1,28 @@
+package com.icandoit.boottalk.bootcamp.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.icandoit.boottalk.bootcamp.dto.TrainingCenterResponseDto;
+import com.icandoit.boottalk.bootcamp.service.TrainingCenterService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/trainingCenter")
+@RequiredArgsConstructor
+public class TrainingCenterController {
+
+	private final TrainingCenterService trainingCenterService;
+
+	@GetMapping("/{trainingCenterId}")
+	public ResponseEntity<TrainingCenterResponseDto> getTrainingCenter(
+		@PathVariable("trainingCenterId") Long trainingCenterId)
+	{
+		return ResponseEntity.ok(trainingCenterService.findById(trainingCenterId));
+	}
+
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/dto/BootcampEmploy24Response.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/dto/BootcampEmploy24Response.java
@@ -16,7 +16,8 @@ public class BootcampEmploy24Response {
 		@JsonProperty("trainstCstId") String trainingCenterId,
 		@JsonProperty("trprDegr") String bootcampDegree,
 		@JsonProperty("trprId") String bootcampId,
-		@JsonProperty("yardMan") String maxCapacity
+		@JsonProperty("yardMan") String maxCapacity,
+		@JsonProperty("courseMan") String cost
 	) {
 	}
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/dto/BootcampResponseDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/dto/BootcampResponseDto.java
@@ -8,8 +8,8 @@ import com.icandoit.boottalk.bootcamp.entity.Bootcamp;
 
 public record BootcampResponseDto(
 	Long bootcampId,
-	String bootcampName,
 	String trainingCenterName,
+	String bootcampName,
 	String bootcampRegion,
 	boolean bootcampCost,
 	String bootcampLink,
@@ -22,8 +22,8 @@ public record BootcampResponseDto(
 	public static BootcampResponseDto from(Bootcamp bootcamp) {
 		return new BootcampResponseDto(
 			bootcamp.getBootcampId(),
-			bootcamp.getBootcampName(),
 			bootcamp.getTrainingCenter().getTrainingCenterName(),
+			bootcamp.getBootcampName(),
 			bootcamp.getBootcampRegion(),
 			bootcamp.isBootcampCost(),
 			bootcamp.getBootcampLink(),

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/dto/BootcampResponseDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/dto/BootcampResponseDto.java
@@ -1,7 +1,6 @@
 package com.icandoit.boottalk.bootcamp.dto;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -9,8 +8,8 @@ import com.icandoit.boottalk.bootcamp.entity.Bootcamp;
 
 public record BootcampResponseDto(
 	Long bootcampId,
-	String trainingCenterName,
 	String bootcampName,
+	String trainingCenterName,
 	String bootcampRegion,
 	boolean bootcampCost,
 	String bootcampLink,
@@ -18,15 +17,13 @@ public record BootcampResponseDto(
 	int bootcampDegree,
 	int bootcampCapacity,
 	LocalDate bootcampStartDate,
-	LocalDate bootcampEndDate,
-	LocalDateTime createdAt,
-	LocalDateTime updatedAt
+	LocalDate bootcampEndDate
 ) {
 	public static BootcampResponseDto from(Bootcamp bootcamp) {
 		return new BootcampResponseDto(
 			bootcamp.getBootcampId(),
-			bootcamp.getTrainingCenter().getTrainingCenterName(),
 			bootcamp.getBootcampName(),
+			bootcamp.getTrainingCenter().getTrainingCenterName(),
 			bootcamp.getBootcampRegion(),
 			bootcamp.isBootcampCost(),
 			bootcamp.getBootcampLink(),
@@ -34,9 +31,7 @@ public record BootcampResponseDto(
 			bootcamp.getBootcampDegree(),
 			bootcamp.getBootcampCapacity(),
 			bootcamp.getBootcampStartDate(),
-			bootcamp.getBootcampEndDate(),
-			bootcamp.getCreatedAt(),
-			bootcamp.getUpdatedAt()
+			bootcamp.getBootcampEndDate()
 		);
 	}
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/dto/TrainingCenterResponseDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/dto/TrainingCenterResponseDto.java
@@ -1,0 +1,23 @@
+package com.icandoit.boottalk.bootcamp.dto;
+
+import com.icandoit.boottalk.bootcamp.entity.TrainingCenter;
+
+public record TrainingCenterResponseDto(
+	Long trainingCenterId,
+	String trainingCenterName,
+	String trainingCenterPhoneNumber,
+	String trainingCenterEmail,
+	String trainingCenterAddress,
+	String trainingCenterUrl
+) {
+	public static TrainingCenterResponseDto from(TrainingCenter trainingCenter) {
+		return new TrainingCenterResponseDto(
+			trainingCenter.getTrainingCenterId(),
+			trainingCenter.getTrainingCenterName(),
+			trainingCenter.getTrainingCenterPhoneNumber(),
+			trainingCenter.getTrainingCenterEmail(),
+			trainingCenter.getTrainingCenterAddress(),
+			trainingCenter.getTrainingCenterUrl()
+		);
+	}
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/entity/BootcampCategoryType.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/entity/BootcampCategoryType.java
@@ -16,7 +16,17 @@ public enum BootcampCategoryType {
 	INFORMATION_SECURITY_MANAGEMENT("정보보호관리·운영"),
 	SW_PRODUCT_PLANNING("SW제품기획"),
 	BIGDATA_ANALYSIS("빅데이터분석"),
-	AI_SERVICE_IMPLEMENTATION("인공지능서비스구현");
+	AI_SERVICE_IMPLEMENTATION("인공지능서비스구현"),
+	UI_UX_ENGINEERING("UI/UX엔지니어링"),
+	SECURITY_ENGINEERING("보안엔지니어링"),
+	ELECTRONIC_HARDWARE_DEV("전자응용기기하드웨어개발"),
+	DIGITAL_BIZ_SUPPORT_SERVICE("디지털비즈니스지원서비스"),
+	SEMICONDUCTOR_DEV("반도체개발"),
+	CLOUD_INFRA_ENGINEERING("클라우드인프라스트럭쳐엔지니어링"),
+	BIGDATA_PLATFORM_DEV("빅데이터플랫폼구축"),
+	DB_ENGINEERING("DB엔지니어링"),
+	CLOUD_SOLUTION_ARCH("클라우드솔루션아키텍처"),
+	IOT_SYSTEM_INTEGRATION("IoT시스템연동");
 
 	private final String koreanName;
 	private static final Map<String, String> englishToKoreanMap = new HashMap<>();
@@ -34,11 +44,15 @@ public enum BootcampCategoryType {
 
 	}
 
+	// TODO : 추후에 리스트 조회시 사용할 예정
 	public String getKoreanNameByEnglishName(String englishName) {
 		return englishToKoreanMap.getOrDefault(englishName, "알 수 없음");
 	}
 
-	//TODO : 부트캠프 openAPI에서 가져올 때 사용 예정
+	public static boolean isValidKoreanName(String koreanName) {
+		return koreanToEnumMap.containsKey(koreanName);
+	}
+
 	public static BootcampCategoryType fromKoreanName(String koreanName) {
 		if(!koreanToEnumMap.containsKey(koreanName)) {
 			throw new BootcampCustomException(BootcampErrorCode.INVALID_CATEGORY_NAME);

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/entity/TrainingCenter.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/entity/TrainingCenter.java
@@ -29,16 +29,12 @@ public class TrainingCenter extends BaseEntity {
 	@Column(nullable = false)
 	private String trainingCenterName;
 
-	@Column(nullable = false)
 	private String trainingCenterPhoneNumber;
 
-	@Column(nullable = false)
 	private String trainingCenterEmail;
 
-	@Column(nullable = false)
 	private String trainingCenterAddress;
 
-	@Column(nullable = false)
 	private String trainingCenterUrl;
 
 	public static TrainingCenter of(String name, String email, String address, String url, String phoneNumber) {

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/repository/BootcampRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/repository/BootcampRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BootcampRepository extends JpaRepository <Bootcamp, Long> {
 
+	boolean existsByBootcampNameAndBootcampDegree(String bootcampName, int bootcampDegree);
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/Employ24ApiService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/Employ24ApiService.java
@@ -6,7 +6,9 @@ import static com.icandoit.boottalk.bootcamp.exception.BootcampErrorCode.*;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +25,7 @@ import com.icandoit.boottalk.bootcamp.exception.BootcampCustomException;
 import com.icandoit.boottalk.bootcamp.repository.BootcampRepository;
 import com.icandoit.boottalk.bootcamp.repository.TrainingCenterRepository;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -41,94 +44,104 @@ public class Employ24ApiService {
 	private final TrainingCenterRepository trainingCenterRepository;
 	private final BootcampRepository bootcampRepository;
 
-	DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+	private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
 
+	@Getter
+	private final Set<String> failedCategoryNames = new HashSet<>();
 
+	// Employ24 API 에서 카테고리/분야 조합별로 데이터를 수집 및 저장
 	public void saveAllFromEmploy24() {
 		List<String> categoryCodes = List.of("C0061", "C0104", "C0105");
 		List<String> ncsCodes = List.of("19", "20");
 
-		for(String categoryCode : categoryCodes) {
-			for(String ncsCode : ncsCodes) {
-				try {
-					List<BootcampListResponseDto> list = fetchBootcampList(categoryCode, ncsCode);
-					for(BootcampListResponseDto dto : list) {
-						saveBootcamp(dto);
-					}
-				} catch (Exception e) {
-					log.warn("데이터 수집 실패: categoryCode={}, ncsCode={}, message={}", categoryCode, ncsCode, e.getMessage());
-				}
+		for (String categoryCode : categoryCodes) {
+			for (String ncsCode : ncsCodes) {
+				processCategoryAndNcs(categoryCode, ncsCode);
 			}
 		}
 	}
 
+	// 주어진 카테고리와 NCS 코드로 리스트 조회 후 저장 처리
+	private void processCategoryAndNcs(String categoryCode, String ncsCode) {
+		try {
+			List<BootcampListResponseDto> list = fetchBootcampList(categoryCode, ncsCode);
+			processBootcampList(list);
+		} catch (Exception e) {
+			log.warn("데이터 수집 실패: categoryCode={}, ncsCode={}, message={}", categoryCode, ncsCode, e.getMessage());
+		}
+	}
+
+	// 중복이 아닌 경우에만 Bootcamp 저장
+	private void processBootcampList(List<BootcampListResponseDto> list) {
+		for (BootcampListResponseDto dto : list) {
+			if (isDuplicate(dto)) {
+				log.info("이미 등록된 부트캠프: {}", dto.bootcampName());
+				continue;
+			}
+			saveBootcamp(dto);
+		}
+	}
+
+	// Bootcamp 저장 (상세 정보 조회 포함)
+	private void saveBootcamp(BootcampListResponseDto dto) {
+		BootcampDetailResponseDto detail = fetchBootcampDetail(dto.bootcampId(), dto.bootcampDegree(), dto.trainingCenterId());
+
+		String categoryName = detail.ncsName();
+		if (!BootcampCategoryType.isValidKoreanName(categoryName)) {
+			failedCategoryNames.add(categoryName);
+			return;
+		}
+
+		TrainingCenter center = trainingCenterRepository.findByTrainingCenterName(dto.trainingCenterName())
+			.orElseGet(() -> trainingCenterRepository.save(
+				TrainingCenter.of(
+					dto.trainingCenterName(),
+					detail.trainingCenterEmail(),
+					detail.address1() + " " + detail.address2(),
+					detail.trainingCenterUrl(),
+					detail.trainingCenterTelephoneNumber()
+				)
+			));
+
+		BootcampCategoryType category = BootcampCategoryType.fromKoreanName(categoryName);
+
+		boolean hasCost = !(detail.bootcampCourseName().equals("K-디지털트레이닝") || dto.maxCapacity().equals("0"));
+
+		Bootcamp bootcamp = Bootcamp.of(
+			center,
+			dto.bootcampName(),
+			category,
+			Integer.parseInt(dto.bootcampDegree()),
+			detail.address1(),
+			Integer.parseInt(dto.maxCapacity()),
+			hasCost,
+			LocalDate.parse(dto.trainingStartDate(), DateTimeFormatter.ofPattern("yyyy-MM-dd")),
+			LocalDate.parse(dto.trainingEndDate(), DateTimeFormatter.ofPattern("yyyy-MM-dd")),
+			dto.bootcampLink()
+		);
+
+		bootcampRepository.save(bootcamp);
+		log.info("저장 성공: {}", bootcamp.getBootcampName());
+	}
+
+	// 중복 데이터 여부 확인
+	private boolean isDuplicate(BootcampListResponseDto dto) {
+		return bootcampRepository.existsByBootcampNameAndBootcampDegree(
+			dto.bootcampName(), Integer.parseInt(dto.bootcampDegree())
+		);
+	}
+
+	// Bootcamp 리스트 API 호출
 	private List<BootcampListResponseDto> fetchBootcampList(String categoryCode, String ncsCode) {
 		String url = buildListApiUrl(categoryCode, ncsCode);
-
 		ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, null, String.class);
 		validateResponse(response);
-
-		try {
-			JsonNode srchList = objectMapper.readTree(response.getBody()).get("srchList");
-
-			if(srchList == null || srchList.isEmpty()) {
-				throw new BootcampCustomException(API_DATA_IS_EMPTY);
-			}
-
-			List<BootcampListResponseDto> result = new ArrayList<>();
-
-			for (JsonNode node : srchList) {
-				result.add(objectMapper.treeToValue(node, BootcampListResponseDto.class));
-			}
-
-			return result;
-		} catch (Exception e) {
-			throw new BootcampCustomException(DATA_PARSING_ERROR);
-		}
+		return parseListResponse(response.getBody());
 	}
 
-	private void saveBootcamp(BootcampListResponseDto dto) {
-		try {
-			BootcampDetailResponseDto detail = fetchBootcampDetail(dto.bootcampId(), dto.bootcampDegree(), dto.trainingCenterId());
-
-			TrainingCenter center = trainingCenterRepository.findByTrainingCenterName(dto.trainingCenterName())
-				.orElseGet(() -> trainingCenterRepository.save(
-					TrainingCenter.of(
-						dto.trainingCenterName(),
-						detail.trainingCenterEmail(),
-						detail.address1() + " " + detail.address2(),
-						detail.trainingCenterUrl(),
-						detail.trainingCenterTelephoneNumber()
-					)
-				));
-
-			BootcampCategoryType category = BootcampCategoryType.fromKoreanName(detail.ncsName());
-
-			boolean hasCost = !(detail.bootcampCourseName().equals("K-디지털트레이닝") || dto.maxCapacity().equals("0"));
-
-			Bootcamp bootcamp = Bootcamp.of(
-				center,
-				dto.bootcampName(),
-				category,
-				Integer.parseInt(dto.bootcampDegree()),
-				detail.address1(),
-				Integer.parseInt(dto.maxCapacity()),
-				hasCost,
-				LocalDate.parse(dto.trainingStartDate(), DateTimeFormatter.ofPattern("yyyy-MM-dd")),
-				LocalDate.parse(dto.trainingEndDate(), DateTimeFormatter.ofPattern("yyyy-MM-dd")),
-				dto.bootcampLink()
-			);
-
-			bootcampRepository.save(bootcamp);
-			log.info("저장 성공: {}", bootcamp.getBootcampName());
-		}catch(Exception e) {
-			log.warn("저장 실패: {}", dto.bootcampName(), e);
-		}
-	}
-
+	// Bootcamp 상세 API 호출
 	private BootcampDetailResponseDto fetchBootcampDetail(String id, String degree, String centerId) {
 		String url = buildDetailApiUrl(id, degree, centerId);
-		log.info("Fetch detail from URL: {}", url);
 
 		ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, null, String.class);
 		validateResponse(response);
@@ -141,9 +154,29 @@ public class Employ24ApiService {
 		}
 	}
 
+	// 응답 JSON 파싱 → BootcampList DTO로 변환
+	private List<BootcampListResponseDto> parseListResponse(String body) {
+		try {
+			JsonNode jsonList = objectMapper.readTree(body).get("srchList");
+
+			if (jsonList == null || jsonList.isEmpty()) {
+				throw new BootcampCustomException(API_DATA_IS_EMPTY);
+			}
+
+			List<BootcampListResponseDto> list = new ArrayList<>();
+			for (JsonNode node : jsonList) {
+				list.add(objectMapper.treeToValue(node, BootcampListResponseDto.class));
+			}
+			return list;
+		} catch (Exception e) {
+			throw new BootcampCustomException(DATA_PARSING_ERROR);
+		}
+	}
+
+	// 리스트 API 호출 URL 생성
 	private String buildListApiUrl(String categoryCode, String ncsCode) {
 		LocalDate today = LocalDate.now();
-		LocalDate end = today.plusDays(1);
+		LocalDate end = today.plusDays(7);
 		return UriComponentsBuilder.newInstance()
 			.scheme("https")
 			.host(HOST)
@@ -161,6 +194,7 @@ public class Employ24ApiService {
 			.toUriString();
 	}
 
+	// 상세 API 호출 URL 생성
 	private String buildDetailApiUrl(String id, String degree, String centerId) {
 		return UriComponentsBuilder.newInstance()
 			.scheme("https")
@@ -176,6 +210,7 @@ public class Employ24ApiService {
 			.toUriString();
 	}
 
+	// API 응답 유효성 검사
 	private void validateResponse(ResponseEntity<String> response) {
 		if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
 			throw new BootcampCustomException(DATA_FETCH_ERROR);

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/Employ24ApiService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/Employ24ApiService.java
@@ -37,6 +37,7 @@ public class Employ24ApiService {
 	private static final String HOST = "www.work24.go.kr";
 	private static final String LIST_API_PATH = "/cm/openApi/call/hr/callOpenApiSvcInfo310L01.do";
 	private static final String DETAIL_API_PATH = "/cm/openApi/call/hr/callOpenApiSvcInfo310L02.do";
+	// TODO : 추후에 AUTH_KEY 관리 방식 지정하기
 	private static final String AUTH_KEY = "646d5bd7-af0c-42b1-94db-fd6d2c6908f7";
 
 	private final ObjectMapper objectMapper = new ObjectMapper();
@@ -105,7 +106,7 @@ public class Employ24ApiService {
 
 		BootcampCategoryType category = BootcampCategoryType.fromKoreanName(categoryName);
 
-		boolean hasCost = !(detail.bootcampCourseName().equals("K-디지털트레이닝") || dto.maxCapacity().equals("0"));
+		boolean hasCost = !(detail.bootcampCourseName().equals("K-디지털트레이닝") || dto.cost().equals("0"));
 
 		Bootcamp bootcamp = Bootcamp.of(
 			center,

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/TrainingCenterService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/TrainingCenterService.java
@@ -1,0 +1,31 @@
+package com.icandoit.boottalk.bootcamp.service;
+
+import static com.icandoit.boottalk.bootcamp.exception.BootcampErrorCode.*;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import com.icandoit.boottalk.bootcamp.dto.TrainingCenterResponseDto;
+import com.icandoit.boottalk.bootcamp.entity.TrainingCenter;
+import com.icandoit.boottalk.bootcamp.exception.BootcampCustomException;
+import com.icandoit.boottalk.bootcamp.repository.TrainingCenterRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TrainingCenterService {
+
+	private final TrainingCenterRepository trainingCenterRepository;
+
+	public TrainingCenterResponseDto findById(Long id) {
+		Optional<TrainingCenter> trainingCenter = trainingCenterRepository.findById(id);
+
+		if(trainingCenter.isEmpty()) {
+			throw new BootcampCustomException(TRAINING_CENTER_NOT_FOUND);
+		}
+
+		return TrainingCenterResponseDto.from(trainingCenter.get());
+	}
+}

--- a/boottalk/src/test/java/com/icandoit/boottalk/bootcamp/service/BootcampServiceTest.java
+++ b/boottalk/src/test/java/com/icandoit/boottalk/bootcamp/service/BootcampServiceTest.java
@@ -94,16 +94,16 @@ class BootcampServiceTest {
 		BootcampCategoryType categoryType = BootcampCategoryType.fromKoreanName(response.bootcampCategory());
 
 		//then
-		assertEquals(response.bootcampId(), bootcamp.getBootcampId());
-		assertEquals(response.bootcampName(), bootcamp.getBootcampName());
-		assertEquals(categoryType, bootcamp.getBootcampCategoryType());
-		assertEquals(response.bootcampDegree(), bootcamp.getBootcampDegree());
-		assertEquals(response.bootcampRegion(), bootcamp.getBootcampRegion());
-		assertEquals(response.bootcampCapacity(), bootcamp.getBootcampCapacity());
-		assertEquals(response.bootcampCost(), bootcamp.isBootcampCost());
-		assertEquals(response.bootcampStartDate(), bootcamp.getBootcampStartDate());
-		assertEquals(response.bootcampEndDate(), bootcamp.getBootcampEndDate());
-		assertEquals(response.bootcampLink(), bootcamp.getBootcampLink());
+		assertEquals(bootcamp.getBootcampId(), response.bootcampId());
+		assertEquals(bootcamp.getBootcampName(), response.bootcampName());
+		assertEquals(bootcamp.getBootcampCategoryType(), categoryType);
+		assertEquals(bootcamp.getBootcampDegree(), response.bootcampDegree());
+		assertEquals(bootcamp.getBootcampRegion(), response.bootcampRegion());
+		assertEquals(bootcamp.getBootcampCapacity(), response.bootcampCapacity());
+		assertEquals(bootcamp.isBootcampCost(), response.bootcampCost());
+		assertEquals(bootcamp.getBootcampStartDate(), response.bootcampStartDate());
+		assertEquals(bootcamp.getBootcampEndDate(), response.bootcampEndDate());
+		assertEquals(bootcamp.getBootcampLink(), response.bootcampLink());
 		verify(bootcampRepository, times(1)).findById(1L);
 	}
 

--- a/boottalk/src/test/java/com/icandoit/boottalk/bootcamp/service/BootcampServiceTest.java
+++ b/boottalk/src/test/java/com/icandoit/boottalk/bootcamp/service/BootcampServiceTest.java
@@ -94,16 +94,16 @@ class BootcampServiceTest {
 		BootcampCategoryType categoryType = BootcampCategoryType.fromKoreanName(response.bootcampCategory());
 
 		//then
-		assertEquals(bootcamp.getBootcampId(), response.bootcampId());
-		assertEquals(bootcamp.getBootcampName(), response.bootcampName());
-		assertEquals(bootcamp.getBootcampCategoryType(), categoryType);
-		assertEquals(bootcamp.getBootcampDegree(), response.bootcampDegree());
-		assertEquals(bootcamp.getBootcampRegion(), response.bootcampRegion());
-		assertEquals(bootcamp.getBootcampCapacity(), response.bootcampCapacity());
-		assertEquals(bootcamp.isBootcampCost(), response.bootcampCost());
-		assertEquals(bootcamp.getBootcampStartDate(), response.bootcampStartDate());
-		assertEquals(bootcamp.getBootcampEndDate(), response.bootcampEndDate());
-		assertEquals(bootcamp.getBootcampLink(), response.bootcampLink());
+		assertEquals(response.bootcampId(), bootcamp.getBootcampId());
+		assertEquals(response.bootcampName(), bootcamp.getBootcampName());
+		assertEquals(categoryType, bootcamp.getBootcampCategoryType());
+		assertEquals(response.bootcampDegree(), bootcamp.getBootcampDegree());
+		assertEquals(response.bootcampRegion(), bootcamp.getBootcampRegion());
+		assertEquals(response.bootcampCapacity(), bootcamp.getBootcampCapacity());
+		assertEquals(response.bootcampCost(), bootcamp.isBootcampCost());
+		assertEquals(response.bootcampStartDate(), bootcamp.getBootcampStartDate());
+		assertEquals(response.bootcampEndDate(), bootcamp.getBootcampEndDate());
+		assertEquals(response.bootcampLink(), bootcamp.getBootcampLink());
 		verify(bootcampRepository, times(1)).findById(1L);
 	}
 

--- a/boottalk/src/test/java/com/icandoit/boottalk/bootcamp/service/TrainingCenterServiceTest.java
+++ b/boottalk/src/test/java/com/icandoit/boottalk/bootcamp/service/TrainingCenterServiceTest.java
@@ -1,0 +1,79 @@
+package com.icandoit.boottalk.bootcamp.service;
+
+import static com.icandoit.boottalk.bootcamp.exception.BootcampErrorCode.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.icandoit.boottalk.bootcamp.dto.TrainingCenterResponseDto;
+import com.icandoit.boottalk.bootcamp.entity.TrainingCenter;
+import com.icandoit.boottalk.bootcamp.exception.BootcampCustomException;
+import com.icandoit.boottalk.bootcamp.repository.TrainingCenterRepository;
+
+class TrainingCenterServiceTest {
+
+	@InjectMocks
+	private TrainingCenterService trainingCenterService;
+
+	@Mock
+	private TrainingCenterRepository trainingCenterRepository;
+
+	private TrainingCenter trainingCenter;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+
+		trainingCenter = TrainingCenter.builder()
+			.trainingCenterId(1L)
+			.trainingCenterName("기관명")
+			.trainingCenterAddress("기관 주소")
+			.trainingCenterEmail("example@test.com")
+			.trainingCenterPhoneNumber("010-1234-5678")
+			.trainingCenterUrl("www.trainingcenter.com")
+			.build();
+	}
+
+	@Test
+	@DisplayName("교육 기관 ID 조회 성공")
+	void findByIdSuccess() {
+		//given
+		when(trainingCenterRepository.findById(1L)).thenReturn(Optional.of(trainingCenter));
+
+		//when
+		TrainingCenterResponseDto response = trainingCenterService.findById(1L);
+
+		//then
+		assertNotNull(response);
+		assertEquals(response.trainingCenterId(), trainingCenter.getTrainingCenterId());
+		assertEquals(response.trainingCenterName(), trainingCenter.getTrainingCenterName());
+		assertEquals(response.trainingCenterPhoneNumber(), trainingCenter.getTrainingCenterPhoneNumber());
+		assertEquals(response.trainingCenterEmail(), trainingCenter.getTrainingCenterEmail());
+		assertEquals(response.trainingCenterAddress(), trainingCenter.getTrainingCenterAddress());
+		assertEquals(response.trainingCenterUrl(), trainingCenter.getTrainingCenterUrl());
+		verify(trainingCenterRepository, times(1)).findById(1L);
+	}
+
+	@Test
+	@DisplayName("교육 기관 ID 조회 실패 - 교육 기관 없음")
+	void findByIdFailedTrainingCenterNotFound() {
+		//given
+		when(trainingCenterRepository.findById(9999L)).thenReturn(Optional.empty());
+
+		//when & then
+		BootcampCustomException exception = assertThrows(BootcampCustomException.class,
+			() -> trainingCenterService.findById(9999L));
+
+		assertEquals(exception.getBootcampErrorCode(), TRAINING_CENTER_NOT_FOUND);
+		verify(trainingCenterRepository, times(1)).findById(9999L);
+	}
+
+}


### PR DESCRIPTION
### 변경사항

**AS-IS**
- 교육기관 단건 조회 기능이 없어서 부트캠프 상세 정보를 확인할 때 교육기관 정보를 따로 확인할 수 없었음

**TO-BE**
- 교육기관 단건 조회 API 추가 (GET /api/trainingCenter/{trainingCenterId})
- TrainingCenterResponseDto를 통해 필요한 기관 정보(JSON) 반환
- 존재하지 않는 ID 요청 시 BootcampCustomException 발생 (TRAINING_CENTER_NOT_FOUND)
- 단위 테스트 작성 완료 (TrainingCenterServiceTest)
- Postman을 통한 실제 API 테스트 수행

### 테스트
- [x] 테스트 코드
    - TrainingCenterServiceTest: 성공 및 실패 케이스 테스트 작성 완료
- [x] API 테스트
    - Postman으로 다음 API 테스트 완료

---

#### 부트캠프 상세조회
![2025-04-01_4 30 23](https://github.com/user-attachments/assets/db1b5ee3-cad7-4d93-974d-28b149cfc8f4)

#### 부트캠프 전체 조회
      
![2025-04-01_4 30 04](https://github.com/user-attachments/assets/3bde8c00-f224-4106-97de-1a766bc8c34c)

#### 교육 기관 조회
![2025-04-01_4 40 36](https://github.com/user-attachments/assets/05e43378-7b76-4162-b145-dc84a87d3f13)
