### PR TITLE
Feat/bootcmap reviews by course

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/controller/BootcampController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/controller/BootcampController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -15,6 +16,8 @@ import org.springframework.web.bind.annotation.RestController;
 import com.icandoit.boottalk.bootcamp.dto.BootcampResponseDto;
 import com.icandoit.boottalk.bootcamp.entity.Bootcamp;
 import com.icandoit.boottalk.bootcamp.service.BootcampService;
+import com.icandoit.boottalk.review.dto.ReviewResponseDto;
+import com.icandoit.boottalk.review.service.ReviewService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,6 +27,7 @@ import lombok.RequiredArgsConstructor;
 public class BootcampController {
 
 	private final BootcampService bootcampService;
+	private final ReviewService reviewService;
 
 	// 부트캠프 목록 조회
 	@GetMapping
@@ -45,7 +49,15 @@ public class BootcampController {
 		return ResponseEntity.ok(bootcampService.findById(bootcampId));
 	}
 
+	// 특정 부트캠프의 훈련 과정 (Course) 에 작성된 리뷰를 페이징으로 조회
+	@GetMapping("/{bootcampId}/reviews")
+	public ResponseEntity<Page<ReviewResponseDto>> getCourseReviews(
+		@PathVariable Long bootcampId,
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "10") int size
+	) {
+		Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+		return ResponseEntity.ok(reviewService.getReviewsBootcampId(bootcampId, pageable));
+	}
 	// TODO : 검색 조회 (엔드 포인트 /search 진행 예정)
