### PR TITLE
Feat/update coffeechattime 커피챗 가능 시간 업데이트 방식 개선 - 성능 최적화를 위한 List → Set 기반 변경

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatTimeController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatTimeController.java
@@ -1,6 +1,7 @@
 package com.icandoit.boottalk.coffeeChat.controller;
 
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatTimeListDto;
+import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatTimeMapDto;
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatTimeResponseDto;
 import com.icandoit.boottalk.coffeeChat.service.CoffeeChatTimeService;
 import jakarta.validation.Valid;
@@ -23,7 +24,7 @@ public class CoffeeChatTimeController {
 
     @PostMapping("/available-times")
     public ResponseEntity<List<CoffeeChatTimeResponseDto>> createCoffeeChatTimes(
-        @RequestBody @Valid CoffeeChatTimeListDto requestDto) {
+        @RequestBody @Valid CoffeeChatTimeMapDto requestDto) {
         // todo : 사용자 인증 사용 시 수정
         Long userId = 1L;
         return ResponseEntity.ok(coffeeChatTimeService.createCoffeeChatTimes(userId, requestDto));

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatTimeController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatTimeController.java
@@ -1,6 +1,5 @@
 package com.icandoit.boottalk.coffeeChat.controller;
 
-import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatTimeListDto;
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatTimeMapDto;
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatTimeResponseDto;
 import com.icandoit.boottalk.coffeeChat.service.CoffeeChatTimeService;
@@ -39,7 +38,7 @@ public class CoffeeChatTimeController {
 
     @PutMapping("/my")
     public ResponseEntity<List<CoffeeChatTimeResponseDto>> updateCoffeeChatTimes(
-        @RequestBody @Valid CoffeeChatTimeListDto requestDto) {
+        @RequestBody @Valid CoffeeChatTimeMapDto requestDto) {
         Long userId = 1L;
         return ResponseEntity.ok(coffeeChatTimeService.updateCoffeeChatTimes(userId, requestDto));
     }

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/dto/CoffeeChatApplicationResponseDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/dto/CoffeeChatApplicationResponseDto.java
@@ -10,7 +10,7 @@ public record CoffeeChatApplicationResponseDto(
     Long coffeeChatInfoId,
     Long menteeUserId,
     String menteeName,
-    String mentoName,
+    String mentorName,
     StatusType status,
     String content,
     LocalDateTime coffeeChatStartTime,

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/dto/CoffeeChatTimeDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/dto/CoffeeChatTimeDto.java
@@ -6,8 +6,7 @@ import java.time.LocalTime;
 
 public record CoffeeChatTimeDto(
     @NotNull DayOfWeek dayOfWeek,
-    @NotNull LocalTime startTime,
-    @NotNull LocalTime endTime
+    @NotNull LocalTime startTime
 ) {
 
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/dto/CoffeeChatTimeListDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/dto/CoffeeChatTimeListDto.java
@@ -1,9 +1,0 @@
-package com.icandoit.boottalk.coffeeChat.dto;
-
-import jakarta.validation.constraints.NotNull;
-import java.util.List;
-
-public record CoffeeChatTimeListDto(
-    @NotNull
-    List<CoffeeChatTimeDto> availableTimes
-) {}

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/dto/CoffeeChatTimeMapDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/dto/CoffeeChatTimeMapDto.java
@@ -1,0 +1,9 @@
+package com.icandoit.boottalk.coffeeChat.dto;
+
+import java.util.List;
+import java.util.Map;
+
+public record CoffeeChatTimeMapDto(
+    Map<String, List<String>> availableTimes
+) {
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/dto/CoffeeChatTimeResponseDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/dto/CoffeeChatTimeResponseDto.java
@@ -2,21 +2,18 @@ package com.icandoit.boottalk.coffeeChat.dto;
 
 import com.icandoit.boottalk.coffeeChat.entity.CoffeeChatTime;
 import java.time.DayOfWeek;
-import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 
 public record CoffeeChatTimeResponseDto(
     Long coffeeChatTimeId,
     DayOfWeek dayOfWeek,
-    LocalTime startTime,
-    LocalTime endTime
+    String startTime
 ) {
-
     public static CoffeeChatTimeResponseDto from(CoffeeChatTime coffeeChatTime) {
         return new CoffeeChatTimeResponseDto(
             coffeeChatTime.getCoffeeChatTimeId(),
             coffeeChatTime.getDayOfWeek(),
-            coffeeChatTime.getStartTime(),
-            coffeeChatTime.getEndTime()
+            coffeeChatTime.getStartTime().format(DateTimeFormatter.ofPattern("HH:mm"))
         );
     }
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/entity/CoffeeChatInfo.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/entity/CoffeeChatInfo.java
@@ -25,6 +25,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 
 @Entity
@@ -33,6 +34,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "coffee_chat_info")
+@Slf4j
 public class CoffeeChatInfo extends BaseEntity {
 
     @Id
@@ -57,10 +59,12 @@ public class CoffeeChatInfo extends BaseEntity {
     @Column(nullable = false)
     private String introduction;
 
+    @Builder.Default
     @OneToMany(mappedBy = "coffeeChatInfo", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CoffeeChatTime> availableTimes = new ArrayList<>();
 
-    public static CoffeeChatInfo of(User mentor, String mentorName, MentorType mentorType, JobType jobType,
+    public static CoffeeChatInfo of(User mentor, String mentorName, MentorType mentorType,
+        JobType jobType,
         String introduction) {
         return CoffeeChatInfo.builder()
             .mentor(mentor)

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/entity/CoffeeChatTime.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/entity/CoffeeChatTime.java
@@ -43,20 +43,15 @@ public class CoffeeChatTime {
     @Column(nullable = false)
     private LocalTime startTime;
 
-    @Column(nullable = false)
-    private LocalTime endTime;
-
     // 생성 메서드
     public static CoffeeChatTime of(CoffeeChatInfo coffeeChatInfo, DayOfWeek dayOfWeek,
-        LocalTime startTime, LocalTime endTime) {
+        LocalTime startTime) {
         return CoffeeChatTime.builder()
             .coffeeChatInfo(coffeeChatInfo)
             .dayOfWeek(dayOfWeek)
             .startTime(startTime)
-            .endTime(endTime)
             .build();
     }
-
 
     void setCoffeeChatInfo(CoffeeChatInfo coffeeChatInfo) {
         this.coffeeChatInfo = coffeeChatInfo;

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/entity/CoffeeChatTime.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/entity/CoffeeChatTime.java
@@ -12,8 +12,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.DayOfWeek;
+import java.time.Duration;
 import java.time.LocalTime;
-import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -27,6 +27,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "coffee_chat_time")
 public class CoffeeChatTime {
+    private static final Duration DURATION = Duration.ofMinutes(30);
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -57,19 +58,8 @@ public class CoffeeChatTime {
         this.coffeeChatInfo = coffeeChatInfo;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        CoffeeChatTime that = (CoffeeChatTime) o;
-        return dayOfWeek == that.dayOfWeek &&
-            Objects.equals(startTime, that.startTime) &&
-            Objects.equals(endTime, that.endTime) &&
-            Objects.equals(coffeeChatInfo, that.coffeeChatInfo);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(coffeeChatInfo, dayOfWeek, startTime, endTime);
+    // 정책 : endTime : startTime + 30min
+    public LocalTime getEndTime() {
+        return startTime.plus(DURATION);
     }
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/repository/CoffeeChatTimeRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/repository/CoffeeChatTimeRepository.java
@@ -1,5 +1,6 @@
 package com.icandoit.boottalk.coffeeChat.repository;
 
+import com.icandoit.boottalk.coffeeChat.entity.CoffeeChatInfo;
 import com.icandoit.boottalk.coffeeChat.entity.CoffeeChatTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +11,6 @@ public interface CoffeeChatTimeRepository extends JpaRepository<CoffeeChatTime, 
 
     @Query("SELECT ct FROM CoffeeChatTime ct JOIN FETCH ct.coffeeChatInfo WHERE ct.coffeeChatInfo.mentor.userId = :mentorId")
     List<CoffeeChatTime> findAllWithCoffeeChatInfoByUserId(@Param("mentorId") Long mentorId);
+
+    boolean existsByCoffeeChatInfo(CoffeeChatInfo coffeeChatInfo);
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatTimeService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatTimeService.java
@@ -2,14 +2,15 @@ package com.icandoit.boottalk.coffeeChat.service;
 
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatTimeDto;
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatTimeListDto;
+import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatTimeMapDto;
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatTimeResponseDto;
 import com.icandoit.boottalk.coffeeChat.entity.CoffeeChatInfo;
 import com.icandoit.boottalk.coffeeChat.entity.CoffeeChatTime;
 import com.icandoit.boottalk.coffeeChat.repository.CoffeeChatInfoRepository;
 import com.icandoit.boottalk.coffeeChat.repository.CoffeeChatTimeRepository;
+import com.icandoit.boottalk.coffeeChat.service.converter.CoffeeChatTimeConverter;
 import com.icandoit.boottalk.libs.exception.CustomException;
 import com.icandoit.boottalk.libs.exception.ErrorCode;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -25,31 +26,36 @@ public class CoffeeChatTimeService {
 
     @Transactional
     public List<CoffeeChatTimeResponseDto> createCoffeeChatTimes(Long userId,
-        CoffeeChatTimeListDto requestDto) {
+        CoffeeChatTimeMapDto requestDto) {
 
-        // todo: 유저조회
         CoffeeChatInfo coffeeChatInfo = coffeeChatInfoRepository.findBymentor_UserId(userId)
-            .orElseThrow(() -> new CustomException(
-                ErrorCode.USER_COFFEE_CHAT_NOT_FOUND));
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_COFFEE_CHAT_NOT_FOUND));
 
-        List<CoffeeChatTime> coffeeChatTimes = new ArrayList<>();
-        for (CoffeeChatTimeDto timeDto : requestDto.availableTimes()) {
-            CoffeeChatTime time = CoffeeChatTime.of(
-                coffeeChatInfo,
-                timeDto.dayOfWeek(),
-                timeDto.startTime(),
-                timeDto.endTime()
-            );
-            coffeeChatInfo.addAvailableTime(time);
-            coffeeChatTimes.add(time);
+        // 이미 시간이 존재한다면 예외처리
+        if (coffeeChatTimeRepository.existsByCoffeeChatInfo(coffeeChatInfo)) {
+            throw new CustomException(ErrorCode.ALREADY_CREATED_COFFEE_CHAT_TIME);
         }
 
-        coffeeChatTimeRepository.saveAll(coffeeChatTimes);
-        return coffeeChatTimes.stream()
+        // 시 : 분 파싱
+        List<CoffeeChatTimeDto> timeDtos = CoffeeChatTimeConverter.toDtoList(requestDto);
+
+        List<CoffeeChatTime> chatTimes = timeDtos.stream()
+            .map(dto -> {
+                CoffeeChatTime time = CoffeeChatTime.of(coffeeChatInfo, dto.dayOfWeek(),
+                    dto.startTime());
+                coffeeChatInfo.addAvailableTime(time);
+                return time;
+            })
+            .toList();
+
+        coffeeChatTimeRepository.saveAll(chatTimes);
+
+        return chatTimes.stream()
             .map(CoffeeChatTimeResponseDto::from)
             .toList();
     }
 
+    // 자신의 멘토 가능 시간 조회
     @Transactional(readOnly = true)
     public List<CoffeeChatTimeResponseDto> getMyCoffeeChatTimes(Long userId) {
         List<CoffeeChatTime> coffeeChatTimes = getmentorCoffeeChatTimesOrThrow(userId);
@@ -69,7 +75,7 @@ public class CoffeeChatTimeService {
         CoffeeChatInfo coffeeChatInfo = existingTimeSlots.get(0).getCoffeeChatInfo();
         List<CoffeeChatTime> newTimeSlots = requestDto.availableTimes().stream()
             .map(timeDto -> CoffeeChatTime.of(coffeeChatInfo, timeDto.dayOfWeek(),
-                timeDto.startTime(), timeDto.endTime()))
+                timeDto.startTime()))
             .toList();
 
         // 삭제할 시간 찾기 (기존 데이터 중에서 새로운 데이터에 없는 항목)

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatTimeService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatTimeService.java
@@ -76,7 +76,8 @@ public class CoffeeChatTimeService {
         CoffeeChatInfo coffeeChatInfo = coffeeChatInfoRepository.findBymentor_UserId(userId)
             .orElseThrow(() -> new CustomException(ErrorCode.USER_COFFEE_CHAT_NOT_FOUND));
 
-        List<CoffeeChatTime> existingTimes = coffeeChatTimeRepository.findAllWithCoffeeChatInfoByUserId(userId);
+        List<CoffeeChatTime> existingTimes = coffeeChatTimeRepository.findAllWithCoffeeChatInfoByUserId(
+            userId);
 
         // 변환된 새 요청 리스트
         List<CoffeeChatTimeDto> newDtos = CoffeeChatTimeConverter.toDtoList(requestDto);
@@ -92,24 +93,31 @@ public class CoffeeChatTimeService {
 
         // 삭제 대상: 기존엔 있었는데, 새 요청에는 없는 것
         List<CoffeeChatTime> toDelete = existingTimes.stream()
-            .filter(time -> !newKeys.contains(generateKey(time.getDayOfWeek(), time.getStartTime())))
+            .filter(
+                time -> !newKeys.contains(generateKey(time.getDayOfWeek(), time.getStartTime())))
             .toList();
 
         // 추가 대상: 새 요청에는 있는데 기존에는 없는 것
         List<CoffeeChatTime> toAdd = newDtos.stream()
             .filter(dto -> !existingKeys.contains(generateKey(dto.dayOfWeek(), dto.startTime())))
             .map(dto -> {
-                CoffeeChatTime time = CoffeeChatTime.of(coffeeChatInfo, dto.dayOfWeek(), dto.startTime());
+                CoffeeChatTime time = CoffeeChatTime.of(coffeeChatInfo, dto.dayOfWeek(),
+                    dto.startTime());
                 coffeeChatInfo.addAvailableTime(time);
                 return time;
             })
             .toList();
 
-        coffeeChatTimeRepository.deleteAll(toDelete);
-        coffeeChatTimeRepository.saveAll(toAdd);
+        if (!toDelete.isEmpty()) {
+            coffeeChatTimeRepository.deleteAll(toDelete);
+        }
+        if (!toAdd.isEmpty()) {
+            coffeeChatTimeRepository.saveAll(toAdd);
+        }
 
         // 최종 조회된 전체 시간 목록 반환
-        List<CoffeeChatTime> finalList = coffeeChatTimeRepository.findAllWithCoffeeChatInfoByUserId(userId);
+        List<CoffeeChatTime> finalList = coffeeChatTimeRepository.findAllWithCoffeeChatInfoByUserId(
+            userId);
         return finalList.stream().map(CoffeeChatTimeResponseDto::from).toList();
     }
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatTimeService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatTimeService.java
@@ -1,7 +1,6 @@
 package com.icandoit.boottalk.coffeeChat.service;
 
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatTimeDto;
-import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatTimeListDto;
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatTimeMapDto;
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatTimeResponseDto;
 import com.icandoit.boottalk.coffeeChat.entity.CoffeeChatInfo;
@@ -11,8 +10,13 @@ import com.icandoit.boottalk.coffeeChat.repository.CoffeeChatTimeRepository;
 import com.icandoit.boottalk.coffeeChat.service.converter.CoffeeChatTimeConverter;
 import com.icandoit.boottalk.libs.exception.CustomException;
 import com.icandoit.boottalk.libs.exception.ErrorCode;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -67,34 +71,50 @@ public class CoffeeChatTimeService {
 
     @Transactional
     public List<CoffeeChatTimeResponseDto> updateCoffeeChatTimes(Long userId,
-        CoffeeChatTimeListDto requestDto) {
-        // 기존 멘토의 커피챗 시간 조회 (없으면 예외 발생)
-        List<CoffeeChatTime> existingTimeSlots = getmentorCoffeeChatTimesOrThrow(userId);
+        CoffeeChatTimeMapDto requestDto) {
 
-        // 새로운 시간 리스트를 CoffeeChatTime 엔티티 리스트로 변환
-        CoffeeChatInfo coffeeChatInfo = existingTimeSlots.get(0).getCoffeeChatInfo();
-        List<CoffeeChatTime> newTimeSlots = requestDto.availableTimes().stream()
-            .map(timeDto -> CoffeeChatTime.of(coffeeChatInfo, timeDto.dayOfWeek(),
-                timeDto.startTime()))
+        CoffeeChatInfo coffeeChatInfo = coffeeChatInfoRepository.findBymentor_UserId(userId)
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_COFFEE_CHAT_NOT_FOUND));
+
+        List<CoffeeChatTime> existingTimes = coffeeChatTimeRepository.findAllWithCoffeeChatInfoByUserId(userId);
+
+        // 변환된 새 요청 리스트
+        List<CoffeeChatTimeDto> newDtos = CoffeeChatTimeConverter.toDtoList(requestDto);
+
+        // Set으로 중복 제거 및 비교를 쉽게
+        Set<String> existingKeys = existingTimes.stream()
+            .map(time -> generateKey(time.getDayOfWeek(), time.getStartTime()))
+            .collect(Collectors.toSet());
+
+        Set<String> newKeys = newDtos.stream()
+            .map(dto -> generateKey(dto.dayOfWeek(), dto.startTime()))
+            .collect(Collectors.toSet());
+
+        // 삭제 대상: 기존엔 있었는데, 새 요청에는 없는 것
+        List<CoffeeChatTime> toDelete = existingTimes.stream()
+            .filter(time -> !newKeys.contains(generateKey(time.getDayOfWeek(), time.getStartTime())))
             .toList();
 
-        // 삭제할 시간 찾기 (기존 데이터 중에서 새로운 데이터에 없는 항목)
-        List<CoffeeChatTime> toDelete = existingTimeSlots.stream()
-            .filter(existing -> !newTimeSlots.contains(existing))
+        // 추가 대상: 새 요청에는 있는데 기존에는 없는 것
+        List<CoffeeChatTime> toAdd = newDtos.stream()
+            .filter(dto -> !existingKeys.contains(generateKey(dto.dayOfWeek(), dto.startTime())))
+            .map(dto -> {
+                CoffeeChatTime time = CoffeeChatTime.of(coffeeChatInfo, dto.dayOfWeek(), dto.startTime());
+                coffeeChatInfo.addAvailableTime(time);
+                return time;
+            })
             .toList();
 
-        // 추가할 시간 찾기 (새로운 데이터 중에서 기존 데이터에 없는 항목)
-        List<CoffeeChatTime> toAdd = newTimeSlots.stream()
-            .filter(newSlot -> !existingTimeSlots.contains(newSlot))
-            .toList();
-
-        // 기존 시간 삭제 및 새로운 시간 추가
         coffeeChatTimeRepository.deleteAll(toDelete);
         coffeeChatTimeRepository.saveAll(toAdd);
 
-        return coffeeChatTimeRepository.findAllWithCoffeeChatInfoByUserId(userId).stream()
-            .map(CoffeeChatTimeResponseDto::from)
-            .toList();
+        // 최종 조회된 전체 시간 목록 반환
+        List<CoffeeChatTime> finalList = coffeeChatTimeRepository.findAllWithCoffeeChatInfoByUserId(userId);
+        return finalList.stream().map(CoffeeChatTimeResponseDto::from).toList();
+    }
+
+    private String generateKey(DayOfWeek dayOfWeek, LocalTime startTime) {
+        return dayOfWeek.toString() + "-" + startTime.format(DateTimeFormatter.ofPattern("HH:mm"));
     }
 
     private List<CoffeeChatTime> getmentorCoffeeChatTimesOrThrow(Long userId) {

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/converter/CoffeeChatTimeConverter.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/converter/CoffeeChatTimeConverter.java
@@ -1,0 +1,40 @@
+package com.icandoit.boottalk.coffeeChat.service.converter;
+
+import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatTimeDto;
+import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatTimeMapDto;
+import com.icandoit.boottalk.libs.exception.CustomException;
+import com.icandoit.boottalk.libs.exception.ErrorCode;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class CoffeeChatTimeConverter {
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+
+    public static List<CoffeeChatTimeDto> toDtoList(CoffeeChatTimeMapDto mapDto) {
+        List<CoffeeChatTimeDto> result = new ArrayList<>();
+
+        for (Map.Entry<String, List<String>> entry : mapDto.availableTimes().entrySet()) {
+            DayOfWeek day;
+            try {
+                day = DayOfWeek.valueOf(entry.getKey());
+            } catch (IllegalArgumentException e) {
+                throw new CustomException(ErrorCode.INVALID_DAY_FORMAT);
+            }
+
+            for (String timeStr : entry.getValue()) {
+                try {
+                    LocalTime time = LocalTime.parse(timeStr, TIME_FORMATTER);
+                    result.add(new CoffeeChatTimeDto(day, time));
+                } catch (DateTimeParseException e) {
+                    throw new CustomException(ErrorCode.INVALID_TIME_FORMAT);
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/libs/exception/ErrorCode.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/libs/exception/ErrorCode.java
@@ -2,7 +2,6 @@ package com.icandoit.boottalk.libs.exception;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
@@ -12,8 +11,8 @@ public enum ErrorCode {
     INVALID_DAY_FORMAT(400, "유효하지 않은 요일 형식입니다."),
     INVALID_TIME_FORMAT(400, "유효하지 않은 시간 형식입니다."),
     INSUFFICIENT_POINT(400, "잔여 포인트가 부족합니다."),
-    EXCEEDS_MAX_LENGTH(400,"최대 길이를 초과했습니다." ),
-    COFFEE_CHAT_STATUS_NOT_PENDING (400, "대기 중 상태가 아니므로 상태를 변경할 수 없습니다."),
+    EXCEEDS_MAX_LENGTH(400, "최대 길이를 초과했습니다."),
+    COFFEE_CHAT_STATUS_NOT_PENDING(400, "대기 중 상태가 아니므로 상태를 변경할 수 없습니다."),
 
     /* 401 UNAUTHORIZED */
     INVALID_TOKEN(401, "유효한 토큰이 아닙니다."),
@@ -26,16 +25,16 @@ public enum ErrorCode {
 
     /* 404 NOT_FOUND */
     NOT_FOUND(404, "요청한 리소스를 찾을 수 없습니다."),
-    USER_NOT_FOUND(404,"유저를 찾을 수 없습니다."),
-    BOOTCAMP_NOT_FOUND(404,"부트캠프를 찾을 수 없습니다."),
-    REVIEW_NOT_FOUND(404,"리뷰를 찾을 수 없습니다."),
-    COFFEE_CHAT_NOT_FOUND(404,"커피챗을 찾을 수 없습니다."),
-    USER_COFFEE_CHAT_NOT_FOUND(404,"유저의 해당하는 커피챗을 찾을 수 없습니다."),
-    COFFEE_CHAT_APPLICATION_NOT_FOUND(404,"커피챗 신청 내역을 찾을 수 없습니다."),
+    USER_NOT_FOUND(404, "유저를 찾을 수 없습니다."),
+    BOOTCAMP_NOT_FOUND(404, "부트캠프를 찾을 수 없습니다."),
+    REVIEW_NOT_FOUND(404, "리뷰를 찾을 수 없습니다."),
+    COFFEE_CHAT_NOT_FOUND(404, "커피챗을 찾을 수 없습니다."),
+    USER_COFFEE_CHAT_NOT_FOUND(404, "유저의 해당하는 커피챗을 찾을 수 없습니다."),
+    COFFEE_CHAT_APPLICATION_NOT_FOUND(404, "커피챗 신청 내역을 찾을 수 없습니다."),
     COURSE_NOT_FOUND(404, "코스를 찾을 수 없습니다."),
 
     /* 409 CONFLICT */
-    DUPLICATE_REVIEW(409,"해당 부트캠프에 이미 리뷰를 작성하였습니다."),
+    DUPLICATE_REVIEW(409, "해당 부트캠프에 이미 리뷰를 작성하였습니다."),
     NOT_PENDING_STATUS(409, "커피챗 신청이 '대기 중' 상태일 때만 수정할 수 있습니다."),
     COFFEE_CHAT_ALREADY_EXISTS(409, "이미 생성된 커피챗이 있습니다."),
     ALREADY_CREATED_COFFEE_CHAT_TIME(409, "해당 유저의 커피챗 시간이 등록되어 있습니다."),

--- a/boottalk/src/main/java/com/icandoit/boottalk/libs/exception/ErrorCode.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/libs/exception/ErrorCode.java
@@ -2,12 +2,15 @@ package com.icandoit.boottalk.libs.exception;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
 
     /* 400 BAD_REQUEST */
+    INVALID_DAY_FORMAT(400, "유효하지 않은 요일 형식입니다."),
+    INVALID_TIME_FORMAT(400, "유효하지 않은 시간 형식입니다."),
     INSUFFICIENT_POINT(400, "잔여 포인트가 부족합니다."),
     EXCEEDS_MAX_LENGTH(400,"최대 길이를 초과했습니다." ),
     COFFEE_CHAT_STATUS_NOT_PENDING (400, "대기 중 상태가 아니므로 상태를 변경할 수 없습니다."),
@@ -34,10 +37,8 @@ public enum ErrorCode {
     /* 409 CONFLICT */
     DUPLICATE_REVIEW(409,"해당 부트캠프에 이미 리뷰를 작성하였습니다."),
     NOT_PENDING_STATUS(409, "커피챗 신청이 '대기 중' 상태일 때만 수정할 수 있습니다."),
-
-    /* 409 Conflict */
     COFFEE_CHAT_ALREADY_EXISTS(409, "이미 생성된 커피챗이 있습니다."),
-
+    ALREADY_CREATED_COFFEE_CHAT_TIME(409, "해당 유저의 커피챗 시간이 등록되어 있습니다."),
     /* 500 INTERNAL_SERVER_ERROR */
     INTERNAL_SERVER_ERROR(500, "서버 오류가 발생했습니다."),
     TOKEN_PARSING_ERROR(500, "토큰 파싱 과정에서 오류가 발생했습니다.");


### PR DESCRIPTION
## 🔍 주요 변경 사항

- 커피챗 가능 시간 생성 및 수정 시 `List` 기반 비교에서 `Set` 기반 비교로 변경
- 시간 형식은 `"HH:mm"` 고정 (ex: `"09:30"`)
- 요일별 커피챗 시간을 Map(DayOfWeek → 시간 목록) 형태로 받는 구조 유지
- 중복 제거 및 변경 시간 판단 로직을 효율적으로 수행하도록 개선

---

## 💡 변경 이유

기존에는 커피챗 시간 업데이트 시 리스트에서 `contains()` 비교를 수행하며  
**O(n × m)** 의 시간복잡도를 가지는 비효율적인 구조였음.

커피챗 시간은 **요일 + 시간(30분 단위)** 조합으로 최대 `48 × 7 = 336`개까지 늘어날 수 있음.

예전 방식대로 비교하면 최악의 경우 다음과 같은 성능 차이가 발생함:

| 비교 대상 | 시간복잡도 | 최대 연산 수 (336개 기준) |
|-----------|-------------|----------------------------|
| List.contains() | O(n × m) | 112,896번(336 * 336) |
| Set.contains() | O(n + m) | 672번 |

---

## 🚀 개선 결과

- 리스트 → Set 변경을 통해 **약 167배 빠른 비교 연산**이 가능해졌습니다.
- Map vs Set -> 중복이 없더라도, 시간 데이터를 다룰 땐 Set 기반 구조가 가장 효율적입니다.
- 유지보수성 및 가독성 향상을 위해 `CoffeeChatTimeConverter` 클래스 분리

---

## 📂 관련 클래스 및 변경 파일

- `CoffeeChatService#createCoffeeChatTimes`
- `CoffeeChatService#updateCoffeeChatTimes`
- `CoffeeChatTimeConverter`
- `CoffeeChatTimeDto`, `CoffeeChatTimeMapDto`

- `CoffeeChatTimeListDto` 제거 

---

## ✅ 테스트 시나리오(예정) 

- [] 기존 시간과 동일한 요청 시 DB update 없음
- [] 기존 시간 일부 삭제, 일부 추가 시 정상 반영
- [] 잘못된 시간 포맷 예외 처리 (ex. "9:00" → 예외 발생)
- [] 중복 시간 요청 시 예외 처리 or 무시

---

## 🖼️ 스크린샷
- 커피챗 시간 수정 API
![image](https://github.com/user-attachments/assets/047f10aa-66c7-4159-ab5f-f4960ab4e8d7)


## 💡 참고 블로그
[equals와 hashCode 사용하기 ( +lombok)](https://jojoldu.tistory.com/134)
