### PR TITLE
feat: 유저엔티티에 resourceUserId 필드값 추가, SignUpService 에서 resourceUserId를 …

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/review/dto/ReviewResponseDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/review/dto/ReviewResponseDto.java
@@ -19,7 +19,7 @@ public record ReviewResponseDto(
 			review.getReviewId(),
 			review.getBootcamp().getBootcampId(),
 			review.getBootcamp().getBootcampName(),
-			review.getUser().getName(),
+			review.getUser().getUserName(),
 			review.getContent(),
 			review.getRating(),
 			review.getCreatedAt(),

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/dto/UserDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/dto/UserDto.java
@@ -1,12 +1,12 @@
 package com.icandoit.boottalk.user.domain.dto;
 
+import com.icandoit.boottalk.bootcamp.entity.BootcampCategoryType;
 import com.icandoit.boottalk.user.domain.entity.User;
-import com.icandoit.boottalk.user.domain.type.DesiredCareer;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
 @NoArgsConstructor
@@ -17,7 +17,7 @@ public class UserDto {
   private String name;
   private String email;
   private String profileImage;
-  private DesiredCareer desiredCareer;
+  private BootcampCategoryType desiredCareer;
 
   public static UserDto from(User user) {
     return UserDto.builder()

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/dto/UserDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/dto/UserDto.java
@@ -21,7 +21,7 @@ public class UserDto {
 
   public static UserDto from(User user) {
     return UserDto.builder()
-        .name(user.getName())
+        .name(user.getUserName())
         .email(user.getEmail())
         .profileImage(user.getProfileImage())
         .desiredCareer(user.getDesiredCareer())

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/entity/User.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/entity/User.java
@@ -33,6 +33,8 @@ public class User extends BaseEntity {
 	private String name;
 	private String email;
 	private String profileImage;
+	//네이버에서 주는 고유 Id
+	private String resourceUserId;
 
 	@Enumerated(EnumType.STRING)
 	private DesiredCareer desiredCareer;
@@ -42,10 +44,10 @@ public class User extends BaseEntity {
 
 	public static User of(SignUpForm form) {
 		return User.builder()
-			.userId(form.getUserId())
 			.name(form.getName())
 			.email(form.getEmail())
 			.profileImage(form.getProfileImage())
+			.resourceUserId(form.getResourceUserId())
 			.desiredCareer(form.getDesiredCareer())
 			.deletedAt(null)
 			.build();

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/entity/User.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/entity/User.java
@@ -2,10 +2,10 @@ package com.icandoit.boottalk.user.domain.entity;
 
 import java.sql.Timestamp;
 
+import com.icandoit.boottalk.bootcamp.entity.BootcampCategoryType;
 import com.icandoit.boottalk.libs.entity.BaseEntity;
 import com.icandoit.boottalk.user.domain.form.SignUpForm;
 import com.icandoit.boottalk.user.domain.form.UpdateForm;
-import com.icandoit.boottalk.user.domain.type.DesiredCareer;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -31,7 +31,7 @@ public class User extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private long userId;
 
-	@Column(nullable = false)
+	@Column(nullable = false, updatable = false)
 	private String userName;
 
 	@Column(nullable = false)
@@ -44,7 +44,7 @@ public class User extends BaseEntity {
 
 	@Column(nullable = false)
 	@Enumerated(EnumType.STRING)
-	private DesiredCareer desiredCareer;
+	private BootcampCategoryType desiredCareer;
 
 	@Setter
 	private Timestamp deletedAt;
@@ -61,11 +61,9 @@ public class User extends BaseEntity {
 	}
 
 	public User updateOf(UpdateForm form) {
-		this.userName = form.getName();
 		this.email = form.getEmail();
 		this.profileImage = form.getProfileImage();
 		this.desiredCareer = form.getDesiredCareer();
-
 		return this;
 	}
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/entity/User.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/entity/User.java
@@ -7,6 +7,7 @@ import com.icandoit.boottalk.user.domain.form.SignUpForm;
 import com.icandoit.boottalk.user.domain.form.UpdateForm;
 import com.icandoit.boottalk.user.domain.type.DesiredCareer;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -30,12 +31,18 @@ public class User extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private long userId;
 
-	private String name;
+	@Column(nullable = false)
+	private String userName;
+
+	@Column(nullable = false)
 	private String email;
+
 	private String profileImage;
 	//네이버에서 주는 고유 Id
+	@Column(nullable = false)
 	private String resourceUserId;
 
+	@Column(nullable = false)
 	@Enumerated(EnumType.STRING)
 	private DesiredCareer desiredCareer;
 
@@ -44,7 +51,7 @@ public class User extends BaseEntity {
 
 	public static User of(SignUpForm form) {
 		return User.builder()
-			.name(form.getName())
+			.userName(form.getUserName())
 			.email(form.getEmail())
 			.profileImage(form.getProfileImage())
 			.resourceUserId(form.getResourceUserId())
@@ -54,7 +61,7 @@ public class User extends BaseEntity {
 	}
 
 	public User updateOf(UpdateForm form) {
-		this.name = form.getName();
+		this.userName = form.getName();
 		this.email = form.getEmail();
 		this.profileImage = form.getProfileImage();
 		this.desiredCareer = form.getDesiredCareer();

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/form/SignUpForm.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/form/SignUpForm.java
@@ -1,8 +1,7 @@
 package com.icandoit.boottalk.user.domain.form;
 
-import org.antlr.v4.runtime.misc.NotNull;
+import com.icandoit.boottalk.bootcamp.entity.BootcampCategoryType;
 
-import com.icandoit.boottalk.user.domain.type.DesiredCareer;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,5 +17,5 @@ public class SignUpForm {
 	private String userName;
 	private String email;
 	private String profileImage;
-	private DesiredCareer desiredCareer;
+	private BootcampCategoryType desiredCareer;
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/form/SignUpForm.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/form/SignUpForm.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 @Builder
 public class SignUpForm {
 
-	private long userId;
+	private String resourceUserId;
 	private String name;
 	private String email;
 	private String profileImage;

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/form/SignUpForm.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/form/SignUpForm.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 public class SignUpForm {
 
 	private String resourceUserId;
-	private String name;
+	private String userName;
 	private String email;
 	private String profileImage;
 	private DesiredCareer desiredCareer;

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/form/UpdateForm.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/form/UpdateForm.java
@@ -1,20 +1,18 @@
 package com.icandoit.boottalk.user.domain.form;
 
-import com.icandoit.boottalk.user.domain.type.DesiredCareer;
-import java.math.BigInteger;
+import com.icandoit.boottalk.bootcamp.entity.BootcampCategoryType;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class UpdateForm {
-  private String name;
   private String email;
   private String profileImage;
-  private DesiredCareer desiredCareer;
+  private BootcampCategoryType desiredCareer;
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/repository/UserRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/repository/UserRepository.java
@@ -8,7 +8,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-
 	Optional<User> findByResourceUserId(String resourceUserId);
-
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/repository/UserRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/repository/UserRepository.java
@@ -1,10 +1,14 @@
 package com.icandoit.boottalk.user.domain.repository;
 
+import java.util.Optional;
+
 import com.icandoit.boottalk.user.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+
+	Optional<User> findByResourceUserId(String resourceUserId);
 
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/type/DesiredCareer.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/type/DesiredCareer.java
@@ -1,7 +1,0 @@
-package com.icandoit.boottalk.user.domain.type;
-
-public enum DesiredCareer {
-  ENGINEER,
-  DESIGNER,
-  MANAGER
-}

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/service/ManageService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/service/ManageService.java
@@ -3,7 +3,6 @@ package com.icandoit.boottalk.user.service;
 import static com.icandoit.boottalk.libs.exception.ErrorCode.*;
 
 import com.icandoit.boottalk.libs.exception.CustomException;
-import com.icandoit.boottalk.libs.exception.ErrorCode;
 import com.icandoit.boottalk.user.domain.dto.UserDto;
 import com.icandoit.boottalk.user.domain.entity.User;
 import com.icandoit.boottalk.user.domain.form.UpdateForm;
@@ -24,27 +23,26 @@ public class ManageService {
 	@Transactional
 	public UserDto getUser(Long userId) {
 
-		return UserDto.from(validateUser(userId));
+		return UserDto.from(getUserInfo(userId));
 	}
 
 	@Transactional
 	public UserDto updateUser(Long userId, UpdateForm form) {
 
-		return UserDto.from(userRepository.save(validateUser(userId).updateOf(form)));
+		return UserDto.from(getUserInfo(userId).updateOf(form));
 	}
 
 	@Transactional
 	public void deleteUser(Long userId) {
 
-		User user = validateUser(userId);
+		User user = getUserInfo(userId);
 
 		user.setDeletedAt(Timestamp.from(Instant.now()));
-		userRepository.save(user);
 	}
 
 
-	//유효한 회원인지 확인
-	private User validateUser(Long userId) {
+	//사용자 정보 불러오기
+	private User getUserInfo(Long userId) {
 
 		return userRepository.findById(userId)
 			.orElseThrow(() -> new CustomException(USER_NOT_FOUND));

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/service/SignUpService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/service/SignUpService.java
@@ -19,7 +19,7 @@ public class SignUpService {
   @Transactional
   public void signUp(SignUpForm form) {
 
-    User user = userRepository.findById(form.getUserId()).orElse(null);
+    User user = userRepository.findByResourceUserId(form.getResourceUserId()).orElse(null);
 
     // 이미 회원가입된 유저인 경우에는 예외처리
     // 회원가입되었던 유저중에서 회원탈퇴한 회원이 다시 회원가입 시도하는 경우,
@@ -35,6 +35,4 @@ public class SignUpService {
 
     userRepository.save(User.of(form));
   }
-
-
 }


### PR DESCRIPTION
…통해 기존 사용자 정보 확인

### 변경사항
**AS-IS**

**TO-BE**
- 추후 소셜 로그인을 구현할 때 받아온 사용자 정보값으로 기존회원과 신규회원을 구분하기 위해 resourceUserId 필드값 추가
- SignUpService 에서 resourceUserId를 통해 기존 회원 정보 확인
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [X] API 테스트 
