### PR TITLE
Feat/ point history 생성 시  트랜잭션으로 관리, 비관적 락 사용

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/point_history/controller/PointHistoryController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/point_history/controller/PointHistoryController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.icandoit.boottalk.common.dto.PagedResponseDto;
 import com.icandoit.boottalk.point_history.domain.dto.PointHistoryDto;
 import com.icandoit.boottalk.point_history.domain.form.PointHistoryForm;
 import com.icandoit.boottalk.point_history.domain.type.EventType;
@@ -33,7 +34,7 @@ public class PointHistoryController {
 	private final CreatePointHistoryService createPointHistoryService;
 
 	@GetMapping
-	public ResponseEntity<PagedModel<PointHistoryDto>> getPointHistory(@AuthenticationPrincipal CustomOAuth2User user,
+	public ResponseEntity<PagedResponseDto<PointHistoryDto>> getPointHistory(@AuthenticationPrincipal CustomOAuth2User user,
 		@PageableDefault(page = 0, size = 10, sort = "pointHistoryId", direction = Direction.DESC)
 		Pageable pageable) {
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/point_history/controller/PointHistoryController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/point_history/controller/PointHistoryController.java
@@ -5,7 +5,9 @@ import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.PagedModel;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,6 +20,7 @@ import com.icandoit.boottalk.point_history.domain.form.PointHistoryForm;
 import com.icandoit.boottalk.point_history.domain.type.EventType;
 import com.icandoit.boottalk.point_history.service.CreatePointHistoryService;
 import com.icandoit.boottalk.point_history.service.SearchPointHistoryService;
+import com.icandoit.boottalk.social_login.dto.CustomOAuth2User;
 
 import lombok.RequiredArgsConstructor;
 
@@ -30,11 +33,11 @@ public class PointHistoryController {
 	private final CreatePointHistoryService createPointHistoryService;
 
 	@GetMapping
-	public ResponseEntity<List<PointHistoryDto>> getPointHistory(@RequestParam long userId,
+	public ResponseEntity<PagedModel<PointHistoryDto>> getPointHistory(@AuthenticationPrincipal CustomOAuth2User user,
 		@PageableDefault(page = 0, size = 10, sort = "pointHistoryId", direction = Direction.DESC)
 		Pageable pageable) {
 
-		return ResponseEntity.ok(searchPointHistoryService.searchMyPointHistory(userId, pageable));
+		return ResponseEntity.ok(searchPointHistoryService.searchMyPointHistory(user.getServiceUserId(), pageable));
 	}
 
 	//테스트용

--- a/boottalk/src/main/java/com/icandoit/boottalk/point_history/domain/repository/PointHistoryRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/point_history/domain/repository/PointHistoryRepository.java
@@ -5,12 +5,16 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 
 import com.icandoit.boottalk.point_history.domain.entity.PointHistory;
+
+import jakarta.persistence.LockModeType;
 
 public interface PointHistoryRepository extends JpaRepository<PointHistory, Long> {
 
 	Page<PointHistory> findAllByUserId(long userId, Pageable pageable);
 
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	Optional<PointHistory> findTopByUserIdOrderByPointHistoryIdDesc(long userId);
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/point_history/service/CreatePointHistoryService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/point_history/service/CreatePointHistoryService.java
@@ -3,6 +3,7 @@ package com.icandoit.boottalk.point_history.service;
 import static com.icandoit.boottalk.libs.exception.ErrorCode.*;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.icandoit.boottalk.libs.exception.CustomException;
 import com.icandoit.boottalk.point_history.domain.dto.PointHistoryDto;
@@ -19,7 +20,7 @@ public class CreatePointHistoryService {
 
 	private final PointHistoryRepository pointHistoryRepository;
 
-
+	@Transactional
 	public PointHistoryDto createPointHistory(EventType eventType, long userId, int changedPoint) {
 
 		int currentPoint = getCurrentPoint(userId);

--- a/boottalk/src/main/java/com/icandoit/boottalk/point_history/service/SearchPointHistoryService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/point_history/service/SearchPointHistoryService.java
@@ -1,6 +1,7 @@
 package com.icandoit.boottalk.point_history.service;
 
 import com.icandoit.boottalk.point_history.domain.dto.PointHistoryDto;
+import com.icandoit.boottalk.point_history.domain.entity.PointHistory;
 import com.icandoit.boottalk.point_history.domain.repository.PointHistoryRepository;
 
 import java.util.List;
@@ -8,6 +9,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PagedModel;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,11 +20,9 @@ public class SearchPointHistoryService {
 	private final PointHistoryRepository pointHistoryRepository;
 
 	@Transactional(readOnly = true)
-	public List<PointHistoryDto> searchMyPointHistory(long userId, Pageable pageable) {
+	public PagedModel<PointHistoryDto> searchMyPointHistory(long userId, Pageable pageable) {
 
-		return pointHistoryRepository.findAllByUserId(userId, pageable)
-			.getContent().stream()
-			.map(PointHistoryDto::from)
-			.toList();
+		return new PagedModel<>(pointHistoryRepository.findAllByUserId(userId, pageable)
+			.map(PointHistoryDto::from));
 	}
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/point_history/service/SearchPointHistoryService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/point_history/service/SearchPointHistoryService.java
@@ -1,5 +1,6 @@
 package com.icandoit.boottalk.point_history.service;
 
+import com.icandoit.boottalk.common.dto.PagedResponseDto;
 import com.icandoit.boottalk.point_history.domain.dto.PointHistoryDto;
 import com.icandoit.boottalk.point_history.domain.entity.PointHistory;
 import com.icandoit.boottalk.point_history.domain.repository.PointHistoryRepository;
@@ -20,9 +21,8 @@ public class SearchPointHistoryService {
 	private final PointHistoryRepository pointHistoryRepository;
 
 	@Transactional(readOnly = true)
-	public PagedModel<PointHistoryDto> searchMyPointHistory(long userId, Pageable pageable) {
+	public PagedResponseDto<PointHistoryDto> searchMyPointHistory(long userId, Pageable pageable) {
 
-		return new PagedModel<>(pointHistoryRepository.findAllByUserId(userId, pageable)
-			.map(PointHistoryDto::from));
+		return PagedResponseDto.from(pointHistoryRepository.findAllByUserId(userId, pageable).map(PointHistoryDto::from));
 	}
 }


### PR DESCRIPTION
## 🔍 주요 변경 사항
- 사용자의 포인트 내역 조회 시 기존 List<PointHistoryDto> 에서 PageModel<PointHistoryDto> 반환 객체 타입 변경
- @AuthenticationPrincipal 어노테이션을 통해 인증된 사용자 정보 가져옴
- 포인트 내역 생성 시 트랜잭션으로 관리
- 포인트 내역 생성 시 현재 포인트를 가져올 때 비관적 락 적용


---

## 💡 변경 이유
- Page의 메타 데이터(현재페이지, 현재 데이터 개수, 총 데이터 개수, 총 페이지 개수) 까지 포함될 수 있도록 하기 위해서 반환 객체 타입을 PageModel 로 변경
- 로그인을 통해 인증된 사용자가 자신의 포인트 내역만을 조회할 수 있도록 하기 위해 @AuthenticationPrincipal 를 통해 인증된 사용자의 정보를 가져옴
- 포인트 내역 생성에 실패할 시에 롤백이 되어야 하므로 트랜잭션으로 관리
- 만약 동시에 포인트 차감 내역과 포인트 적립 내역이 생성된다고 가정할 때 둘 다 같은 최근 포인트 내역의 현재 포인트 값을 가져오면 안되므로 최근 포인트 내역 조회 시 비관적 락을 사용해 동시에 해당 데이터에 접근할 수 없도록 함.

---

## 🚀 개선 결과



---

## 📂 관련 클래스 및 변경 파일
- `PointHistoryController`
- `SearchPointHistoryService`
- `PointHistoryRepository`
- `CreatePointHistoryService`


---

## ✅ 테스트 시나리오(예정) 



---

## 💡 참고 블로그



--- 

## 🖼️ 스크린샷
![image](https://github.com/user-attachments/assets/a41648f5-71eb-4a34-9bce-4d2f437b19e6)



