### PR TITLE
Feat/토큰 발급 테스트용 로그인, 회원가입

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/repository/UserRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/repository/UserRepository.java
@@ -1,9 +1,13 @@
 package com.icandoit.boottalk.user.domain.repository;
 
+import java.sql.Timestamp;
+import java.util.List;
 import java.util.Optional;
 
 import com.icandoit.boottalk.user.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -11,4 +15,13 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
 	//해당 id를 기준으로 삭제일이 없는 유저만 반환
 	Optional<User> findByResourceUserIdAndDeletedAtIsNull(String resourceUserId);
+
+	@Query("SELECT COUNT(u) > 0 FROM User u WHERE u.resourceUserId = :resourceUserId AND u.deletedAt >= :sixMonthsAgo")
+	boolean existsByResourceUserIdAndDeletedWithinSixMonths(
+		@Param("resourceUserId") String resourceUserId,
+		@Param("sixMonthsAgo") Timestamp time
+	);
+
+	//테스트용
+	Optional<User> findByUserName(String userName);
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/user_test/controller/UserTestController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user_test/controller/UserTestController.java
@@ -22,14 +22,13 @@ public class UserTestController {
 
 	private final UserTestService userTestService;
 	private final JwtProvider jwtProvider;
-	private final String TOKEN_PREFIX = "Bearer ";
 
 	//테스트 회원 가입
 	@PostMapping("/signup")
 	public ResponseEntity<String> signUp(@RequestBody TestSignUpForm form) {
 		CustomOAuth2User authUser = userTestService.signUp(form);
 
-		return ResponseEntity.ok(TOKEN_PREFIX +
+		return ResponseEntity.ok(
 			jwtProvider.createToken(authUser.getServiceUserId(), authUser.getName(), UserRole.USER.name()));
 	}
 
@@ -39,7 +38,7 @@ public class UserTestController {
 	public ResponseEntity<String> login(@RequestParam String username) {
 		CustomOAuth2User authUser = userTestService.login(username);
 
-		return ResponseEntity.ok(TOKEN_PREFIX +
+		return ResponseEntity.ok(
 			jwtProvider.createToken(authUser.getServiceUserId(), authUser.getName(), UserRole.USER.name()));
 
 	}

--- a/boottalk/src/main/java/com/icandoit/boottalk/user_test/controller/UserTestController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user_test/controller/UserTestController.java
@@ -1,0 +1,48 @@
+package com.icandoit.boottalk.user_test.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.icandoit.boottalk.social_login.dto.CustomOAuth2User;
+import com.icandoit.boottalk.social_login.dto.UserRole;
+import com.icandoit.boottalk.social_login.jwt.JwtProvider;
+import com.icandoit.boottalk.user_test.form.TestSignUpForm;
+import com.icandoit.boottalk.user_test.service.UserTestService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/test/users")
+public class UserTestController {
+
+	private final UserTestService userTestService;
+	private final JwtProvider jwtProvider;
+	private final String TOKEN_PREFIX = "Bearer ";
+
+	//테스트 회원 가입
+	@PostMapping("/signup")
+	public ResponseEntity<String> signUp(@RequestBody TestSignUpForm form) {
+		CustomOAuth2User authUser = userTestService.signUp(form);
+
+		return ResponseEntity.ok(TOKEN_PREFIX +
+			jwtProvider.createToken(authUser.getServiceUserId(), authUser.getName(), UserRole.USER.name()));
+	}
+
+
+	//로그인 (회원가입된 이름으로 로그인)
+	@PostMapping("/login")
+	public ResponseEntity<String> login(@RequestParam String username) {
+		CustomOAuth2User authUser = userTestService.login(username);
+
+		return ResponseEntity.ok(TOKEN_PREFIX +
+			jwtProvider.createToken(authUser.getServiceUserId(), authUser.getName(), UserRole.USER.name()));
+
+	}
+
+
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/user_test/form/TestSignUpForm.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user_test/form/TestSignUpForm.java
@@ -1,0 +1,13 @@
+package com.icandoit.boottalk.user_test.form;
+
+import com.icandoit.boottalk.bootcamp.entity.BootcampCategoryType;
+
+
+public record TestSignUpForm(
+	String userName,
+	String email,
+	String resourceUserId,
+	String profileImage,
+	BootcampCategoryType desiredCareer
+) {
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/user_test/service/UserTestService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user_test/service/UserTestService.java
@@ -1,0 +1,41 @@
+package com.icandoit.boottalk.user_test.service;
+
+import org.springframework.stereotype.Service;
+
+import com.icandoit.boottalk.libs.exception.CustomException;
+import com.icandoit.boottalk.libs.exception.ErrorCode;
+import com.icandoit.boottalk.social_login.dto.CustomOAuth2User;
+import com.icandoit.boottalk.social_login.dto.UserAuthDto;
+import com.icandoit.boottalk.social_login.dto.UserRole;
+import com.icandoit.boottalk.user.domain.entity.User;
+import com.icandoit.boottalk.user_test.form.TestSignUpForm;
+import com.icandoit.boottalk.user.domain.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class UserTestService {
+
+	private final UserRepository userRepository;
+
+	public CustomOAuth2User signUp(TestSignUpForm form) {
+		User user = userRepository.save(User.builder()
+			.userName(form.userName())
+			.email(form.email())
+			.resourceUserId(form.resourceUserId())
+			.desiredCareer(form.desiredCareer())
+			.profileImage(form.profileImage())
+			.build());
+
+		return new CustomOAuth2User(UserAuthDto.from(user, UserRole.USER));
+	}
+
+	public CustomOAuth2User login(String username) {
+		User user = userRepository.findByUserName(username).orElseThrow(
+			() -> new CustomException(ErrorCode.USER_NOT_FOUND)
+		);
+
+		return new CustomOAuth2User(UserAuthDto.from(user, UserRole.USER));
+	}
+}


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 소셜 로그인을 통해서만 토큰 발급 가능

**TO-BE**
- 테스트용 회원가입, 로그인 api 생성 
- 회원가입, 로그인하면 토큰 발급.
- 해당 토큰을 헤더에 넣어서 사용
  - 토큰 필터에서 토큰이 파싱되고 사용자 정보를 ContextHolder에 저장됨  
      - `@GetMapping public ResponseEntity<UserDto> getUser(@AuthenticationPrincipal CustomOAuth2User user)` 와 같은 식으로  저장된 사용자 정보를 불러올 수 있음. 
      -`user.getServiceUserId()`를 통해 사용자의 고유 pk Id를 불러올 수 있음.
	
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [X] API 테스트 

![image](https://github.com/user-attachments/assets/027a4d83-0ebd-4342-99cc-cdb276cd6db3)
![image](https://github.com/user-attachments/assets/6d8fe1e5-ac43-4240-a0b9-aa779fc8615f)
![image](https://github.com/user-attachments/assets/b1299a30-964a-42cd-9844-2518b3815cf0)

