### PR TITLE
Refactor: 커피챗 신청/수신 리팩토링 (페이징 처리, @AuthenticationPrincipal 사용)

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatApplicationController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatApplicationController.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -19,6 +20,7 @@ import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatApplicationUpdateDto;
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatInfoApprovedDto;
 import com.icandoit.boottalk.coffeeChat.service.CoffeeChatApplicationService;
 import com.icandoit.boottalk.common.dto.PagedResponseDto;
+import com.icandoit.boottalk.social_login.dto.CustomOAuth2User;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -33,48 +35,52 @@ public class CoffeeChatApplicationController {
     // 커피챗 신청 등록
     @PostMapping
     public ResponseEntity<CoffeeChatApplicationResponseDto> createCoffeeChatApp(
+        @AuthenticationPrincipal CustomOAuth2User user,
         @Valid @RequestBody CoffeeChatApplicationCreateDto request
     ) {
-        // TODO : 사용자 인증 사용 시 수정
-        Long userId = 1L;
-        return ResponseEntity.ok(coffeeChatAppService.createCoffeeChatApp(userId, request));
+        return ResponseEntity.ok(coffeeChatAppService.createCoffeeChatApp(
+            user.getServiceUserId(), request));
     }
 
     // 나의 커피챗 신청 목록 조회
     @GetMapping
     public ResponseEntity<PagedResponseDto<CoffeeChatApplicationResponseDto>> getMyCoffeeChatApps(
+        @AuthenticationPrincipal CustomOAuth2User user,
         @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
-        Pageable pageable) {
-        // TODO : 사용자 인증 사용 시 수정
-        Long userId = 1L;
-        return ResponseEntity.ok(coffeeChatAppService.getMyCoffeeChatApps(userId, pageable));
+        Pageable pageable
+    ) {
+        return ResponseEntity.ok(coffeeChatAppService.getMyCoffeeChatApps(
+            user.getServiceUserId(), pageable));
     }
 
     // 나의 수락된 커피챗 목록 조회
     @GetMapping("/approved")
     public ResponseEntity<PagedResponseDto<CoffeeChatInfoApprovedDto>> getApprovedCoffeeChats(
-        Pageable pageable) {
-        Long userId = 1L;
-        return ResponseEntity.ok(coffeeChatAppService.getApprovedCoffeeChats(userId, pageable));
+        @AuthenticationPrincipal CustomOAuth2User user,
+        Pageable pageable
+    ) {
+        return ResponseEntity.ok(coffeeChatAppService.getApprovedCoffeeChats(
+            user.getServiceUserId(), pageable));
     }
 
     // 커피챗 신청 수정
     @PutMapping("/{coffeeChatAppId}")
     public ResponseEntity<CoffeeChatApplicationResponseDto> updateCoffeeChatApp(
+        @AuthenticationPrincipal CustomOAuth2User user,
         @PathVariable Long coffeeChatAppId,
-        @Valid @RequestBody CoffeeChatApplicationUpdateDto request) {
-        // TODO : 사용자 인증 사용 시 수정
-        Long userId = 1L;
-        return ResponseEntity.ok(
-            coffeeChatAppService.updateCoffeeChatApp(userId, coffeeChatAppId, request));
+        @Valid @RequestBody CoffeeChatApplicationUpdateDto request
+    ) {
+        return ResponseEntity.ok(coffeeChatAppService.updateCoffeeChatApp(
+            user.getServiceUserId(), coffeeChatAppId, request));
     }
 
     // 커피챗 신청 삭제
     @DeleteMapping("/{coffeeChatAppId}")
-    public ResponseEntity<Void> deleteCoffeeChatApp(@PathVariable Long coffeeChatAppId) {
-        // TODO : 사용자 인증 사용 시 수정
-        Long userId = 1L;
-        coffeeChatAppService.deleteCoffeeChatApp(userId, coffeeChatAppId);
+    public ResponseEntity<Void> deleteCoffeeChatApp(
+        @AuthenticationPrincipal CustomOAuth2User user,
+        @PathVariable Long coffeeChatAppId
+    ) {
+        coffeeChatAppService.deleteCoffeeChatApp(user.getServiceUserId(), coffeeChatAppId);
         return ResponseEntity.ok().build();
     }
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatApplicationController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatApplicationController.java
@@ -1,15 +1,8 @@
 package com.icandoit.boottalk.coffeeChat.controller;
 
-import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatApplicationCreateDto;
-import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatApplicationResponseDto;
-import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatApplicationUpdateDto;
-import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatInfoApprovedDto;
-import com.icandoit.boottalk.coffeeChat.service.CoffeeChatApplicationService;
-import com.icandoit.boottalk.common.dto.PagedResponseDto;
-import jakarta.validation.Valid;
-import java.util.List;
-import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,6 +12,16 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatApplicationCreateDto;
+import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatApplicationResponseDto;
+import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatApplicationUpdateDto;
+import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatInfoApprovedDto;
+import com.icandoit.boottalk.coffeeChat.service.CoffeeChatApplicationService;
+import com.icandoit.boottalk.common.dto.PagedResponseDto;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/coffee-chats/applications")
@@ -39,10 +42,12 @@ public class CoffeeChatApplicationController {
 
     // 나의 커피챗 신청 목록 조회
     @GetMapping
-    public ResponseEntity<List<CoffeeChatApplicationResponseDto>> getMyCoffeeChatApps() {
+    public ResponseEntity<PagedResponseDto<CoffeeChatApplicationResponseDto>> getMyCoffeeChatApps(
+        @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
+        Pageable pageable) {
         // TODO : 사용자 인증 사용 시 수정
         Long userId = 1L;
-        return ResponseEntity.ok(coffeeChatAppService.getMyCoffeeChatApps(userId));
+        return ResponseEntity.ok(coffeeChatAppService.getMyCoffeeChatApps(userId, pageable));
     }
 
     // 나의 수락된 커피챗 목록 조회

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatReceivedController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatReceivedController.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -18,6 +19,7 @@ import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatAppChangeStatusDto;
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatAppStatusResponseDto;
 import com.icandoit.boottalk.coffeeChat.service.CoffeeChatReceivedService;
 import com.icandoit.boottalk.common.dto.PagedResponseDto;
+import com.icandoit.boottalk.social_login.dto.CustomOAuth2User;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -32,22 +34,23 @@ public class CoffeeChatReceivedController {
     // 수신된 커피챗 신청 목록 조회 (멘티가 나에게 신청한 커피챗 신청 목록 조회)
     @GetMapping
     public ResponseEntity<PagedResponseDto<CoffeeChatApplicationResponseDto>> getReceivedCoffeeChatApplications(
+        @AuthenticationPrincipal CustomOAuth2User user,
         @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
-            Pageable pageable) {
-        // TODO : 사용자 인증 사용 시 수정
-        Long userId = 1L;
-        return ResponseEntity.ok(coffeeChatReceivedService.getReceivedCoffeeChatApplications(userId, pageable));
+            Pageable pageable
+    ) {
+        return ResponseEntity.ok(coffeeChatReceivedService.getReceivedCoffeeChatApplications(
+            user.getServiceUserId(), pageable));
     }
 
     // 커피챗 신청 상태 변경 (멘티가 나에게 신청한 커피챗 신청에 대한 상태 변경 처리 요청)
     @PutMapping("/{coffeeChatAppId}/status")
     public ResponseEntity<CoffeeChatAppStatusResponseDto> changeCoffeeChatAppStatus(
+        @AuthenticationPrincipal CustomOAuth2User user,
         @PathVariable Long coffeeChatAppId,
         @Valid @RequestBody CoffeeChatAppChangeStatusDto request
     ) {
-        // TODO : 사용자 인증 사용 시 수정
-        Long userId = 1L;
-        return ResponseEntity.ok(coffeeChatReceivedService.changeCoffeeChatAppStatus(userId, coffeeChatAppId, request));
+        return ResponseEntity.ok(coffeeChatReceivedService.changeCoffeeChatAppStatus(
+            user.getServiceUserId(), coffeeChatAppId, request));
     }
 
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatReceivedController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatReceivedController.java
@@ -2,6 +2,9 @@ package com.icandoit.boottalk.coffeeChat.controller;
 
 import java.util.List;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -14,6 +17,7 @@ import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatApplicationResponseDto;
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatAppChangeStatusDto;
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatAppStatusResponseDto;
 import com.icandoit.boottalk.coffeeChat.service.CoffeeChatReceivedService;
+import com.icandoit.boottalk.common.dto.PagedResponseDto;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -27,11 +31,12 @@ public class CoffeeChatReceivedController {
 
     // 수신된 커피챗 신청 목록 조회 (멘티가 나에게 신청한 커피챗 신청 목록 조회)
     @GetMapping
-    public ResponseEntity<List<CoffeeChatApplicationResponseDto>> getReceivedCoffeeChatApplications(
-    ) {
+    public ResponseEntity<PagedResponseDto<CoffeeChatApplicationResponseDto>> getReceivedCoffeeChatApplications(
+        @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
+            Pageable pageable) {
         // TODO : 사용자 인증 사용 시 수정
         Long userId = 1L;
-        return ResponseEntity.ok(coffeeChatReceivedService.getReceivedCoffeeChatApplications(userId));
+        return ResponseEntity.ok(coffeeChatReceivedService.getReceivedCoffeeChatApplications(userId, pageable));
     }
 
     // 커피챗 신청 상태 변경 (멘티가 나에게 신청한 커피챗 신청에 대한 상태 변경 처리 요청)

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/repository/CoffeeChatApplicationRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/repository/CoffeeChatApplicationRepository.java
@@ -10,9 +10,9 @@ import org.springframework.data.repository.query.Param;
 
 public interface CoffeeChatApplicationRepository extends JpaRepository<CoffeeChatApplication, Long> {
 
-	List<CoffeeChatApplication> findByMentee_UserId(Long userId);
+	Page<CoffeeChatApplication> findByMentee_UserId(Long userId, Pageable pageable);
 
-	List<CoffeeChatApplication> findByCoffeeChatInfo_CoffeeChatInfoId(Long userId);
+	Page<CoffeeChatApplication> findByCoffeeChatInfo_CoffeeChatInfoId(Long userId, Pageable pageable);
 
 	// Param으로 받은 userId에 따라 멘토 or 멘티의 예약된 커피챗 리스트 조회
 	@Query("""

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatApplicationService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatApplicationService.java
@@ -50,14 +50,11 @@ public class CoffeeChatApplicationService {
     }
 
 	@Transactional(readOnly = true)
-    public List<CoffeeChatApplicationResponseDto> getMyCoffeeChatApps(Long userId) {
+    public PagedResponseDto<CoffeeChatApplicationResponseDto> getMyCoffeeChatApps(Long userId, Pageable pageable) {
+        Page<CoffeeChatApplicationResponseDto> page = coffeeChatAppRepository.findByMentee_UserId(userId, pageable)
+            .map(CoffeeChatApplicationResponseDto::from);
 
-        List<CoffeeChatApplication> coffeeChatApps = coffeeChatAppRepository.findByMentee_UserId(userId);
-
-        return coffeeChatApps.stream()
-            .map(CoffeeChatApplicationResponseDto::from)
-            .toList();
-
+        return PagedResponseDto.from(page);
     }
 
     @Transactional(readOnly = true)

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatReceivedService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatReceivedService.java
@@ -3,6 +3,8 @@ package com.icandoit.boottalk.coffeeChat.service;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,6 +15,7 @@ import com.icandoit.boottalk.coffeeChat.entity.CoffeeChatApplication;
 import com.icandoit.boottalk.coffeeChat.entity.CoffeeChatInfo;
 import com.icandoit.boottalk.coffeeChat.entity.enums.StatusType;
 import com.icandoit.boottalk.coffeeChat.repository.CoffeeChatApplicationRepository;
+import com.icandoit.boottalk.common.dto.PagedResponseDto;
 import com.icandoit.boottalk.libs.exception.CustomException;
 import com.icandoit.boottalk.libs.exception.ErrorCode;
 
@@ -28,18 +31,17 @@ public class CoffeeChatReceivedService {
     private final CoffeeChatApplicationService coffeeChatAppService;
 
     // 나에게 신청한 커피챗 신정 목록 조회
-    @Transactional(readOnly = true)
-    public List<CoffeeChatApplicationResponseDto> getReceivedCoffeeChatApplications(Long userId) {
+    public PagedResponseDto<CoffeeChatApplicationResponseDto> getReceivedCoffeeChatApplications(
+        Long userId, Pageable pageable) {
 
         // 커피챗 정보 조회
         CoffeeChatInfo coffeeChatInfo = coffeeChatInfoService.getCoffeeChatInfoByUserId(userId);
 
-        List<CoffeeChatApplication> coffeeChatApplications =
-            coffeeChatAppRepository.findByCoffeeChatInfo_CoffeeChatInfoId(coffeeChatInfo.getCoffeeChatInfoId());
+        Page<CoffeeChatApplicationResponseDto> page =
+            coffeeChatAppRepository.findByCoffeeChatInfo_CoffeeChatInfoId(coffeeChatInfo.getCoffeeChatInfoId(), pageable)
+                .map(CoffeeChatApplicationResponseDto::from);
 
-        return coffeeChatApplications.stream()
-            .map(coffeeChatApplication -> CoffeeChatApplicationResponseDto.from(coffeeChatApplication))
-            .collect(Collectors.toList());
+        return PagedResponseDto.from(page);
     }
 
     @Transactional


### PR DESCRIPTION
## 🔍 주요 변경 사항
- CoffeeChatApplicationController, CoffeeChatReceivedController에서 `@AuthenticationPrincipal`을 사용하여 인증된 사용자 정보 조회
- 기존에 하드코딩되어 있던 userId = 1L 코드 제거
- 서비스 메서드 호출 시 실제 로그인된 사용자의 ID를 넘기도록 수정
- Pageable 기반 페이지네이션 처리
- 기본 페이징 설정: 한 페이지당 10건, `createdAt` 기준 내림차순 정렬

---

## 💡 변경 이유
- 하드코딩된 사용자 ID는 테스트용으로, 인증된 사용자의 데이터만 조회할 수 있도록 변경이 필요했음
- 스프링 시큐리티를 통해 로그인한 사용자 정보를 활용하면 보안성과 확장성이 향상됨
- 커피챗 신청/수신 목록이 많아질 경우를 대비하여 페이징 처리를 통해 성능 및 응답 속도 최적화

---

## 🚀 개선 결과

- 로그인한 사용자 기준으로 커피챗 신청/수신 목록을 정확하게 조회 가능
- 인증 기반 로직으로 실서비스에 적용 가능한 구조 완성
- 목록 조회 시 페이징 처리 적용으로 데이터 응답 최적화
---


## 🖼️ 스크린샷
- 나의 커피챗 신청 목록 조회
![페이징-나의커피챗신청](https://github.com/user-attachments/assets/12ee5c03-9ef6-418e-89aa-14fbb7eadd8b)

- 수신된 커피챗 목록 조회
![페이징-수신커피챗](https://github.com/user-attachments/assets/7fb33268-cf6b-4a51-9bc8-8886ab8be02d)

## 💡 참고 블로그
