### PR TITLE
Feat/ coffeechatTime 조회 API 추가 및 변경

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatInfoController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatInfoController.java
@@ -22,7 +22,7 @@ public class CoffeeChatInfoController {
     private final CoffeeChatInfoService coffeeChatInfoService;
 
 
-    @PostMapping("/user-info")
+    @PostMapping
     public ResponseEntity<CoffeeChatInfoResponseDto> createCoffeeChatInfo(
         @RequestBody @Valid CoffeeChatInfoRequestDto requestDto
     ) {
@@ -31,21 +31,21 @@ public class CoffeeChatInfoController {
         return ResponseEntity.ok(coffeeChatInfoService.createCoffeeChatInfo(userId, requestDto));
     }
 
-    @GetMapping("/my")
+    @GetMapping
     public ResponseEntity<CoffeeChatInfoResponseDto> getMyCoffeeChatInfo() {
         // todo : 사용자 인증 사용 시 수정
         Long userId = 1L;
         return ResponseEntity.ok(coffeeChatInfoService.getMyCoffeeChatInfo(userId));
     }
 
-    @PutMapping("/my")
+    @PutMapping
     public ResponseEntity<CoffeeChatInfoResponseDto> updateCoffeeChatInfo(
         @RequestBody CoffeeChatInfoRequestDto requestDto) {
         Long userId = 1L;
         return ResponseEntity.ok(coffeeChatInfoService.updateMyCoffeeChatInfo(userId, requestDto));
     }
 
-    @DeleteMapping("/my")
+    @DeleteMapping
     public ResponseEntity<Void> deleteCoffeeChatInfo() {
         Long userId = 1L;
         coffeeChatInfoService.deleteMyCoffeeChatInfo(userId);

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatTimeController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatTimeController.java
@@ -8,6 +8,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,7 +22,7 @@ public class CoffeeChatTimeController {
 
     private final CoffeeChatTimeService coffeeChatTimeService;
 
-    @PostMapping("/available-times")
+    @PostMapping
     public ResponseEntity<List<CoffeeChatTimeResponseDto>> createCoffeeChatTimes(
         @RequestBody @Valid CoffeeChatTimeMapDto requestDto) {
         // todo : 사용자 인증 사용 시 수정
@@ -29,14 +30,22 @@ public class CoffeeChatTimeController {
         return ResponseEntity.ok(coffeeChatTimeService.createCoffeeChatTimes(userId, requestDto));
     }
 
-    @GetMapping("/my")
+    // 멘토 자신의 시간을 조회
+    @GetMapping
     public ResponseEntity<List<CoffeeChatTimeResponseDto>> getMyCoffeeChatTimes() {
         Long userId = 1L;
 
-        return ResponseEntity.ok(coffeeChatTimeService.getMyCoffeeChatTimes(userId));
+        return ResponseEntity.ok(coffeeChatTimeService.getMentorAvailableChatTimes(userId));
     }
 
-    @PutMapping("/my")
+    //mentorId를 받아 커피챗 가능 시간 조회
+    @GetMapping("/{mentorId}")
+    public ResponseEntity<List<CoffeeChatTimeResponseDto>> getMentorAvailableChatTimes(@PathVariable Long mentorId) {
+
+        return ResponseEntity.ok(coffeeChatTimeService.getMentorAvailableChatTimes(mentorId));
+    }
+
+    @PutMapping
     public ResponseEntity<List<CoffeeChatTimeResponseDto>> updateCoffeeChatTimes(
         @RequestBody @Valid CoffeeChatTimeMapDto requestDto) {
         Long userId = 1L;

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatTimeService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatTimeService.java
@@ -61,7 +61,7 @@ public class CoffeeChatTimeService {
 
     // 자신의 멘토 가능 시간 조회
     @Transactional(readOnly = true)
-    public List<CoffeeChatTimeResponseDto> getMyCoffeeChatTimes(Long userId) {
+    public List<CoffeeChatTimeResponseDto> getMentorAvailableChatTimes(Long userId) {
         List<CoffeeChatTime> coffeeChatTimes = getmentorCoffeeChatTimesOrThrow(userId);
 
         return coffeeChatTimes.stream()


### PR DESCRIPTION
## 🔍 주요 변경 사항

- 멘토(자신)의 커피챗 시간 조회 메소드명 수정 
- 커피챗 신청 가능 시간 조회 API 추가(mentorId 조회) 
- CoffeeChatInfo, CoffeeChatTime 관련한 API 엔드포인트 변경

---

## 💡 변경 이유

- 커피챗 신청 가능 시간 조회 & 멘토(자신)의 커피챗 시간 조회 
- 두 경우 모두 커피챗 가능 시간을 조회하는 서비스 로직은 동일하나 요청하는 주체에 따라 의미가 달라지므로, 컨트롤러 분기 적용을 위해 변경 
- `CoffeeChatInfo`, `CoffeeChatTime` 관련한 API 엔드포인트의 중복된 의미가 많아 간소화 진행 
- 
---

## 🚀 개선 결과



---

## 📂 관련 클래스 및 변경 파일

- `CoffeeChatInfoController`
- `CoffeeChatTimeController`
- `CoffeeChatTimeService` 
---

## ✅ 테스트 시나리오(예정) 



---

## 💡 참고 블로그



--- 

## 🖼️ 스크린샷

- 멘토(자신)의 커피챗 시간 조회 
![image](https://github.com/user-attachments/assets/dcfd81ba-144a-4d2b-b500-33f8cd8945bc)

- 커피팻 시간 조회 (일반유저) 
![image](https://github.com/user-attachments/assets/59817fb3-d86e-4034-90fa-116d6bceaeaf)