-
-	// TODO : 부트캠프 리뷰 조회 (엔드 포인트 /{bootcampId}/reviews)
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/dto/CoffeeChatInfoResponseDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/dto/CoffeeChatInfoResponseDto.java
@@ -21,7 +21,7 @@ public record CoffeeChatInfoResponseDto(
         return new CoffeeChatInfoResponseDto(
             coffeeChatInfo.getCoffeeChatInfoId(),
             coffeeChatInfo.getUser().getUserId(),
-            coffeeChatInfo.getUser().getName(),
+            coffeeChatInfo.getUser().getUserName(),
             coffeeChatInfo.getUserType(),
             coffeeChatInfo.getJobType(),
             coffeeChatInfo.getIntroduction(),

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/repository/CoffeeChatInfoRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/repository/CoffeeChatInfoRepository.java
@@ -8,5 +8,5 @@ public interface CoffeeChatInfoRepository extends JpaRepository<CoffeeChatInfo, 
 
     Optional<CoffeeChatInfo> findByUser_UserId(Long userId);
 
-    boolean existsByUserId(Long userId);
+    boolean existsByUser_UserId(Long userId);
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatInfoService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatInfoService.java
@@ -33,12 +33,12 @@ public class CoffeeChatInfoService {
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        if (coffeeChatInfoRepository.existsByUserId(userId)) {
+        if (coffeeChatInfoRepository.existsByUser_UserId(userId)) {
             throw new CustomException(ErrorCode.COFFEE_CHAT_ALREADY_EXISTS);
         }
         CoffeeChatInfo coffeeChatInfo = CoffeeChatInfo.of(
             user,
-            user.getName(),
+            user.getUserName(),
             requestDto.userType(),
             requestDto.jobType(),
             requestDto.introduction()

--- a/boottalk/src/main/java/com/icandoit/boottalk/review/controller/ReviewController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/review/controller/ReviewController.java
@@ -12,8 +12,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.icandoit.boottalk.review.dto.ReviewRequestDto;
+import com.icandoit.boottalk.review.dto.ReviewCreateRequestDto;
 import com.icandoit.boottalk.review.dto.ReviewResponseDto;
+import com.icandoit.boottalk.review.dto.ReviewUpdateRequestDto;
 import com.icandoit.boottalk.review.service.ReviewService;
 
 import jakarta.validation.Valid;
@@ -28,7 +29,7 @@ public class ReviewController {
 
 	// 리뷰 등록
 	@PostMapping
-	public ResponseEntity<ReviewResponseDto> create(@RequestBody @Valid ReviewRequestDto request) {
+	public ResponseEntity<ReviewResponseDto> create(@RequestBody @Valid ReviewCreateRequestDto request) {
 		Long userId = 1L; // test
 		return ResponseEntity.ok(reviewService.create(request, userId));
 	}
@@ -52,7 +53,7 @@ public class ReviewController {
 	// 내 리뷰 수정
 	@PutMapping("/my/{reviewId}")
 	public ResponseEntity<ReviewResponseDto> update(@PathVariable Long reviewId,
-		@RequestBody @Valid ReviewRequestDto request) {
+		@RequestBody @Valid ReviewUpdateRequestDto request) {
 		Long userId = 1L; // test
 		return ResponseEntity.ok(reviewService.update(request, reviewId, userId));
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/review/dto/ReviewCreateRequestDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/review/dto/ReviewCreateRequestDto.java
@@ -2,7 +2,7 @@ package com.icandoit.boottalk.review.dto;
 
 import jakarta.validation.constraints.NotNull;
 
-public record ReviewRequestDto (
+public record ReviewCreateRequestDto(
 	@NotNull(message = "훈련과정 ID는 필수 항목입니다.") String trainingProgramId,
 	@NotNull(message = "내용은 필수 항목입니다.") String content,
 	@NotNull(message = "평점은 필수 항목입니다.") int rating

--- a/boottalk/src/main/java/com/icandoit/boottalk/review/dto/ReviewRequestDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/review/dto/ReviewRequestDto.java
@@ -3,7 +3,6 @@ package com.icandoit.boottalk.review.dto;
 import jakarta.validation.constraints.NotNull;
 
 public record ReviewRequestDto (
-	Long reviewId,
 	@NotNull(message = "훈련과정 ID는 필수 항목입니다.") String trainingProgramId,
 	@NotNull(message = "내용은 필수 항목입니다.") String content,
 	@NotNull(message = "평점은 필수 항목입니다.") int rating

--- a/boottalk/src/main/java/com/icandoit/boottalk/review/dto/ReviewResponseDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/review/dto/ReviewResponseDto.java
@@ -19,7 +19,7 @@ public record ReviewResponseDto(
 			review.getReviewId(),
 			review.getCourse().getTrainingProgramId(),
 			review.getCourse().getCourseName(),
-			review.getUser().getName(),
+			review.getUser().getUserName(),
 			review.getContent(),
 			review.getRating(),
 			review.getCreatedAt(),

--- a/boottalk/src/main/java/com/icandoit/boottalk/review/dto/ReviewUpdateRequestDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/review/dto/ReviewUpdateRequestDto.java
@@ -1,0 +1,9 @@
+package com.icandoit.boottalk.review.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ReviewUpdateRequestDto(
+	@NotNull(message = "내용은 필수 항목입니다.") String content,
+	@NotNull(message = "평점은 필수 항목입니다.") int rating
+) {
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/review/entity/Review.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/review/entity/Review.java
@@ -2,7 +2,8 @@ package com.icandoit.boottalk.review.entity;
 
 import com.icandoit.boottalk.bootcamp.entity.Course;
 import com.icandoit.boottalk.libs.entity.BaseEntity;
-import com.icandoit.boottalk.review.dto.ReviewRequestDto;
+import com.icandoit.boottalk.review.dto.ReviewCreateRequestDto;
+import com.icandoit.boottalk.review.dto.ReviewUpdateRequestDto;
 import com.icandoit.boottalk.user.domain.entity.User;
 
 import jakarta.persistence.Column;
@@ -46,7 +47,7 @@ public class Review extends BaseEntity {
 	@Column(nullable = false)
 	private int rating;
 
-	public static Review of(ReviewRequestDto dto, Course course, User user) {
+	public static Review of(ReviewCreateRequestDto dto, Course course, User user) {
 		return Review.builder()
 			.course(course)
 			.user(user)
@@ -55,7 +56,7 @@ public class Review extends BaseEntity {
 			.build();
 	}
 
-	public void update(ReviewRequestDto dto) {
+	public void update(ReviewUpdateRequestDto dto) {
 		this.content = dto.content();
 		this.rating = dto.rating();
 	}

--- a/boottalk/src/main/java/com/icandoit/boottalk/review/repository/ReviewRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/review/repository/ReviewRepository.java
@@ -1,11 +1,19 @@
 package com.icandoit.boottalk.review.repository;
 
-import com.icandoit.boottalk.review.entity.Review;
 import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.icandoit.boottalk.bootcamp.entity.Course;
+import com.icandoit.boottalk.review.entity.Review;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 	List<Review> findByUser_UserId(Long userId);
 
 	boolean existsByCourse_TrainingProgramIdAndUser_UserId(String trainingProgramId, Long userId);
+
+	// 해당 Course 에 속한 리뷰들을 페이징 처리하여 반환
+	Page<Review> findByCourse(Course course, Pageable pageable);
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/review/service/ReviewService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/review/service/ReviewService.java
@@ -1,5 +1,6 @@
 package com.icandoit.boottalk.review.service;
 
+import com.icandoit.boottalk.bootcamp.entity.Bootcamp;
 import com.icandoit.boottalk.bootcamp.repository.CourseRepository;
 import com.icandoit.boottalk.libs.exception.CustomException;
 import com.icandoit.boottalk.libs.exception.ErrorCode;
@@ -13,6 +14,9 @@ import com.icandoit.boottalk.user.domain.repository.UserRepository;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -87,6 +91,15 @@ public class ReviewService {
 
 	}
 
+	// 부트캠프 ID 로부터 Course 를 조회한 후, 해당 Course 에 작성된 리뷰를 페이징 처리하여 반환
+	@Transactional(readOnly = true)
+	public Page<ReviewResponseDto> getReviewsBootcampId(Long bootcampId, Pageable pageable) {
+		Bootcamp bootcamp = getBootcamp(bootcampId);
+
+		return reviewRepository.findByCourse(bootcamp.getCourse(), pageable)
+			.map(ReviewResponseDto::from);
+	}
+
 	private Review getReview(Long id) {
 		return reviewRepository.findById(id).
 			orElseThrow(() -> new CustomException(ErrorCode.REVIEW_NOT_FOUND));
@@ -108,6 +121,11 @@ public class ReviewService {
 		if (courseRepository.findByTrainingProgramId(trainingProgramId).isEmpty()) {
 			throw new CustomException(ErrorCode.BOOTCAMP_NOT_FOUND);
 		}
+	}
+
+	private Bootcamp getBootcamp(Long id) {
+		return bootcampRepository.findById(id)
+			.orElseThrow(() -> new CustomException(ErrorCode.BOOTCAMP_NOT_FOUND));
 	}
 
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/review/service/ReviewService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/review/service/ReviewService.java
@@ -31,6 +31,7 @@ public class ReviewService {
 
 	@Transactional
 	public ReviewResponseDto create(ReviewRequestDto request, Long userId) {
+		// TODO : 리뷰 작성시 해당 코스에 평점 반영하는 로직 필요
 		String trainingProgramId = request.trainingProgramId();
 
 		validateCreateReview(trainingProgramId, userId);
@@ -69,6 +70,7 @@ public class ReviewService {
 	
 	@Transactional
 	public ReviewResponseDto update(ReviewRequestDto request, Long reviewId, Long userId) {
+		// TODO : 리뷰 수정시 해당 코스의 평점 업데이트 하는 로직 추가
 		Review review = getReview(reviewId);
 
 		validateCourse(review.getCourse().getTrainingProgramId());
@@ -81,7 +83,7 @@ public class ReviewService {
 
 	@Transactional
 	public void delete(Long reviewId, Long userId) {
-
+		// TODO : 리뷰 삭제시 해당 코스의 평점 업데이트하는 로직 추가
 		Review review = getReview(reviewId);
 		validateCourse(review.getCourse().getTrainingProgramId());
 		validateReview(review.getUser().getUserId(), userId);

--- a/boottalk/src/main/java/com/icandoit/boottalk/review/service/ReviewService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/review/service/ReviewService.java
@@ -4,8 +4,9 @@ import com.icandoit.boottalk.bootcamp.entity.Bootcamp;
 import com.icandoit.boottalk.bootcamp.repository.CourseRepository;
 import com.icandoit.boottalk.libs.exception.CustomException;
 import com.icandoit.boottalk.libs.exception.ErrorCode;
-import com.icandoit.boottalk.review.dto.ReviewRequestDto;
+import com.icandoit.boottalk.review.dto.ReviewCreateRequestDto;
 import com.icandoit.boottalk.review.dto.ReviewResponseDto;
+import com.icandoit.boottalk.review.dto.ReviewUpdateRequestDto;
 import com.icandoit.boottalk.review.entity.Review;
 import com.icandoit.boottalk.review.repository.ReviewRepository;
 import com.icandoit.boottalk.bootcamp.repository.BootcampRepository;
@@ -30,7 +31,7 @@ public class ReviewService {
 	private final CourseRepository courseRepository;
 
 	@Transactional
-	public ReviewResponseDto create(ReviewRequestDto request, Long userId) {
+	public ReviewResponseDto create(ReviewCreateRequestDto request, Long userId) {
 		// TODO : 리뷰 작성시 해당 코스에 평점 반영하는 로직 필요
 		String trainingProgramId = request.trainingProgramId();
 
@@ -69,7 +70,7 @@ public class ReviewService {
 	}
 	
 	@Transactional
-	public ReviewResponseDto update(ReviewRequestDto request, Long reviewId, Long userId) {
+	public ReviewResponseDto update(ReviewUpdateRequestDto request, Long reviewId, Long userId) {
 		// TODO : 리뷰 수정시 해당 코스의 평점 업데이트 하는 로직 추가
 		Review review = getReview(reviewId);
 

--- a/boottalk/src/test/java/com/icandoit/boottalk/review/service/ReviewServiceTest.java
+++ b/boottalk/src/test/java/com/icandoit/boottalk/review/service/ReviewServiceTest.java
@@ -1,0 +1,99 @@
+package com.icandoit.boottalk.review.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import com.icandoit.boottalk.bootcamp.entity.Bootcamp;
+import com.icandoit.boottalk.bootcamp.entity.Course;
+import com.icandoit.boottalk.bootcamp.entity.TrainingCenter;
+import com.icandoit.boottalk.bootcamp.repository.BootcampRepository;
+import com.icandoit.boottalk.bootcamp.repository.CourseRepository;
+import com.icandoit.boottalk.review.dto.ReviewResponseDto;
+import com.icandoit.boottalk.review.entity.Review;
+import com.icandoit.boottalk.review.repository.ReviewRepository;
+import com.icandoit.boottalk.user.domain.entity.User;
+import com.icandoit.boottalk.user.domain.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewServiceTest {
+
+	@InjectMocks
+	private ReviewService reviewService;
+
+	@Mock
+	private BootcampRepository bootcampRepository;
+
+	@Mock
+	private CourseRepository courseRepository;
+
+	@Mock
+	private ReviewRepository reviewRepository;
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Test
+	@DisplayName("부트캠프 ID로 해당 코스의 리뷰 리스트를 페이징으로 조회 성공")
+	void getReviewsBootcampId_Success() {
+	    //given
+		Long bootcampId = 1L;
+		Pageable pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
+
+		TrainingCenter trainingCenter = TrainingCenter.of("센터", "email", "주소", "url", "010-1234");
+		Course course = Course.of("TPID-123", "코스 이름", trainingCenter);
+
+		User user = User.builder()
+			.userId(1L)
+			.userName("홍길동")
+			.build();
+
+		Bootcamp bootcamp = Bootcamp.builder()
+			.bootcampId(bootcampId)
+			.course(course)
+			.build();
+
+		Review review = Review.builder()
+			.reviewId(1L)
+			.course(course)
+			.user(user)
+			.content("좋아요")
+			.rating(5)
+			.build();
+
+		Page<Review> reviewPage = new PageImpl<>(List.of(review));
+
+		given(bootcampRepository.findById(bootcampId)).willReturn(Optional.of(bootcamp));
+		given(reviewRepository.findByCourse(course, pageable)).willReturn(reviewPage);
+
+	    //when
+		Page<ReviewResponseDto> result = reviewService.getReviewsBootcampId(bootcampId, pageable);
+
+	    //then
+		ReviewResponseDto dto = result.getContent().get(0);
+
+		assertEquals(1, result.getTotalElements());
+		assertEquals(review.getReviewId(), dto.reviewId());
+		assertEquals(course.getTrainingProgramId(), dto.trainingProgramId());
+		assertEquals(course.getCourseName(), dto.courseName());
+		assertEquals(user.getUserName(), dto.userName());
+		assertEquals(review.getContent(), dto.content());
+		assertEquals(review.getRating(), dto.rating());
+	}
+
+}


### PR DESCRIPTION
### 변경사항

ISSUE : #33 
**AS-IS**
- 부트캠프(bootcampId) 기준으로만 리뷰 조회가 가능했음.
- 동일한 훈련과정(trainingProgramId)이더라도 기수가 다르면 리뷰를 통합해서 조회할 수 없었음.

**TO-BE**
- Bootcamp → Course → Review 연관관계를 활용하여, 주어진 bootcampId에 속한 Course 기준으로 전체 리뷰 조회 가능.
    - 즉, 기수(bootcampDegree)가 다르더라도 동일한 과정의 리뷰를 통합 조회.
- ReviewRepository에 findByCourse(Course course, Pageable pageable) 메서드 추가
- ReviewService에 getReviewsBootcampId(Long bootcampId, Pageable pageable) 구현
- BootcampController에 /bootcamps/{bootcampId}/reviews GET API 추가
- 응답은 Page<ReviewResponseDto> 형태로 최신순(createdAt DESC) 정렬되어 반환됨

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] ReviewServiceTest: 부트캠프 ID로 리뷰 페이징 조회 테스트 작성 완료
- [x]  Postman으로 /api/bootcamps/{bootcampId}/reviews 정상 응답 확인 (200 OK)
- [x]  예외 케이스: 존재하지 않는 부트캠프 ID로 요청 시 404 응답
