### PR TITLE
feat: Swagger 로 API 문서 자동화

### DIFF
--- a/boottalk/build.gradle
+++ b/boottalk/build.gradle
@@ -34,6 +34,9 @@ dependencies {
 	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
+	// swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
 	implementation 'org.apache.httpcomponents.client5:httpclient5:5.4.1'
 	implementation 'org.springframework.boot:spring-boot-starter-batch'
 	implementation 'org.springframework:spring-context-support'

--- a/boottalk/src/main/java/com/icandoit/boottalk/common/config/SwaggerConfig.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/common/config/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package com.icandoit.boottalk.config;
+package com.icandoit.boottalk.common.config;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;

--- a/boottalk/src/main/java/com/icandoit/boottalk/config/SwaggerConfig.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/config/SwaggerConfig.java
@@ -1,0 +1,37 @@
+package com.icandoit.boottalk.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+// http://localhost:8080/swagger-ui/index.html
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+            .addSecurityItem(new SecurityRequirement().addList("Authorization"))
+            .components(new Components()
+                // .addSecuritySchemes("Authorization",
+                //     new SecurityScheme()
+                //         .type(SecurityScheme.Type.HTTP)
+                //         .scheme("bearer")
+                //         .bearerFormat("JWT")
+                // )
+            );
+    }
+
+
+	private Info apiInfo() {
+		return new Info()
+				.title("Timate")
+				.description("Timate API Documentation")
+				.version("v1");
+	}
+
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- API 문서가 존재하지 않음  

**TO-BE**
- Swagger를 적용하여 API 문서 자동화 
- Swagger 접속 URL: `{서버 도메인}/swagger-ui/index.html` 
- 추후 Spring Security 및 JWT 적용 시 추가할 사항   (@P-Taeyoung 님 참고 부탁드려요)
  - SecurityConfig에서 Swagger 관련 URL 허용  
    - `"/v3/api-docs/**", "/swagger-ui/**"`를 `permitAll()`로 설정  
  - OpenAPI 설정에서 Authorization 헤더 추가  
    - SwaggerConfig에 주석 처리해둠 → 나중에 주석 해제하여 적용  

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 
