### PR TITLE
Feat/커피챗 신청 시 동일 시간대 중복 신청 방지 기능 및 테스트 추가 

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/repository/CoffeeChatApplicationRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/repository/CoffeeChatApplicationRepository.java
@@ -1,12 +1,17 @@
 package com.icandoit.boottalk.coffeeChat.repository;
 
 import com.icandoit.boottalk.coffeeChat.entity.CoffeeChatApplication;
-import java.util.List;
+
+import java.time.LocalDateTime;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import jakarta.persistence.LockModeType;
 
 public interface CoffeeChatApplicationRepository extends JpaRepository<CoffeeChatApplication, Long> {
 
@@ -23,4 +28,9 @@ public interface CoffeeChatApplicationRepository extends JpaRepository<CoffeeCha
 	Page<CoffeeChatApplication> findApprovedChatsByUserId(@Param("userId") Long userId, Pageable pageable);
 
 	boolean existsByMentee_UserIdAndCoffeeChatInfo_CoffeeChatInfoId(Long userId, Long coffeeChatInfoId);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	boolean existsByCoffeeChatInfo_CoffeeChatInfoIdAndCoffeeChatStartTime(
+		Long coffeeChatInfoId, LocalDateTime coffeeChatStartTime);
+
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatApplicationService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatApplicationService.java
@@ -45,13 +45,24 @@ public class CoffeeChatApplicationService {
     @Transactional
     public CoffeeChatApplicationResponseDto createCoffeeChatApp(Long userId, CoffeeChatApplicationCreateDto request) {
 
-        if (coffeeChatAppRepository.existsByMentee_UserIdAndCoffeeChatInfo_CoffeeChatInfoId(
-            userId, request.coffeeChatInfoId())) {
+        Long coffeChatInfoId = request.coffeeChatInfoId();
+        
+        if (coffeeChatAppRepository.existsByMentee_UserIdAndCoffeeChatInfo_CoffeeChatInfoId(userId, coffeChatInfoId)) {
             throw new CustomException(ErrorCode.COFFEE_CHAT_APPLICATION_ALREADY_EXISTS);
         }
+        
+        log.debug("커피챗 신청 Lock : userId: {}", userId);
+        // 커피챗 신청 시, 해당 시간대의 커피챗에 다른 사용자가 신청 요청하지 못하도록 동시성 제어
+        if (coffeeChatAppRepository.existsByCoffeeChatInfo_CoffeeChatInfoIdAndCoffeeChatStartTime(
+            coffeChatInfoId, request.coffeeChatStartTime())
+        ) {
+            throw new CustomException(ErrorCode.COFFEE_CHAT_APPLICATION_TIME_ALREADY_EXISTS);
+        }
+        log.debug("커피챗 신청 Lock 해제 : userId: {}", userId);
+
 
         User user = getUser(userId);
-        CoffeeChatInfo coffeeChatInfo = getCoffeeChatInfo(request.coffeeChatInfoId());
+        CoffeeChatInfo coffeeChatInfo = getCoffeeChatInfo(coffeChatInfoId);
 
         // 멘토 타입에 따른 커피챗 포인트 차감. 포인트 부족 시 커피챗 신청 실패 처리
         MentorType mentorType = coffeeChatInfo.getMentorType();
@@ -70,8 +81,6 @@ public class CoffeeChatApplicationService {
 
         CoffeeChatApplication coffeeChatApp = CoffeeChatApplication.of(user, coffeeChatInfo, request);
         coffeeChatAppRepository.save(coffeeChatApp);
-
-        // TODO: 커피챗 신청 성공 시, 해당 시간대의 커피챗에 다른 사용자가 신청 요청하지 못하도록 동시성 제어 필요
 
         return CoffeeChatApplicationResponseDto.from(coffeeChatApp);
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/libs/exception/ErrorCode.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/libs/exception/ErrorCode.java
@@ -40,6 +40,7 @@ public enum ErrorCode {
     COFFEE_CHAT_ALREADY_EXISTS(409, "이미 생성된 커피챗이 있습니다."),
     ALREADY_CREATED_COFFEE_CHAT_TIME(409, "해당 유저의 커피챗 시간이 등록되어 있습니다."),
     COFFEE_CHAT_APPLICATION_ALREADY_EXISTS(409, "이미 해당 커피챗에 신청되었습니다."),
+    COFFEE_CHAT_APPLICATION_TIME_ALREADY_EXISTS(400, "이미 신청된 시간입니다."),
 
     /* 500 INTERNAL_SERVER_ERROR */
     INTERNAL_SERVER_ERROR(500, "서버 오류가 발생했습니다."),

--- a/boottalk/src/test/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatApplicationConcurrencyTest.java
+++ b/boottalk/src/test/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatApplicationConcurrencyTest.java
@@ -9,6 +9,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.icandoit.boottalk.bootcamp.entity.BootcampCategoryType;
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatApplicationCreateDto;
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatApplicationResponseDto;
@@ -60,12 +62,16 @@ public class CoffeeChatApplicationConcurrencyTest {
     void setUp() {
         menteeList = new ArrayList<>();
 
-        mentor = userRepository.save(User.builder()
-            .userName("테스트 멘토")
-            .email("mentor@example.com")
-            .resourceUserId("mentor")
-            .desiredCareer(BootcampCategoryType.APPLICATION_SW_ENGINEERING)
-            .build());
+        String mentorName = "test_mentor";
+        mentor = userRepository.findByUserName(mentorName)
+            .orElseGet(() -> userRepository.save(
+                User.builder()
+                    .userName(mentorName)
+                    .email(mentorName)
+                    .resourceUserId(mentorName)
+                    .desiredCareer(BootcampCategoryType.APPLICATION_SW_ENGINEERING)
+                    .build()
+            ));
 
         chatInfo = coffeeChatInfoRepository.save(CoffeeChatInfo.of(
             mentor,
@@ -75,21 +81,29 @@ public class CoffeeChatApplicationConcurrencyTest {
             "현업자 백엔드 멘토입니다."
         ));
 
-        for (int i = 0; i < THREAD_COUNT; i++){
+        for (int i = 0; i < THREAD_COUNT; i++) {
             String menteeName = "test_mentee" + (i + 1);
-            User mentee = userRepository.save(User.builder()
-                .userName(menteeName)
-                .email(menteeName)
-                .resourceUserId(menteeName)
-                .desiredCareer(BootcampCategoryType.APPLICATION_SW_ENGINEERING)
-                .build());
 
-            // 초기 포인트 적립
-            createPointHistoryService.createPointHistory(EventType.SIGN_UP, mentee.getUserId(), 5);
+            // 유저가 이미 있는지 확인
+            User mentee = userRepository.findByUserName(menteeName)
+                .orElseGet(() -> {
+                    // 없으면 새로 생성
+                    User newUser = userRepository.save(
+                        User.builder()
+                            .userName(menteeName)
+                            .email(menteeName)
+                            .resourceUserId(menteeName)
+                            .desiredCareer(BootcampCategoryType.APPLICATION_SW_ENGINEERING)
+                            .build());
+
+                    // 초기 포인트 적립
+                    createPointHistoryService.createPointHistory(EventType.SIGN_UP, newUser.getUserId(), 5);
+
+                    return newUser;
+                });
 
             menteeList.add(mentee);
         }
-
 
     }
 

--- a/boottalk/src/test/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatApplicationConcurrencyTest.java
+++ b/boottalk/src/test/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatApplicationConcurrencyTest.java
@@ -1,0 +1,167 @@
+package com.icandoit.boottalk.coffeeChat.service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.icandoit.boottalk.bootcamp.entity.BootcampCategoryType;
+import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatApplicationCreateDto;
+import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatApplicationResponseDto;
+import com.icandoit.boottalk.coffeeChat.entity.CoffeeChatInfo;
+import com.icandoit.boottalk.coffeeChat.entity.enums.JobType;
+import com.icandoit.boottalk.coffeeChat.entity.enums.MentorType;
+import com.icandoit.boottalk.coffeeChat.repository.CoffeeChatApplicationRepository;
+import com.icandoit.boottalk.coffeeChat.repository.CoffeeChatInfoRepository;
+import com.icandoit.boottalk.libs.exception.CustomException;
+import com.icandoit.boottalk.point_history.domain.type.EventType;
+import com.icandoit.boottalk.point_history.service.CreatePointHistoryService;
+import com.icandoit.boottalk.user.domain.entity.User;
+import com.icandoit.boottalk.user.domain.repository.UserRepository;
+
+
+@SpringBootTest
+public class CoffeeChatApplicationConcurrencyTest {
+
+    private final int THREAD_COUNT = 1000;
+    private final ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
+
+    @Autowired
+    private CoffeeChatApplicationService coffeeChatApplicationService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private CoffeeChatInfoRepository coffeeChatInfoRepository;
+
+    @Autowired
+    private CoffeeChatApplicationRepository coffeeChatApplicationRepository;
+
+    @Autowired
+    private CreatePointHistoryService createPointHistoryService;
+
+    private List<User> menteeList;
+    private User mentor;
+    private CoffeeChatInfo chatInfo;
+
+    @BeforeEach
+    void setUp() {
+        menteeList = new ArrayList<>();
+
+        mentor = userRepository.save(User.builder()
+            .userName("테스트 멘토")
+            .email("mentor@example.com")
+            .resourceUserId("mentor")
+            .desiredCareer(BootcampCategoryType.APPLICATION_SW_ENGINEERING)
+            .build());
+
+        chatInfo = coffeeChatInfoRepository.save(CoffeeChatInfo.of(
+            mentor,
+            mentor.getUserName(),
+            MentorType.PROFESSIONAL,
+            JobType.BACKEND,
+            "현업자 백엔드 멘토입니다."
+        ));
+
+        for (int i = 0; i < THREAD_COUNT; i++){
+            String menteeName = "test_mentee" + (i + 1);
+            User mentee = userRepository.save(User.builder()
+                .userName(menteeName)
+                .email(menteeName)
+                .resourceUserId(menteeName)
+                .desiredCareer(BootcampCategoryType.APPLICATION_SW_ENGINEERING)
+                .build());
+
+            // 초기 포인트 적립
+            createPointHistoryService.createPointHistory(EventType.SIGN_UP, mentee.getUserId(), 5);
+
+            menteeList.add(mentee);
+        }
+
+
+    }
+
+    @Test
+    @DisplayName("동일한 커피챗의 동일한 시간대에 여러 명이 신청 시, 1명만 신청 할 수 있음")
+    public void onlyOneUserCanApplyForSameTimeSlotInSameCoffeeChat() throws InterruptedException {
+
+        // 테스트 대상 요청 DTO 생성 (동일한 시간대에 대해 여러 명이 신청 시도)
+        CoffeeChatApplicationCreateDto request = new CoffeeChatApplicationCreateDto(
+            chatInfo.getCoffeeChatInfoId(),
+            "커피챗 신청합니다.",
+            LocalDateTime.of(2025, 4, 5, 10, 30),
+            LocalDateTime.of(2025, 4, 5, 11, 0)
+        );
+
+        // 모든 스레드가 작업을 완료할 떄 까지 기다리기 위한 CountDownLatch
+        CountDownLatch latch = new CountDownLatch(THREAD_COUNT);
+
+        // 각 스레드의 실행 결과(Future)를 담기 위한 리스트
+        // Future는 비동기 작업의 결과를 나중에 조회할 수 있도록 도와주는 객체
+        List<Future<CoffeeChatApplicationResponseDto>> futures = new ArrayList<>();
+
+        // THREAD_COUNT 수 만큼의 멘티가 동시에 같은 시간대의 커피챗을 신청 시도
+        for (int i = 0; i < THREAD_COUNT; i++) {
+            final int menteeNumber = i;
+
+            // submit() 은 작업 결과를 받을 수 있는 Fure 를 반환함
+            Future<CoffeeChatApplicationResponseDto> future = executorService.submit(() -> {
+                try {
+                    // 각 멘티가 커피챗 신청 시도
+                    return coffeeChatApplicationService.createCoffeeChatApp(
+                        menteeList.get(menteeNumber).getUserId(), request);
+                } finally {
+                    // 현재 스레드 완료 ->  latch 감소
+                    latch.countDown();
+                }
+            });
+            futures.add(future);
+        }
+
+        // 모든 스레드가 작업을 마칠 때까지 대기
+        latch.await();
+
+        int successCount = 0;
+        int failCount = 0;
+        // 각 스레드의 결과 확인
+        for (Future<CoffeeChatApplicationResponseDto> future: futures) {
+            try{
+                CoffeeChatApplicationResponseDto result = future.get();
+                System.out.println("신청 성공 : " + result);
+                successCount++;
+            }catch (ExecutionException e){
+                failCount++;
+                Throwable cause = e.getCause();
+                if (cause instanceof CustomException customEx) {
+                    System.out.println("신청 실패 : " + customEx.getErrorCode().name());
+                }
+            } catch (Exception e){
+                e.printStackTrace();
+             }
+        }
+
+        System.out.println("=== 최종 결과 ====");
+        System.out.println("성공 건수: " + successCount);
+        System.out.println("실패 건수: " + failCount);
+
+        Assertions.assertEquals(1, successCount); // 딱 한 명만 성공해야 함
+        Assertions.assertEquals(THREAD_COUNT - 1, failCount);
+
+
+    }
+
+
+
+}

--- a/boottalk/src/test/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatApplicationConcurrencyTest.java
+++ b/boottalk/src/test/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatApplicationConcurrencyTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.icandoit.boottalk.bootcamp.entity.BootcampCategoryType;
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatApplicationCreateDto;
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatApplicationResponseDto;
@@ -27,12 +26,17 @@ import com.icandoit.boottalk.coffeeChat.entity.enums.MentorType;
 import com.icandoit.boottalk.coffeeChat.repository.CoffeeChatApplicationRepository;
 import com.icandoit.boottalk.coffeeChat.repository.CoffeeChatInfoRepository;
 import com.icandoit.boottalk.libs.exception.CustomException;
+import com.icandoit.boottalk.point_history.domain.repository.PointHistoryRepository;
 import com.icandoit.boottalk.point_history.domain.type.EventType;
 import com.icandoit.boottalk.point_history.service.CreatePointHistoryService;
 import com.icandoit.boottalk.user.domain.entity.User;
 import com.icandoit.boottalk.user.domain.repository.UserRepository;
 
-
+/**
+ * *** 주의 ****
+ * 테스트 실행 후, @AfterEach를 통해 모든 데이터를 deleteALl()로 삭제합니다.
+ * 실제 데이터 손실을 방지하기 위해 반드시 **테스트 전용 DB**에서 실행하세요!!
+ */
 @SpringBootTest
 public class CoffeeChatApplicationConcurrencyTest {
 
@@ -50,6 +54,9 @@ public class CoffeeChatApplicationConcurrencyTest {
 
     @Autowired
     private CoffeeChatApplicationRepository coffeeChatApplicationRepository;
+
+    @Autowired
+    private PointHistoryRepository pointHistoryRepository;
 
     @Autowired
     private CreatePointHistoryService createPointHistoryService;
@@ -105,6 +112,14 @@ public class CoffeeChatApplicationConcurrencyTest {
             menteeList.add(mentee);
         }
 
+    }
+
+    @AfterEach
+    void cleanUp() {
+        coffeeChatApplicationRepository.deleteAll();
+        coffeeChatInfoRepository.deleteAll();
+        pointHistoryRepository.deleteAll();
+        userRepository.deleteAll();
     }
 
     @Test


### PR DESCRIPTION
## 🔍 주요 변경 사항
- 커피챗 신청 시, 다른 사용자(멘티)가 동일한 시간대에 중복 신청이 불가능하도록 기능 추가
- PESSIMISTIC_WRITE 락을 활용하여 동시성 제어 적용
- 중복 신청 시 CustomException이 발생하도록 구현
- 커피챗 신청 동시성 테스트 케이스 추가

> ⚠️ **테스트 실행 시 주의 사항**
> 테스트 클래스(CoffeeChatApplicationConcurrencyTest) 실행 후, `@AfterEach`에서 `deleteAll()`로 모든 데이터를 삭제합니다.  
> 반드시 **테스트 전용 DB**에서 실행해주세요!

---

## 💡 변경 이유
- 여러 사용자가 동일한 시간대에 커피챗을 동시에 신청할 경우, 하나의 신청만 허용되도록 하기 위함
- 실서비스 환경에서 발생할 수 있는 동시성 문제를 사전에 방지하고, 안정적인 예약 처리 로직을 확보하기 위함

---

## 🚀 개선 결과
- 커피챗 신청 기능에서 동일 시간대 중복 신청이 방지됨
- 실제 동시 요청 상황에서도 하나의 신청만 성공하는 안정적인 동작 확인
- 테스트 케이스 반복 실행 시에도 충돌 없이 일관된 결과 도출 가능

---

## 📂 관련 클래스 및 변경 파일


---

## ✅ 테스트 시나리오
**커피챗 신청 동시성 테스트**
-  테스트 구현 내용
    - ExecutorService, CountDownLatch, Future를 활용한 멀티스레드 환경 구성
    - 멘토/멘티 생성 시, DB에 해당 유저 정보가 이미 존재하는지 확인한 후 없을 경우에만 생성하도록 처리
    - 테스트를 반복 실행해도 중복 데이터로 인한 충돌이 발생하지 않도록 처리
- 테스트 검증 내용
    - 동일한 커피챗 시간대에 여러 명이 동시에 신청할 경우, 오직 1명만 신청에 성공하는지 확인
    - 신청 실패한 요청은 COFFEE_CHAT_APPLICATION_TIME_ALREADY_EXISTS 예외가 발생하는지 검증
    - 테스트 실행 결과를 통해 성공/실패 건수가 올바르게 카운트되는지 확인

---

## 🚀차후 고려할 개선 사항: **커피챗 재신청 정책**
관련 이슈 #55 

---

## 💡 참고 블로그



--- 

## 🖼️ 스크린샷



