### PR TITLE
Feat/social login 기능 구현

### DIFF
--- a/boottalk/build.gradle
+++ b/boottalk/build.gradle
@@ -34,6 +34,13 @@ dependencies {
 	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
 	implementation 'org.apache.httpcomponents.client5:httpclient5:5.4.1'
 	implementation 'org.springframework.boot:spring-boot-starter-batch'
 	implementation 'org.springframework:spring-context-support'
@@ -43,6 +50,8 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+
 }
 
 tasks.named('test') {

--- a/boottalk/src/main/java/com/icandoit/boottalk/libs/exception/ErrorCode.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/libs/exception/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
     INSUFFICIENT_POINT(400, "잔여 포인트가 부족합니다."),
 
     /* 401 UNAUTHORIZED */
+    INVALID_TOKEN(401, "유효한 토큰이 아닙니다."),
 
     EXCEEDS_MAX_LENGTH(400,"최대 길이를 초과했습니다." ),
     /* 403 FORBIDDEN */
@@ -32,7 +33,8 @@ public enum ErrorCode {
     COFFEE_CHAT_ALREADY_EXISTS(409, "이미 생성된 커피챗이 있습니다."),
 
     /* 500 INTERNAL_SERVER_ERROR */
-    INTERNAL_SERVER_ERROR(500, "서버 오류가 발생했습니다.");
+    INTERNAL_SERVER_ERROR(500, "서버 오류가 발생했습니다."),
+    TOKEN_PARSING_ERROR(500, "토큰 파싱 과정에서 오류가 발생했습니다.");
 
     private final Integer httpStatus;
     private final String message;

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/SecurityConfiguration.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/SecurityConfiguration.java
@@ -1,0 +1,55 @@
+package com.icandoit.boottalk.social_login.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import com.icandoit.boottalk.social_login.jwt.JwtFilter;
+import com.icandoit.boottalk.social_login.oauth2.CustomClientRegistrationRepository;
+import com.icandoit.boottalk.social_login.oauth2.CustomSuccessHandler;
+import com.icandoit.boottalk.social_login.service.CustomUserService;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfiguration {
+
+	private final CustomClientRegistrationRepository customClientRegistrationRepository;
+	private final CustomSuccessHandler customSuccessHandler;
+	private final CustomUserService customUserService;
+	private final JwtFilter jwtFilter;
+
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
+		http
+			.csrf(AbstractHttpConfigurer::disable)
+			.httpBasic(AbstractHttpConfigurer::disable)
+			.formLogin(AbstractHttpConfigurer::disable)
+			// 세션 사용하지 않기 때문에
+			.sessionManagement(session -> session
+				.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.authorizeHttpRequests(auth -> auth
+				// 경로에 대한 접근 권한 설정
+				.requestMatchers("/").permitAll()
+				.anyRequest().authenticated())
+			.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+			//oauth2 로그인 설정
+			.oauth2Login(oauth2 -> oauth2
+				.userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig
+					.userService(customUserService)) // 네이버로부터 사용자 정보()를 받아올 클래스
+				.successHandler(customSuccessHandler) // 로그인 성공 시 토큰을 발급하는 클래스
+				.clientRegistrationRepository(customClientRegistrationRepository.clientRegistrationRepository())); // 부트톡 서버와 네이버 서버간 인증코드와 엑세스 토큰을 주고 받기 위한 설정이 저장된 클래스
+
+		return http.build();
+	}
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/SecurityConfiguration.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/SecurityConfiguration.java
@@ -40,7 +40,7 @@ public class SecurityConfiguration {
 				.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.authorizeHttpRequests(auth -> auth
 				// 경로에 대한 접근 권한 설정
-				.requestMatchers("/").permitAll()
+				.requestMatchers("/", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
 				.anyRequest().authenticated())
 			.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
 			//oauth2 로그인 설정

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/dto/CustomOAuth2User.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/dto/CustomOAuth2User.java
@@ -8,10 +8,8 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import lombok.AllArgsConstructor;
-import lombok.ToString;
 
 @AllArgsConstructor
-@ToString
 public class CustomOAuth2User implements OAuth2User {
 
 	private final UserAuthDto userAuthDto;
@@ -30,7 +28,7 @@ public class CustomOAuth2User implements OAuth2User {
 
 			@Override
 			public String getAuthority() {
-				return userAuthDto.getRole().name();
+				return userAuthDto.role().name();
 			}
 		});
 
@@ -40,12 +38,12 @@ public class CustomOAuth2User implements OAuth2User {
 	@Override
 	public String getName() {
 
-		return userAuthDto.getResourceUserId();
+		return userAuthDto.resourceUserId();
 	}
 
 	public Long getServiceUserId() {
 
-		return userAuthDto.getServiceUserId();
+		return userAuthDto.serviceUserId();
 	}
 
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/dto/CustomOAuth2User.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/dto/CustomOAuth2User.java
@@ -1,0 +1,51 @@
+package com.icandoit.boottalk.social_login.dto;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import lombok.AllArgsConstructor;
+import lombok.ToString;
+
+@AllArgsConstructor
+@ToString
+public class CustomOAuth2User implements OAuth2User {
+
+	private final UserAuthDto userAuthDto;
+
+	@Override
+	public Map<String, Object> getAttributes() {
+		return null;
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+
+		Collection<GrantedAuthority> authorities = new ArrayList<>();
+
+		authorities.add(new GrantedAuthority() {
+
+			@Override
+			public String getAuthority() {
+				return userAuthDto.getRole().name();
+			}
+		});
+
+		return authorities;
+	}
+
+	@Override
+	public String getName() {
+
+		return userAuthDto.getResourceUserId();
+	}
+
+	public Long getServiceUserId() {
+
+		return userAuthDto.getServiceUserId();
+	}
+
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/dto/NaverResponse.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/dto/NaverResponse.java
@@ -1,0 +1,32 @@
+package com.icandoit.boottalk.social_login.dto;
+
+import java.util.Map;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class NaverResponse{
+
+	private String provider;
+	private String providerId;
+	private String email;
+	private String name;
+	private String profileImage;
+
+	public static NaverResponse from(Map<String,Object> attributes) {
+		return NaverResponse.builder()
+			.provider("naver")
+			.providerId(attributes.get("id").toString())
+			.email(attributes.get("email").toString())
+			.name(attributes.get("name").toString())
+			.profileImage(attributes.get("profile_image").toString())
+			.build();
+	}
+
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/dto/NaverResponse.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/dto/NaverResponse.java
@@ -3,6 +3,7 @@ package com.icandoit.boottalk.social_login.dto;
 import java.util.Map;
 
 import lombok.Builder;
+import lombok.Getter;
 
 @Builder
 public record NaverResponse(
@@ -13,13 +14,13 @@ public record NaverResponse(
 	String profileImage
 ) {
 	public static NaverResponse from(Map<String,Object> attributes) {
-		return NaverResponse.builder()
-			.provider("naver")
-			.providerId(attributes.get("id").toString())
-			.email(attributes.get("email").toString())
-			.name(attributes.get("name").toString())
-			.profileImage(attributes.get("profile_image").toString())
-			.build();
+		return new NaverResponse(
+			"naver",
+			attributes.get("id").toString(),
+			attributes.get("email").toString(),
+			attributes.get("name").toString(),
+			attributes.get("profile_image").toString()
+		);
 	}
 
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/dto/NaverResponse.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/dto/NaverResponse.java
@@ -2,23 +2,16 @@ package com.icandoit.boottalk.social_login.dto;
 
 import java.util.Map;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Builder
-@Getter
-@AllArgsConstructor
-@NoArgsConstructor
-public class NaverResponse{
-
-	private String provider;
-	private String providerId;
-	private String email;
-	private String name;
-	private String profileImage;
-
+public record NaverResponse(
+	String provider,
+	String providerId,
+	String email,
+	String name,
+	String profileImage
+) {
 	public static NaverResponse from(Map<String,Object> attributes) {
 		return NaverResponse.builder()
 			.provider("naver")

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/dto/UserAuthDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/dto/UserAuthDto.java
@@ -1,0 +1,27 @@
+package com.icandoit.boottalk.social_login.dto;
+
+import com.icandoit.boottalk.user.domain.entity.User;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserAuthDto {
+
+	private Long serviceUserId;
+	private String resourceUserId;
+	private UserRole role;
+
+	public static UserAuthDto from(User user, UserRole role) {
+		return UserAuthDto.builder()
+			.serviceUserId(user.getUserId())
+			.resourceUserId(user.getResourceUserId())
+			.role(role)
+			.build();
+	}
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/dto/UserAuthDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/dto/UserAuthDto.java
@@ -7,15 +7,13 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Getter
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
-public class UserAuthDto {
 
-	private Long serviceUserId;
-	private String resourceUserId;
-	private UserRole role;
+@Builder
+public record UserAuthDto(
+	Long serviceUserId,
+	String resourceUserId,
+	UserRole role
+) {
 
 	public static UserAuthDto from(User user, UserRole role) {
 		return UserAuthDto.builder()

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/dto/UserRole.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/dto/UserRole.java
@@ -1,0 +1,5 @@
+package com.icandoit.boottalk.social_login.dto;
+
+public enum UserRole {
+	USER, ADMIN, NEW_USER
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/jwt/JwtFilter.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/jwt/JwtFilter.java
@@ -5,7 +5,6 @@ import static com.icandoit.boottalk.libs.exception.ErrorCode.*;
 import java.io.IOException;
 import java.util.stream.Collectors;
 
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -37,7 +36,15 @@ public class JwtFilter extends OncePerRequestFilter {
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
 		FilterChain filterChain) throws ServletException, IOException {
 
-		// 테스트를 위한 필터 적용 해제
+
+		String requestURI = request.getRequestURI();
+
+		if (requestURI.startsWith("/swagger-ui/")
+			|| requestURI.startsWith("/v3/api-docs"))
+		{
+			filterChain.doFilter(request, response);
+			return;
+		}
 
 
 		// 처음 로그인하고 나서 리다이렉트 된 url에서는 토큰이 헤더에 담겨져 있지 않고 쿠키에 담겨 있음.
@@ -45,11 +52,7 @@ public class JwtFilter extends OncePerRequestFilter {
 		String token = null;
 
 		// 먼저 헤더에서 토큰 확인
-		try {
-			token = tokenFromHeader(request);
-		} catch (CustomException e) {
-			log.warn(e.getMessage(), e);
-		}
+		token = tokenFromHeader(request);
 
 		// 리다이렉션 후에는 헤더에 토큰이 없기 때문에 쿠키에서 가져와 응답 헤더에 옮기고 그 후 쿠키에 있는 토큰값 삭제
 		if (token == null) {
@@ -98,7 +101,12 @@ public class JwtFilter extends OncePerRequestFilter {
 		String bearerToken = request.getHeader(TOKEN_HEADER);
 		log.info("bearer token {}", bearerToken);
 
-		if (!StringUtils.hasText(bearerToken) || !bearerToken.startsWith(TOKEN_PREFIX)) {
+		if (!StringUtils.hasText(bearerToken)) {
+			return null;
+		}
+
+		// 토큰 형식이 잘못된 경우 예외 발생
+		if (!bearerToken.startsWith(TOKEN_PREFIX)) {
 			throw new CustomException(INVALID_TOKEN);
 		}
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/jwt/JwtFilter.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/jwt/JwtFilter.java
@@ -37,7 +37,15 @@ public class JwtFilter extends OncePerRequestFilter {
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
 		FilterChain filterChain) throws ServletException, IOException {
 
-		// 테스트를 위한 필터 적용 해제
+		// swagger 접근 시 필터 적용 X
+		String requestURI = request.getRequestURI();
+
+		if (requestURI.startsWith("/swagger-ui/")
+			|| requestURI.startsWith("/v3/api-docs"))
+		{
+			filterChain.doFilter(request, response);
+			return;
+		}
 
 
 		// 처음 로그인하고 나서 리다이렉트 된 url에서는 토큰이 헤더에 담겨져 있지 않고 쿠키에 담겨 있음.
@@ -45,11 +53,7 @@ public class JwtFilter extends OncePerRequestFilter {
 		String token = null;
 
 		// 먼저 헤더에서 토큰 확인
-		try {
-			token = tokenFromHeader(request);
-		} catch (CustomException e) {
-			log.warn(e.getMessage(), e);
-		}
+		token = tokenFromHeader(request);
 
 		// 리다이렉션 후에는 헤더에 토큰이 없기 때문에 쿠키에서 가져와 응답 헤더에 옮기고 그 후 쿠키에 있는 토큰값 삭제
 		if (token == null) {
@@ -98,7 +102,12 @@ public class JwtFilter extends OncePerRequestFilter {
 		String bearerToken = request.getHeader(TOKEN_HEADER);
 		log.info("bearer token {}", bearerToken);
 
-		if (!StringUtils.hasText(bearerToken) || !bearerToken.startsWith(TOKEN_PREFIX)) {
+		if (!StringUtils.hasText(bearerToken)) {
+			return null;
+		}
+
+		// 토큰 형식이 잘못된 경우 예외 발생
+		if (!bearerToken.startsWith(TOKEN_PREFIX)) {
 			throw new CustomException(INVALID_TOKEN);
 		}
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/jwt/JwtFilter.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/jwt/JwtFilter.java
@@ -1,0 +1,107 @@
+package com.icandoit.boottalk.social_login.jwt;
+
+import static com.icandoit.boottalk.libs.exception.ErrorCode.*;
+
+import java.io.IOException;
+import java.util.stream.Collectors;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.icandoit.boottalk.libs.exception.CustomException;
+import com.icandoit.boottalk.social_login.dto.CustomOAuth2User;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtFilter extends OncePerRequestFilter {
+
+	private final JwtProvider jwtProvider;
+
+	public static final String TOKEN_HEADER = "Authorization";
+	public static final String TOKEN_PREFIX = "Bearer ";
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+
+		// 테스트를 위한 필터 적용 해제
+
+
+		// 처음 로그인하고 나서 리다이렉트 된 url에서는 토큰이 헤더에 담겨져 있지 않고 쿠키에 담겨 있음.
+
+		String token = null;
+
+		// 먼저 헤더에서 토큰 확인
+		try {
+			token = tokenFromHeader(request);
+		} catch (CustomException e) {
+			log.warn(e.getMessage(), e);
+		}
+
+		// 리다이렉션 후에는 헤더에 토큰이 없기 때문에 쿠키에서 가져와 응답 헤더에 옮기고 그 후 쿠키에 있는 토큰값 삭제
+		if (token == null) {
+			Cookie[] cookies = request.getCookies();
+
+			if (cookies != null) {
+				for (Cookie cookie : cookies) {
+					if (cookie.getName().equals(TOKEN_HEADER)) {
+						token = cookie.getValue();
+
+						// 쿠키에서 찾은 토큰을 다음 요청부터는 헤더에서 사용할 수 있도록
+						// 응답 헤더에 토큰 추가
+						response.setHeader(TOKEN_HEADER, TOKEN_PREFIX + token);
+
+						// TODO 추후 프론트 엔드에서 헤더에 토큰 값을 담아서 요청을 보내도록 설정 시 쿠키 삭제 활성화
+						// Cookie deleteCookie = new Cookie(TOKEN_HEADER, null);
+						// deleteCookie.setMaxAge(0); // 쿠키 만료
+						// deleteCookie.setPath("/"); // 쿠키의 경로를 원래 쿠키와 동일하게 설정
+						// response.addCookie(deleteCookie);
+
+						break;
+					}
+				}
+			}
+		}
+
+		// 토큰이 아예 없는 경우
+		if (token == null) {
+			log.warn("Not Found Authorization Token");
+			filterChain.doFilter(request, response);
+			return;
+		}
+
+		// 토큰에 담겨있는 사용자 정보를 SecurityContextHolder 에 저장
+		SecurityContextHolder.getContext().setAuthentication(jwtProvider.getAuthentication(token));
+
+		//TODO 어떤 사용자 정보를 가지고 있는지 로그를 통해 확인. 추후 사용자 ID 정도만 확인할 수 있도록 변경
+		CustomOAuth2User userDetails =  (CustomOAuth2User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+		log.info("token info : {}, {}, {}", userDetails.getName(), userDetails.getAuthorities().stream().map(
+			GrantedAuthority::getAuthority).collect(Collectors.toList()), userDetails.getServiceUserId());
+
+		filterChain.doFilter(request, response);
+	}
+
+	private String tokenFromHeader(HttpServletRequest request) {
+		String bearerToken = request.getHeader(TOKEN_HEADER);
+		log.info("bearer token {}", bearerToken);
+
+		if (!StringUtils.hasText(bearerToken) || !bearerToken.startsWith(TOKEN_PREFIX)) {
+			throw new CustomException(INVALID_TOKEN);
+		}
+
+		return bearerToken.substring(TOKEN_PREFIX.length()).trim();
+	}
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/jwt/JwtProvider.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/jwt/JwtProvider.java
@@ -1,0 +1,103 @@
+package com.icandoit.boottalk.social_login.jwt;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Objects;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Component;
+
+import com.icandoit.boottalk.libs.exception.CustomException;
+import com.icandoit.boottalk.libs.exception.ErrorCode;
+import com.icandoit.boottalk.social_login.dto.CustomOAuth2User;
+import com.icandoit.boottalk.social_login.dto.UserAuthDto;
+import com.icandoit.boottalk.social_login.dto.UserRole;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.DecodingException;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class JwtProvider {
+
+	private final SecretKey secretKey;
+
+	//토큰 유효시간
+	private static final long tokenValidTime = 1000L * 60 * 60 * 24;
+
+	public JwtProvider(@Value("${spring.jwt.secret}") String secret) {
+		secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+	}
+
+	//회원 토큰
+	//TODO 사용자 정보를 암호화하여 토큰에 저장
+	public String createToken(Long serviceUserId, String resourceUserId, String userRole) {
+
+		return Jwts.builder()
+			.claim("serviceUserId", serviceUserId.toString())
+			.claim("resourceUserId", resourceUserId)
+			.claim("role", userRole)
+			.issuedAt(new Date(System.currentTimeMillis()))
+			.expiration(new Date(System.currentTimeMillis() + tokenValidTime))
+			.signWith(secretKey)
+			.compact();
+	}
+
+
+
+
+	// 토큰 파싱 후 SecurityContextHolder 에 저장될 사용자 정보 반환
+	public Authentication getAuthentication(String token) {
+
+		OAuth2User oAuth2User = new CustomOAuth2User(getUserFromToken(token));
+
+		return new UsernamePasswordAuthenticationToken(oAuth2User, null, oAuth2User.getAuthorities());
+	}
+
+
+	//토큰 파싱과 동시에 유효 토큰 검증
+	//TODO 커스텀 에러 적용
+	private Claims parseValidateToken(String token) {
+		try {
+
+			log.info("Parsing token : {}", token);
+			return Jwts.parser()
+				.verifyWith(secretKey)
+				.build()
+				.parseSignedClaims(token)
+				.getPayload();
+
+		} catch (ExpiredJwtException e) {
+			log.error("Token expired: {}", e.getMessage());
+			return e.getClaims();
+		} catch (DecodingException e) {
+			log.error("Decoding error: {}", e.getMessage());
+			throw new RuntimeException("Invalid token format", e);
+		} catch (Exception e) {
+			log.error("Unknown error during token parsing: {}", e.getMessage());
+			throw new CustomException(ErrorCode.TOKEN_PARSING_ERROR);
+		}
+	}
+
+	private UserAuthDto getUserFromToken(String token) {
+
+		Claims claims = parseValidateToken(token);
+
+		return UserAuthDto.builder()
+			.serviceUserId(
+				Long.valueOf(Objects.requireNonNull(
+					claims.get("serviceUserId", String.class))))
+			.resourceUserId(claims.get("resourceUserId", String.class))
+			.role(UserRole.valueOf(claims.get("role", String.class)))
+			.build();
+	}
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/oauth2/CustomClientRegistrationRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/oauth2/CustomClientRegistrationRepository.java
@@ -1,0 +1,23 @@
+package com.icandoit.boottalk.social_login.oauth2;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+
+// SocialClientRegistration 정보들을 저장할 장소
+@Configuration
+public class CustomClientRegistrationRepository {
+
+	private final SocialClientRegistration socialClientRegistration;
+
+	public CustomClientRegistrationRepository(SocialClientRegistration socialClientRegistration) {
+
+		this.socialClientRegistration = socialClientRegistration;
+	}
+
+	public ClientRegistrationRepository clientRegistrationRepository() {
+
+		return new InMemoryClientRegistrationRepository(socialClientRegistration.naverClientRegistration());
+
+	}
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/oauth2/CustomSuccessHandler.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/oauth2/CustomSuccessHandler.java
@@ -1,0 +1,71 @@
+package com.icandoit.boottalk.social_login.oauth2;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import com.icandoit.boottalk.social_login.dto.CustomOAuth2User;
+import com.icandoit.boottalk.social_login.dto.UserRole;
+import com.icandoit.boottalk.social_login.jwt.JwtProvider;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+	private final JwtProvider jwtProvider;
+
+	@Override
+	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+		Authentication authentication) throws IOException, ServletException {
+
+		//CustomOAuth2UserService.loadUser 에서 반환된 사용자 정보 가져오기
+		CustomOAuth2User userDetails = (CustomOAuth2User) authentication.getPrincipal();
+		log.error("userDetails info : {}, {}, {}", userDetails.getServiceUserId(), userDetails.getName(), userDetails.getAuthorities());
+
+		//사용자 권한 가져오기
+		Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+		Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+		GrantedAuthority auth = iterator.next();
+		String role = auth.getAuthority();
+		log.info("role : {}", role);
+
+
+		//토큰 생성 후 쿠키에 담아 전달
+		response.addCookie(createCookie("Authorization"
+			, jwtProvider.createToken(userDetails.getServiceUserId(), userDetails.getName(), role)));
+
+		// 신규회원인 경우,추가정보 입력 url로 리다이렉션
+		if (UserRole.valueOf(role).equals(UserRole.NEW_USER)) {
+			response.sendRedirect("http://localhost:8080/new");
+		} else {
+			// 기존 회원의 경우, 메인페이지로 리다이렉션
+			response.sendRedirect("http://localhost:8080/");
+		}
+	}
+
+	// 쿠키 생성
+	private Cookie createCookie(String key, String value) {
+
+		Cookie cookie = new Cookie(key, value);
+		cookie.setMaxAge(60*60*60);
+		// cookie.setSecure(true); 실제 서비스 배포시에 활성화 (https 에서만 해당 쿠키가 전달되게 함)
+		cookie.setPath("/");
+		cookie.setHttpOnly(true);
+
+		return cookie;
+	}
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/oauth2/SocialClientRegistration.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/oauth2/SocialClientRegistration.java
@@ -1,0 +1,40 @@
+package com.icandoit.boottalk.social_login.oauth2;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.stereotype.Component;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+
+//
+@Component
+public class SocialClientRegistration {
+
+	@Value("${spring.security.oauth2.registration.naver.client-id}")
+	private String clientId;
+
+	@Value("${spring.security.oauth2.registration.naver.client-secret}")
+	private String clientSecret;
+
+
+	//네이버 인증 서버에서 사용자로부터 권한 승인을 받으면 그로부터 인증 코드가 발급되고
+	//해당 코드로 다시 엑세스토큰을 발급받아 네이버 api를 통해 네이버 사용자 정보를 가져올 수 있도록 함.
+	@Bean
+	public ClientRegistration naverClientRegistration() {
+
+		return ClientRegistration.withRegistrationId("naver")
+			.clientId(clientId)
+			.clientSecret(clientSecret)
+			.redirectUri("http://localhost:8080/login/oauth2/code/naver")
+			.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+			.scope("name", "email")
+			.authorizationUri("https://nid.naver.com/oauth2.0/authorize")
+			.tokenUri("https://nid.naver.com/oauth2.0/token")
+			.userInfoUri("https://openapi.naver.com/v1/nid/me")
+			.userNameAttributeName("response")
+			.build();
+	}
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/service/CustomUserService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/service/CustomUserService.java
@@ -1,0 +1,65 @@
+package com.icandoit.boottalk.social_login.service;
+
+import static com.icandoit.boottalk.social_login.dto.UserRole.*;
+
+import java.util.Map;
+
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import com.icandoit.boottalk.social_login.dto.CustomOAuth2User;
+import com.icandoit.boottalk.social_login.dto.NaverResponse;
+import com.icandoit.boottalk.social_login.dto.UserAuthDto;
+import com.icandoit.boottalk.user.domain.entity.User;
+import com.icandoit.boottalk.user.domain.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CustomUserService extends DefaultOAuth2UserService {
+
+	private final UserRepository userRepository;
+
+	// 네이버 리소스 서버로부터 받은 사용자 정보를 받아 사용자 인증 처리
+	@Override
+	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+		OAuth2User oAuth2User = super.loadUser(userRequest);
+		log.info("UserInfo from Service: {}", oAuth2User);
+
+		String registrationId = userRequest.getClientRegistration().getRegistrationId();
+
+		// 네이버의 경우 사용자 정보를 이중맵형식으로 전달받기 때문에 아래와 같이 작성
+		NaverResponse naverResponse = NaverResponse.from((Map<String, Object>) oAuth2User.getAttributes().get("response"));
+
+		// 기존 회원과 신규회원 구분할 id
+		String resourceUserId = naverResponse.getProvider() + " " + naverResponse.getProviderId();
+
+		// 삭제일자가 없는 기존회원 정보 가져오기
+		User user = userRepository.findByResourceUserIdAndDeletedAtIsNull(resourceUserId).orElse(null);
+
+		//신규회원인 경우, 회원가입(User 데이터 베이스에 저장)
+		if (user == null) {
+			return new CustomOAuth2User(UserAuthDto.from(
+				userRepository.save(User.builder()
+					.userName(naverResponse.getName())
+					.email(naverResponse.getEmail())
+					.resourceUserId(resourceUserId)
+					.build())
+				, NEW_USER
+			));
+		}
+
+		// 기존 회원인 경우 인증 성공
+		//TODO 회원 권한(관리자, 일반)을 구별할 수 있는 기능 필요
+		return new CustomOAuth2User(UserAuthDto.from(user, USER));
+	}
+
+
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/service/CustomUserService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/service/CustomUserService.java
@@ -39,7 +39,7 @@ public class CustomUserService extends DefaultOAuth2UserService {
 		NaverResponse naverResponse = NaverResponse.from((Map<String, Object>) oAuth2User.getAttributes().get("response"));
 
 		// 기존 회원과 신규회원 구분할 id
-		String resourceUserId = naverResponse.getProvider() + " " + naverResponse.getProviderId();
+		String resourceUserId = naverResponse.provider() + " " + naverResponse.providerId();
 
 		// 삭제일자가 없는 기존회원 정보 가져오기
 		User user = userRepository.findByResourceUserIdAndDeletedAtIsNull(resourceUserId).orElse(null);
@@ -48,8 +48,8 @@ public class CustomUserService extends DefaultOAuth2UserService {
 		if (user == null) {
 			return new CustomOAuth2User(UserAuthDto.from(
 				userRepository.save(User.builder()
-					.userName(naverResponse.getName())
-					.email(naverResponse.getEmail())
+					.userName(naverResponse.name())
+					.email(naverResponse.email())
 					.resourceUserId(resourceUserId)
 					.build())
 				, NEW_USER

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/dto/UserDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/dto/UserDto.java
@@ -3,22 +3,15 @@ package com.icandoit.boottalk.user.domain.dto;
 import com.icandoit.boottalk.bootcamp.entity.BootcampCategoryType;
 import com.icandoit.boottalk.user.domain.entity.User;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
 @Builder
-public class UserDto {
-
-  private String name;
-  private String email;
-  private String profileImage;
-  private BootcampCategoryType desiredCareer;
-
+public record UserDto(
+    String name,
+    String email,
+    String profileImage,
+    BootcampCategoryType desiredCareer
+) {
   public static UserDto from(User user) {
     return UserDto.builder()
         .name(user.getUserName())

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/entity/User.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/entity/User.java
@@ -42,7 +42,6 @@ public class User extends BaseEntity {
 	@Column(nullable = false)
 	private String resourceUserId;
 
-	@Column(nullable = false)
 	@Enumerated(EnumType.STRING)
 	private BootcampCategoryType desiredCareer;
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/repository/UserRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/repository/UserRepository.java
@@ -8,5 +8,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-	Optional<User> findByResourceUserId(String resourceUserId);
+
+	//해당 id를 기준으로 삭제일이 없는 유저만 반환
+	Optional<User> findByResourceUserIdAndDeletedAtIsNull(String resourceUserId);
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/service/SignUpService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/service/SignUpService.java
@@ -19,7 +19,7 @@ public class SignUpService {
   @Transactional
   public void signUp(SignUpForm form) {
 
-    User user = userRepository.findByResourceUserId(form.getResourceUserId()).orElse(null);
+    User user = userRepository.findByResourceUserIdAndDeletedAtIsNull(form.getResourceUserId()).orElse(null);
 
     // 이미 회원가입된 유저인 경우에는 예외처리
     // 회원가입되었던 유저중에서 회원탈퇴한 회원이 다시 회원가입 시도하는 경우,


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 로그인 기능이 없음에 따라 사용자 인증 인가 기능 없었음.

**TO-BE**
- 소셜 로그인을 통한 사용자 인증 인가 기능 구현
- Security oAuth2와 jwt 토큰을 이용하여 구현
  - 기능 구현을 위해 `security`, `oAuth2`, `jwt` 라이브러리 추가
- `CustomClientRegistrationRepository `, `SocialClientRegistration ` 를 통해 네이버 서버(resource server)와 부트톡 서버(client server) 와 데이터(인증코드, 엑세스 토큰, 사용자 정보)를 주고받을 수 있도록 함.
- `CustomOAuth2User `와 `UserAuthDto ` 를 통해 사용자 인증 인가 정보 저장
- `NaverResponse` 를 통해 네이버에서 받은 정보를 변환
- `CustomUserService `를 통해 소셜로그인 한 사용자를 인증 인가 처리
  - 이 떄,  ("naver") + id(네이버에서 받은 고유Id) 를 이용하여 사용자를 구분할 수 있는 id 생성 후 해당 사용자가 신규회원인지 기존회원인지 구분
  - 신규회원인 경우, 사용자 인증 정보에 UserRole.NEW_USER 저장 ->  추후 추가 정보(프로필 사진, 관심직군)를 받는 페이지로 리다이렉션될 수 있도록함.
- `CustomSuccessHandler `를 통해 로그인 후 토큰 발급,  회원 정보에 따라 설정된 경로로 리다이렉션 됨. (기존회원 -> 메인페이지), (신규회원 -> 추가 정보 입력 페이지)
-  `JwtFilter `를 통해 헤더에 담긴 토큰을 파싱, 유효한 토큰일 경우 해당 사용자 정보를 ContextHolder에 저장함으로써 사용자 인증 인가 처리
  - 로그인 후 리다이렉션 시 헤더에 토큰을 담을 수 없으므로 쿠키에 담아 전달. 그 후 쿠키에 담긴 토큰을 헤더에 옮김.
- `SecurityConfiguration ` 를 통해 위 과정이 순서에 따라 잘 돌아갈 수 있도록함. 그 외 필요한 설정들 작성(권한에 따른 접근 가능한 경로 설정, 세션 상태 설정...)

**TO-DO**
- 추후 코드 정리
- 커스텀 로그인 경로, 리다이렉션 경로 설정
- 필요 시 cors 설정 추가

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [X] API 테스트 

https://github.com/user-attachments/assets/fa08e42f-a4f3-4d6b-ba01-374e97d31fb6

