### PR TITLE
Feat/review 등록, 수정, 삭제 시 Course의 총 평점 리뷰 수를 실시간으로 갱신

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/entity/Course.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/entity/Course.java
@@ -42,7 +42,6 @@ public class Course extends BaseEntity {
 	private int totalScore;
 	private int reviewCount;
 
-	// TODO : 리뷰가 추가될 때 해당 필드 관리 예정
 	public void updateReviewStats(int totalScore, int reviewCount) {
 		this.totalScore = totalScore;
 		this.reviewCount = reviewCount;

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/repository/CourseRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/repository/CourseRepository.java
@@ -3,10 +3,19 @@ package com.icandoit.boottalk.bootcamp.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 import com.icandoit.boottalk.bootcamp.entity.Course;
+
+import jakarta.persistence.LockModeType;
 
 public interface CourseRepository extends JpaRepository<Course, Long> {
 	// trainingProgramId(훈련과정 ID)를 기준으로 Course 조회.
 	Optional<Course> findByTrainingProgramId(String trainingProgramId);
+
+	// 비관적 락을 사용한 조회
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("SELECT c From Course c WHERE c.trainingProgramId = :trainingProgramId")
+	Optional<Course> findWithLockByTrainingProgramId(String trainingProgramId);
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/common/dto/PagedResponseDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/common/dto/PagedResponseDto.java
@@ -1,0 +1,14 @@
+package com.icandoit.boottalk.common.dto;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+public record PagedResponseDto<T>(
+	List<T> data,
+	PaginationDto pagination
+) {
+	public static <T> PagedResponseDto<T> from(Page<T> page) {
+		return new PagedResponseDto<>(page.getContent(), PaginationDto.from(page));
+	}
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/common/dto/PaginationDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/common/dto/PaginationDto.java
@@ -1,0 +1,23 @@
+package com.icandoit.boottalk.common.dto;
+
+import org.springframework.data.domain.Page;
+
+public record PaginationDto(
+	int currentPage,
+	int limit,
+	long totalItems,
+	int totalPages,
+	boolean hasNext,
+	boolean hasPrevious
+) {
+	public static PaginationDto from(Page<?> page) {
+		return new PaginationDto(
+			page.getNumber() + 1, // 페이지 번호는 0부터 시작하므로 +1
+			page.getSize(),
+			page.getTotalElements(),
+			page.getTotalPages(),
+			page.hasNext(),
+			page.hasPrevious()
+		);
+	}
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/libs/exception/ErrorCode.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/libs/exception/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     COFFEE_CHAT_NOT_FOUND(404,"커피챗을 찾을 수 없습니다."),
     USER_COFFEE_CHAT_NOT_FOUND(404,"유저의 해당하는 커피챗을 찾을 수 없습니다."),
     COFFEE_CHAT_APPLICATION_NOT_FOUND(404,"커피챗 신청 내역을 찾을 수 없습니다."),
+    COURSE_NOT_FOUND(404, "코스를 찾을 수 없습니다."),
 
     /* 409 CONFLICT */
     DUPLICATE_REVIEW(409,"해당 부트캠프에 이미 리뷰를 작성하였습니다."),

--- a/boottalk/src/main/java/com/icandoit/boottalk/review/service/ReviewService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/review/service/ReviewService.java
@@ -1,6 +1,7 @@
 package com.icandoit.boottalk.review.service;
 
 import com.icandoit.boottalk.bootcamp.entity.Bootcamp;
+import com.icandoit.boottalk.bootcamp.entity.Course;
 import com.icandoit.boottalk.bootcamp.repository.CourseRepository;
 import com.icandoit.boottalk.libs.exception.CustomException;
 import com.icandoit.boottalk.libs.exception.ErrorCode;
@@ -10,6 +11,7 @@ import com.icandoit.boottalk.review.dto.ReviewUpdateRequestDto;
 import com.icandoit.boottalk.review.entity.Review;
 import com.icandoit.boottalk.review.repository.ReviewRepository;
 import com.icandoit.boottalk.bootcamp.repository.BootcampRepository;
+import com.icandoit.boottalk.user.domain.entity.User;
 import com.icandoit.boottalk.user.domain.repository.UserRepository;
 
 import java.util.List;
@@ -32,17 +34,20 @@ public class ReviewService {
 
 	@Transactional
 	public ReviewResponseDto create(ReviewCreateRequestDto request, Long userId) {
-		// TODO : 리뷰 작성시 해당 코스에 평점 반영하는 로직 필요
 		String trainingProgramId = request.trainingProgramId();
 
 		validateCreateReview(trainingProgramId, userId);
-		validateCourse(trainingProgramId);
 
-		Review review = Review.of(
-			request,
-			courseRepository.findByTrainingProgramId(trainingProgramId).get(),
-			userRepository.findById(userId).get()
-		);
+		// 비관적 락으로 course 를 조회
+		Course course = getCourseWithLock(trainingProgramId);
+
+		User user = userRepository.getReferenceById(userId);
+
+		Review review = Review.of(request, course, user);
+
+		// course 점수 업데이트
+		updateCourseReviewStats(course, request.rating(), 1);
+
 		reviewRepository.save(review);
 
 		// TODO: 포인트 적립 추가
@@ -71,11 +76,16 @@ public class ReviewService {
 	
 	@Transactional
 	public ReviewResponseDto update(ReviewUpdateRequestDto request, Long reviewId, Long userId) {
-		// TODO : 리뷰 수정시 해당 코스의 평점 업데이트 하는 로직 추가
+
 		Review review = getReview(reviewId);
 
-		validateCourse(review.getCourse().getTrainingProgramId());
 		validateReview(review.getUser().getUserId(), userId);
+
+		// 비관적 락으로 코드 조회
+		Course course = getCourseWithLock(review.getCourse().getTrainingProgramId());
+
+		// 기존 평점 제거 후 새 평점 반영
+		updateCourseReviewStats(course, request.rating() - review.getRating(), 0);
 
 		review.update(request);
 
@@ -84,10 +94,13 @@ public class ReviewService {
 
 	@Transactional
 	public void delete(Long reviewId, Long userId) {
-		// TODO : 리뷰 삭제시 해당 코스의 평점 업데이트하는 로직 추가
 		Review review = getReview(reviewId);
-		validateCourse(review.getCourse().getTrainingProgramId());
+
 		validateReview(review.getUser().getUserId(), userId);
+
+		Course course = getCourseWithLock(review.getCourse().getTrainingProgramId());
+
+		updateCourseReviewStats(course, -review.getRating(), -1);
 
 		// TODO: 리뷰를 삭제하면 이미 리뷰 작성으로 적립받은 포인트는 어떻게 되는 것인지?
 		reviewRepository.delete(review);
@@ -122,13 +135,26 @@ public class ReviewService {
 
 	private void validateCourse(String trainingProgramId) {
 		if (courseRepository.findByTrainingProgramId(trainingProgramId).isEmpty()) {
-			throw new CustomException(ErrorCode.BOOTCAMP_NOT_FOUND);
+			throw new CustomException(ErrorCode.COURSE_NOT_FOUND);
 		}
 	}
 
 	private Bootcamp getBootcamp(Long id) {
 		return bootcampRepository.findById(id)
 			.orElseThrow(() -> new CustomException(ErrorCode.BOOTCAMP_NOT_FOUND));
+	}
+
+	// 비관적 락을 사용해 course 조회
+	private Course getCourseWithLock(String trainingProgramId) {
+		return courseRepository.findWithLockByTrainingProgramId(trainingProgramId)
+			.orElseThrow(() -> new CustomException(ErrorCode.COURSE_NOT_FOUND));
+	}
+
+	// 리뷰 평점값을 course 에 업데이트
+	private void updateCourseReviewStats(Course course, int deltaScore, int deltaCount) {
+		int newTotalScore = course.getTotalScore() + deltaScore;
+		int newReviewCount = course.getReviewCount() + deltaCount;
+		course.updateReviewStats(newTotalScore, newReviewCount);
 	}
 
 }

--- a/boottalk/src/test/java/com/icandoit/boottalk/review/service/ReviewConcurrencyTest.java
+++ b/boottalk/src/test/java/com/icandoit/boottalk/review/service/ReviewConcurrencyTest.java
@@ -43,7 +43,6 @@ public class ReviewConcurrencyTest {
 	private final String trainingProgramId = "CONCURRENT-TPID";
 	private Long userId = 999L;
 
-	// 💡 저장된 엔티티 ID 추적
 	private Long trainingCenterId;
 	private Long courseId;
 

--- a/boottalk/src/test/java/com/icandoit/boottalk/review/service/ReviewConcurrencyTest.java
+++ b/boottalk/src/test/java/com/icandoit/boottalk/review/service/ReviewConcurrencyTest.java
@@ -1,0 +1,122 @@
+package com.icandoit.boottalk.review.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.icandoit.boottalk.bootcamp.entity.BootcampCategoryType;
+import com.icandoit.boottalk.bootcamp.entity.Course;
+import com.icandoit.boottalk.bootcamp.entity.TrainingCenter;
+import com.icandoit.boottalk.bootcamp.repository.CourseRepository;
+import com.icandoit.boottalk.bootcamp.repository.TrainingCenterRepository;
+import com.icandoit.boottalk.review.dto.ReviewCreateRequestDto;
+import com.icandoit.boottalk.review.repository.ReviewRepository;
+import com.icandoit.boottalk.user.domain.entity.User;
+import com.icandoit.boottalk.user.domain.repository.UserRepository;
+
+@SpringBootTest
+public class ReviewConcurrencyTest {
+
+	@Autowired
+	private ReviewService reviewService;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private CourseRepository courseRepository;
+
+	@Autowired
+	private ReviewRepository reviewRepository;
+
+	@Autowired
+	private TrainingCenterRepository trainingCenterRepository;
+
+	private final String trainingProgramId = "CONCURRENT-TPID";
+	private Long userId = 999L;
+
+	// 💡 저장된 엔티티 ID 추적
+	private Long trainingCenterId;
+	private Long courseId;
+
+	@BeforeEach
+	void setUp() {
+		// 기존 유저 먼저 삭제 (테스트용이라면 깔끔하게 시작)
+		userRepository.findById(userId).ifPresent(userRepository::delete);
+
+		User user = User.builder()
+			.userName("동시성유저")
+			.desiredCareer(BootcampCategoryType.AI_SERVICE_IMPLEMENTATION)
+			.email("testEmail")
+			.resourceUserId("test")
+			.build();
+		user = userRepository.save(user);
+		userId = user.getUserId();
+
+		TrainingCenter center = trainingCenterRepository.save(
+			TrainingCenter.of("센터", "email", "주소", "url", "010-1234")
+		);
+		this.trainingCenterId = center.getTrainingCenterId();
+
+		Course course = courseRepository.save(
+			Course.of(trainingProgramId, "동시성 테스트 코스", center)
+		);
+		this.courseId = course.getCourseId();
+	}
+
+
+	@AfterEach
+	void tearDown() {
+		// 1. 리뷰 먼저 삭제
+		reviewRepository.deleteAll();
+
+		// 2. 코스 삭제
+		courseRepository.deleteById(courseId);
+
+		// 3. 센터 삭제
+		trainingCenterRepository.deleteById(trainingCenterId);
+
+		// 4. 유저 삭제
+		userRepository.deleteById(userId);
+	}
+
+	@Test
+	void testConcurrentReviewCreate() throws InterruptedException {
+		int threadCount = 10;
+		ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+		CountDownLatch latch = new CountDownLatch(threadCount);
+
+		for (int i = 0; i < threadCount; i++) {
+			final int rating = 5;
+			executor.submit(() -> {
+				try {
+					reviewService.create(
+						new ReviewCreateRequestDto(trainingProgramId, "좋아요", rating),
+						userId
+					);
+				} catch (Exception e) {
+					System.out.println("예외 발생: " + e.getMessage());
+				} finally {
+					latch.countDown();
+				}
+			});
+		}
+
+		latch.await();
+
+		Course course = courseRepository.findById(courseId).orElseThrow();
+		System.out.println("총 점수: " + course.getTotalScore());
+		System.out.println("리뷰 수: " + course.getReviewCount());
+
+		assertEquals(5 * threadCount, course.getTotalScore());
+		assertEquals(threadCount, course.getReviewCount());
+	}
+}

--- a/boottalk/src/test/java/com/icandoit/boottalk/review/service/ReviewServiceTest.java
+++ b/boottalk/src/test/java/com/icandoit/boottalk/review/service/ReviewServiceTest.java
@@ -2,17 +2,16 @@ package com.icandoit.boottalk.review.service;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
-import static org.mockito.Mockito.*;
 
 import java.util.List;
 import java.util.Optional;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.MockitoAnnotations;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -24,13 +23,14 @@ import com.icandoit.boottalk.bootcamp.entity.Course;
 import com.icandoit.boottalk.bootcamp.entity.TrainingCenter;
 import com.icandoit.boottalk.bootcamp.repository.BootcampRepository;
 import com.icandoit.boottalk.bootcamp.repository.CourseRepository;
+import com.icandoit.boottalk.review.dto.ReviewCreateRequestDto;
 import com.icandoit.boottalk.review.dto.ReviewResponseDto;
+import com.icandoit.boottalk.review.dto.ReviewUpdateRequestDto;
 import com.icandoit.boottalk.review.entity.Review;
 import com.icandoit.boottalk.review.repository.ReviewRepository;
 import com.icandoit.boottalk.user.domain.entity.User;
 import com.icandoit.boottalk.user.domain.repository.UserRepository;
 
-@ExtendWith(MockitoExtension.class)
 class ReviewServiceTest {
 
 	@InjectMocks
@@ -47,6 +47,11 @@ class ReviewServiceTest {
 
 	@Mock
 	private UserRepository userRepository;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+	}
 
 	@Test
 	@DisplayName("부트캠프 ID로 해당 코스의 리뷰 리스트를 페이징으로 조회 성공")
@@ -96,4 +101,77 @@ class ReviewServiceTest {
 		assertEquals(review.getRating(), dto.rating());
 	}
 
+	@Test
+	@DisplayName("리뷰 생성 시 Course 평점 및 리뷰 수 증가 확인")
+	void createReviewUpdatesCourseStats() {
+		//given
+		String trainingProgramId = "TPID-123";
+		Long userId = 1L;
+
+		Course course = Course.of(trainingProgramId, "TestCourse", null);
+		User user = User.builder().userId(userId).userName("testUser").build();
+
+		ReviewCreateRequestDto request = new ReviewCreateRequestDto(trainingProgramId, "this is review", 3);
+
+		when(courseRepository.findWithLockByTrainingProgramId(trainingProgramId)).thenReturn(Optional.of(course));
+		when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+		//when
+		reviewService.create(request, userId);
+
+		//then
+		assertEquals(3, course.getTotalScore());
+		assertEquals(1, course.getReviewCount());
+	}
+
+	@Test
+	@DisplayName("리뷰 수정 시 Course 평점 반영 확인")
+	void updateReviewUpdatesCourseStats() {
+		String trainingProgramId = "TP123";
+		Long userId = 1L;
+
+		Course course = Course.of(trainingProgramId, "TestCourse", null);
+		course.updateReviewStats(4, 1); // 기존 평점 4점 1개
+
+		User user = User.builder().userId(userId).userName("testUser").build();
+		Review review = Review.builder()
+			.reviewId(1L)
+			.user(user)
+			.course(course)
+			.rating(4)
+			.content("this is review")
+			.build();
+
+		ReviewUpdateRequestDto request = new ReviewUpdateRequestDto("Updated", 5);
+
+		when(reviewRepository.findById(1L)).thenReturn(Optional.of(review));
+		when(courseRepository.findWithLockByTrainingProgramId(trainingProgramId)).thenReturn(Optional.of(course));
+
+		reviewService.update(request, 1L, userId);
+
+		assertEquals(5, course.getTotalScore());
+		assertEquals(1, course.getReviewCount());
+	}
+
+	@Test
+	@DisplayName("리뷰 삭제 시 Course 평점 및 리뷰 수 감소 확인")
+	void deleteReviewUpdatesCourseStats() {
+		String trainingProgramId = "TP123";
+		Long userId = 1L;
+
+		Course course = Course.of(trainingProgramId, "TestCourse", null);
+		course.updateReviewStats(4, 1); // 평점 4점 1개
+
+		User user = User.builder().userId(userId).userName("testUser").build();
+		Review review = Review.builder().reviewId(1L).user(user).course(course).rating(4).build();
+
+		when(reviewRepository.findById(1L)).thenReturn(Optional.of(review));
+		when(courseRepository.findWithLockByTrainingProgramId(trainingProgramId)).thenReturn(Optional.of(course));
+
+		reviewService.delete(1L, userId);
+
+		assertEquals(0, course.getTotalScore());
+		assertEquals(0, course.getReviewCount());
+		verify(reviewRepository).delete(review);
+	}
 }


### PR DESCRIPTION
### 변경사항

ISSUE : #35 

**AS-IS**
- 리뷰 작성/수정/삭제 시 Course 엔티티의 평점 통계(totalScore, reviewCount)가 갱신되지 않음
- 사용자에게 평균 평점 제공 불가능

**TO-BE**
- 리뷰 등록/수정/삭제 시 Course의 총 평점, 리뷰 수를 실시간으로 갱신
- 추후 평균 평점 계산이 가능하도록 구조 마련 (averageScore = totalScore / reviewCount)
- Course 엔티티에 평점 관련 메서드 추가:
    - addReview(int score)
    - updateReview(int oldScore, int newScore)
    - removeReview(int score)
- ReviewService에 위 기능 반영:
    - 리뷰 작성 시 → addReview(score)
    - 리뷰 수정 시 → updateReview(oldScore, newScore)
    - 리뷰 삭제 시 → removeReview(score)
- 비관적 락(PESSIMISTIC_WRITE) 적용 → 동시성 문제 방지

### 테스트
- [x]  테스트 코드: ReviewConcurrencyTest로 동시성 테스트 및 평점 통계 일치 여부 검증
- [x]  단위 테스트: ReviewServiceTest에서 각각의 리뷰 액션이 통계에 미치는 영향 검증
- [ ] API 테스트 
