### PR TITLE
Feat/coffeechat 커피챗 멘토 시간 등록 API 포맷팅 변경 및 중복 생성 방지 

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatTimeController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatTimeController.java
@@ -1,6 +1,7 @@
 package com.icandoit.boottalk.coffeeChat.controller;
 
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatTimeListDto;
+import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatTimeMapDto;
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatTimeResponseDto;
 import com.icandoit.boottalk.coffeeChat.service.CoffeeChatTimeService;
 import jakarta.validation.Valid;
@@ -23,7 +24,7 @@ public class CoffeeChatTimeController {
 
     @PostMapping("/available-times")
     public ResponseEntity<List<CoffeeChatTimeResponseDto>> createCoffeeChatTimes(
-        @RequestBody @Valid CoffeeChatTimeListDto requestDto) {
+        @RequestBody @Valid CoffeeChatTimeMapDto requestDto) {
         // todo : 사용자 인증 사용 시 수정
         Long userId = 1L;
         return ResponseEntity.ok(coffeeChatTimeService.createCoffeeChatTimes(userId, requestDto));

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/dto/CoffeeChatApplicationResponseDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/dto/CoffeeChatApplicationResponseDto.java
@@ -10,7 +10,7 @@ public record CoffeeChatApplicationResponseDto(
     Long coffeeChatInfoId,
     Long menteeUserId,
     String menteeName,
-    String mentoName,
+    String mentorName,
     StatusType status,
     String content,
     LocalDateTime coffeeChatStartTime,

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/dto/CoffeeChatTimeDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/dto/CoffeeChatTimeDto.java
@@ -6,8 +6,7 @@ import java.time.LocalTime;
 
 public record CoffeeChatTimeDto(
     @NotNull DayOfWeek dayOfWeek,
-    @NotNull LocalTime startTime,
-    @NotNull LocalTime endTime
+    @NotNull LocalTime startTime
 ) {
 
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/dto/CoffeeChatTimeMapDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/dto/CoffeeChatTimeMapDto.java
@@ -1,0 +1,9 @@
+package com.icandoit.boottalk.coffeeChat.dto;
+
+import java.util.List;
+import java.util.Map;
+
+public record CoffeeChatTimeMapDto(
+    Map<String, List<String>> availableTimes
+) {
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/dto/CoffeeChatTimeResponseDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/dto/CoffeeChatTimeResponseDto.java
@@ -2,21 +2,18 @@ package com.icandoit.boottalk.coffeeChat.dto;
 
 import com.icandoit.boottalk.coffeeChat.entity.CoffeeChatTime;
 import java.time.DayOfWeek;
-import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 
 public record CoffeeChatTimeResponseDto(
     Long coffeeChatTimeId,
     DayOfWeek dayOfWeek,
-    LocalTime startTime,
-    LocalTime endTime
+    String startTime
 ) {
-
     public static CoffeeChatTimeResponseDto from(CoffeeChatTime coffeeChatTime) {
         return new CoffeeChatTimeResponseDto(
             coffeeChatTime.getCoffeeChatTimeId(),
             coffeeChatTime.getDayOfWeek(),
-            coffeeChatTime.getStartTime(),
-            coffeeChatTime.getEndTime()
+            coffeeChatTime.getStartTime().format(DateTimeFormatter.ofPattern("HH:mm"))
         );
     }
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/entity/CoffeeChatTime.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/entity/CoffeeChatTime.java
@@ -43,20 +43,15 @@ public class CoffeeChatTime {
     @Column(nullable = false)
     private LocalTime startTime;
 
-    @Column(nullable = false)
-    private LocalTime endTime;
-
     // 생성 메서드
     public static CoffeeChatTime of(CoffeeChatInfo coffeeChatInfo, DayOfWeek dayOfWeek,
-        LocalTime startTime, LocalTime endTime) {
+        LocalTime startTime) {
         return CoffeeChatTime.builder()
             .coffeeChatInfo(coffeeChatInfo)
             .dayOfWeek(dayOfWeek)
             .startTime(startTime)
-            .endTime(endTime)
             .build();
     }
-
 
     void setCoffeeChatInfo(CoffeeChatInfo coffeeChatInfo) {
         this.coffeeChatInfo = coffeeChatInfo;

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/repository/CoffeeChatTimeRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/repository/CoffeeChatTimeRepository.java
@@ -1,5 +1,6 @@
 package com.icandoit.boottalk.coffeeChat.repository;
 
+import com.icandoit.boottalk.coffeeChat.entity.CoffeeChatInfo;
 import com.icandoit.boottalk.coffeeChat.entity.CoffeeChatTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +11,6 @@ public interface CoffeeChatTimeRepository extends JpaRepository<CoffeeChatTime, 
 
     @Query("SELECT ct FROM CoffeeChatTime ct JOIN FETCH ct.coffeeChatInfo WHERE ct.coffeeChatInfo.mentor.userId = :mentorId")
     List<CoffeeChatTime> findAllWithCoffeeChatInfoByUserId(@Param("mentorId") Long mentorId);
+
+    boolean existsByCoffeeChatInfo(CoffeeChatInfo coffeeChatInfo);
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatTimeService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatTimeService.java
@@ -2,14 +2,15 @@ package com.icandoit.boottalk.coffeeChat.service;
 
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatTimeDto;
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatTimeListDto;
+import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatTimeMapDto;
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatTimeResponseDto;
 import com.icandoit.boottalk.coffeeChat.entity.CoffeeChatInfo;
 import com.icandoit.boottalk.coffeeChat.entity.CoffeeChatTime;
 import com.icandoit.boottalk.coffeeChat.repository.CoffeeChatInfoRepository;
 import com.icandoit.boottalk.coffeeChat.repository.CoffeeChatTimeRepository;
+import com.icandoit.boottalk.coffeeChat.service.converter.CoffeeChatTimeConverter;
 import com.icandoit.boottalk.libs.exception.CustomException;
 import com.icandoit.boottalk.libs.exception.ErrorCode;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -25,31 +26,36 @@ public class CoffeeChatTimeService {
 
     @Transactional
     public List<CoffeeChatTimeResponseDto> createCoffeeChatTimes(Long userId,
-        CoffeeChatTimeListDto requestDto) {
+        CoffeeChatTimeMapDto requestDto) {
 
-        // todo: 유저조회
         CoffeeChatInfo coffeeChatInfo = coffeeChatInfoRepository.findBymentor_UserId(userId)
-            .orElseThrow(() -> new CustomException(
-                ErrorCode.USER_COFFEE_CHAT_NOT_FOUND));
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_COFFEE_CHAT_NOT_FOUND));
 
-        List<CoffeeChatTime> coffeeChatTimes = new ArrayList<>();
-        for (CoffeeChatTimeDto timeDto : requestDto.availableTimes()) {
-            CoffeeChatTime time = CoffeeChatTime.of(
-                coffeeChatInfo,
-                timeDto.dayOfWeek(),
-                timeDto.startTime(),
-                timeDto.endTime()
-            );
-            coffeeChatInfo.addAvailableTime(time);
-            coffeeChatTimes.add(time);
+        // 이미 시간이 존재한다면 예외처리
+        if (coffeeChatTimeRepository.existsByCoffeeChatInfo(coffeeChatInfo)) {
+            throw new CustomException(ErrorCode.ALREADY_CREATED_COFFEE_CHAT_TIME);
         }
 
-        coffeeChatTimeRepository.saveAll(coffeeChatTimes);
-        return coffeeChatTimes.stream()
+        // 시 : 분 파싱
+        List<CoffeeChatTimeDto> timeDtos = CoffeeChatTimeConverter.toDtoList(requestDto);
+
+        List<CoffeeChatTime> chatTimes = timeDtos.stream()
+            .map(dto -> {
+                CoffeeChatTime time = CoffeeChatTime.of(coffeeChatInfo, dto.dayOfWeek(),
+                    dto.startTime());
+                coffeeChatInfo.addAvailableTime(time);
+                return time;
+            })
+            .toList();
+
+        coffeeChatTimeRepository.saveAll(chatTimes);
+
+        return chatTimes.stream()
             .map(CoffeeChatTimeResponseDto::from)
             .toList();
     }
 
+    // 자신의 멘토 가능 시간 조회
     @Transactional(readOnly = true)
     public List<CoffeeChatTimeResponseDto> getMyCoffeeChatTimes(Long userId) {
         List<CoffeeChatTime> coffeeChatTimes = getmentorCoffeeChatTimesOrThrow(userId);
@@ -69,7 +75,7 @@ public class CoffeeChatTimeService {
         CoffeeChatInfo coffeeChatInfo = existingTimeSlots.get(0).getCoffeeChatInfo();
         List<CoffeeChatTime> newTimeSlots = requestDto.availableTimes().stream()
             .map(timeDto -> CoffeeChatTime.of(coffeeChatInfo, timeDto.dayOfWeek(),
-                timeDto.startTime(), timeDto.endTime()))
+                timeDto.startTime()))
             .toList();
 
         // 삭제할 시간 찾기 (기존 데이터 중에서 새로운 데이터에 없는 항목)

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/converter/CoffeeChatTimeConverter.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/converter/CoffeeChatTimeConverter.java
@@ -1,0 +1,40 @@
+package com.icandoit.boottalk.coffeeChat.service.converter;
+
+import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatTimeDto;
+import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatTimeMapDto;
+import com.icandoit.boottalk.libs.exception.CustomException;
+import com.icandoit.boottalk.libs.exception.ErrorCode;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class CoffeeChatTimeConverter {
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+
+    public static List<CoffeeChatTimeDto> toDtoList(CoffeeChatTimeMapDto mapDto) {
+        List<CoffeeChatTimeDto> result = new ArrayList<>();
+
+        for (Map.Entry<String, List<String>> entry : mapDto.availableTimes().entrySet()) {
+            DayOfWeek day;
+            try {
+                day = DayOfWeek.valueOf(entry.getKey());
+            } catch (IllegalArgumentException e) {
+                throw new CustomException(ErrorCode.INVALID_DAY_FORMAT);
+            }
+
+            for (String timeStr : entry.getValue()) {
+                try {
+                    LocalTime time = LocalTime.parse(timeStr, TIME_FORMATTER);
+                    result.add(new CoffeeChatTimeDto(day, time));
+                } catch (DateTimeParseException e) {
+                    throw new CustomException(ErrorCode.INVALID_TIME_FORMAT);
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/libs/exception/ErrorCode.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/libs/exception/ErrorCode.java
@@ -2,7 +2,6 @@ package com.icandoit.boottalk.libs.exception;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
@@ -12,8 +11,8 @@ public enum ErrorCode {
     INVALID_DAY_FORMAT(400, "유효하지 않은 요일 형식입니다."),
     INVALID_TIME_FORMAT(400, "유효하지 않은 시간 형식입니다."),
     INSUFFICIENT_POINT(400, "잔여 포인트가 부족합니다."),
-    EXCEEDS_MAX_LENGTH(400,"최대 길이를 초과했습니다." ),
-    COFFEE_CHAT_STATUS_NOT_PENDING (400, "대기 중 상태가 아니므로 상태를 변경할 수 없습니다."),
+    EXCEEDS_MAX_LENGTH(400, "최대 길이를 초과했습니다."),
+    COFFEE_CHAT_STATUS_NOT_PENDING(400, "대기 중 상태가 아니므로 상태를 변경할 수 없습니다."),
 
     /* 401 UNAUTHORIZED */
     INVALID_TOKEN(401, "유효한 토큰이 아닙니다."),
@@ -26,16 +25,16 @@ public enum ErrorCode {
 
     /* 404 NOT_FOUND */
     NOT_FOUND(404, "요청한 리소스를 찾을 수 없습니다."),
-    USER_NOT_FOUND(404,"유저를 찾을 수 없습니다."),
-    BOOTCAMP_NOT_FOUND(404,"부트캠프를 찾을 수 없습니다."),
-    REVIEW_NOT_FOUND(404,"리뷰를 찾을 수 없습니다."),
-    COFFEE_CHAT_NOT_FOUND(404,"커피챗을 찾을 수 없습니다."),
-    USER_COFFEE_CHAT_NOT_FOUND(404,"유저의 해당하는 커피챗을 찾을 수 없습니다."),
-    COFFEE_CHAT_APPLICATION_NOT_FOUND(404,"커피챗 신청 내역을 찾을 수 없습니다."),
+    USER_NOT_FOUND(404, "유저를 찾을 수 없습니다."),
+    BOOTCAMP_NOT_FOUND(404, "부트캠프를 찾을 수 없습니다."),
+    REVIEW_NOT_FOUND(404, "리뷰를 찾을 수 없습니다."),
+    COFFEE_CHAT_NOT_FOUND(404, "커피챗을 찾을 수 없습니다."),
+    USER_COFFEE_CHAT_NOT_FOUND(404, "유저의 해당하는 커피챗을 찾을 수 없습니다."),
+    COFFEE_CHAT_APPLICATION_NOT_FOUND(404, "커피챗 신청 내역을 찾을 수 없습니다."),
     COURSE_NOT_FOUND(404, "코스를 찾을 수 없습니다."),
 
     /* 409 CONFLICT */
-    DUPLICATE_REVIEW(409,"해당 부트캠프에 이미 리뷰를 작성하였습니다."),
+    DUPLICATE_REVIEW(409, "해당 부트캠프에 이미 리뷰를 작성하였습니다."),
     NOT_PENDING_STATUS(409, "커피챗 신청이 '대기 중' 상태일 때만 수정할 수 있습니다."),
     COFFEE_CHAT_ALREADY_EXISTS(409, "이미 생성된 커피챗이 있습니다."),
     ALREADY_CREATED_COFFEE_CHAT_TIME(409, "해당 유저의 커피챗 시간이 등록되어 있습니다."),

--- a/boottalk/src/main/java/com/icandoit/boottalk/libs/exception/ErrorCode.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/libs/exception/ErrorCode.java
@@ -2,12 +2,15 @@ package com.icandoit.boottalk.libs.exception;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
 
     /* 400 BAD_REQUEST */
+    INVALID_DAY_FORMAT(400, "유효하지 않은 요일 형식입니다."),
+    INVALID_TIME_FORMAT(400, "유효하지 않은 시간 형식입니다."),
     INSUFFICIENT_POINT(400, "잔여 포인트가 부족합니다."),
     EXCEEDS_MAX_LENGTH(400,"최대 길이를 초과했습니다." ),
     COFFEE_CHAT_STATUS_NOT_PENDING (400, "대기 중 상태가 아니므로 상태를 변경할 수 없습니다."),
@@ -34,10 +37,8 @@ public enum ErrorCode {
     /* 409 CONFLICT */
     DUPLICATE_REVIEW(409,"해당 부트캠프에 이미 리뷰를 작성하였습니다."),
     NOT_PENDING_STATUS(409, "커피챗 신청이 '대기 중' 상태일 때만 수정할 수 있습니다."),
-
-    /* 409 Conflict */
     COFFEE_CHAT_ALREADY_EXISTS(409, "이미 생성된 커피챗이 있습니다."),
-
+    ALREADY_CREATED_COFFEE_CHAT_TIME(409, "해당 유저의 커피챗 시간이 등록되어 있습니다."),
     /* 500 INTERNAL_SERVER_ERROR */
     INTERNAL_SERVER_ERROR(500, "서버 오류가 발생했습니다."),
     TOKEN_PARSING_ERROR(500, "토큰 파싱 과정에서 오류가 발생했습니다.");


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

- 기존 시간 포멧팅 : `HH:mm:ss`
- 커피챗 시간이 중복 생성 가능 
**TO-BE**

- 시간 포맷팅 : `HH:mm` 변경
- 커피챗 시간 등록 API에서, **이미 등록된 시간 데이터가 있는 경우 중복 생성을 방지**하기 위해  
`CoffeeChatTimeRepository.existsByCoffeeChatInfo()`를 활용한 중복 체크 로직을 추가했습니다. 

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 

- 커피챗 시간 등록 
![image](https://github.com/user-attachments/assets/99896112-b4bd-4977-9edb-2e2fe6201a38)

- 커피챗 중복 등록 시 예외처리 
![스크린샷 2025-04-05 012924](https://github.com/user-attachments/assets/489e9d15-7622-4a87-842c-69a51191abcb)


closes #47