### PR TITLE
Fix: 커피챗 신청 관련 수정 (현재 포인트 조회 코드 제거, 신청 삭제 -> 신청 취소로 수정) 

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatApplicationController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatApplicationController.java
@@ -74,13 +74,13 @@ public class CoffeeChatApplicationController {
             user.getServiceUserId(), coffeeChatAppId, request));
     }
 
-    // 커피챗 신청 삭제
+    // 커피챗 신청 취소
     @DeleteMapping("/{coffeeChatAppId}")
-    public ResponseEntity<Void> deleteCoffeeChatApp(
+    public ResponseEntity<Void> cancelCoffeeChatApp(
         @AuthenticationPrincipal CustomOAuth2User user,
         @PathVariable Long coffeeChatAppId
     ) {
-        coffeeChatAppService.deleteCoffeeChatApp(user.getServiceUserId(), coffeeChatAppId);
+        coffeeChatAppService.cancelCoffeeChatApp(user.getServiceUserId(), coffeeChatAppId);
         return ResponseEntity.ok().build();
     }
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/entity/enums/StatusType.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/entity/enums/StatusType.java
@@ -1,5 +1,9 @@
 package com.icandoit.boottalk.coffeeChat.entity.enums;
 
 public enum StatusType {
-    PENDING, APPROVED, REJECTED
+    PENDING,    // 대기 - 멘토가 아직 수락/거절하지 않은 상태
+    CANCELED,   // 취소 - 멘티가 신청을 취소한 상태
+    REJECTED,   // 거절 - 멘토가 신청을 거절한 상태
+    APPROVED,   // 수락 - 멘토가 신청을 수락한 상태
+    COMPLETED,  // 완료 - 커피챗 일정이 종료된 상태
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/repository/CoffeeChatApplicationRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/repository/CoffeeChatApplicationRepository.java
@@ -1,12 +1,17 @@
 package com.icandoit.boottalk.coffeeChat.repository;
 
 import com.icandoit.boottalk.coffeeChat.entity.CoffeeChatApplication;
-import java.util.List;
+
+import java.time.LocalDateTime;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import jakarta.persistence.LockModeType;
 
 public interface CoffeeChatApplicationRepository extends JpaRepository<CoffeeChatApplication, Long> {
 
@@ -23,4 +28,9 @@ public interface CoffeeChatApplicationRepository extends JpaRepository<CoffeeCha
 	Page<CoffeeChatApplication> findApprovedChatsByUserId(@Param("userId") Long userId, Pageable pageable);
 
 	boolean existsByMentee_UserIdAndCoffeeChatInfo_CoffeeChatInfoId(Long userId, Long coffeeChatInfoId);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	boolean existsByCoffeeChatInfo_CoffeeChatInfoIdAndCoffeeChatStartTime(
+		Long coffeeChatInfoId, LocalDateTime coffeeChatStartTime);
+
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatApplicationService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatApplicationService.java
@@ -66,15 +66,7 @@ public class CoffeeChatApplicationService {
 
         // 멘토 타입에 따른 커피챗 포인트 차감. 포인트 부족 시 커피챗 신청 실패 처리
         MentorType mentorType = coffeeChatInfo.getMentorType();
-        int currentPoint = createPointHistoryService.getCurrentPoint(userId);
         int deductionPoint = getPointCostByMentorType (mentorType);
-
-        log.info("userId: {}, mentorType: {}, currentPoint: {}, deductionPoint: {}",
-            userId, mentorType, currentPoint, deductionPoint);
-
-        if (currentPoint < deductionPoint) {
-            throw new CustomException(ErrorCode.INSUFFICIENT_POINT_FOR_CHAT);
-        }
 
 
         createPointHistoryService.createPointHistory(EventType.COFFEE_CHAT_APPLY, userId, deductionPoint);

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatApplicationService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatApplicationService.java
@@ -45,13 +45,24 @@ public class CoffeeChatApplicationService {
     @Transactional
     public CoffeeChatApplicationResponseDto createCoffeeChatApp(Long userId, CoffeeChatApplicationCreateDto request) {
 
-        if (coffeeChatAppRepository.existsByMentee_UserIdAndCoffeeChatInfo_CoffeeChatInfoId(
-            userId, request.coffeeChatInfoId())) {
+        Long coffeChatInfoId = request.coffeeChatInfoId();
+        
+        if (coffeeChatAppRepository.existsByMentee_UserIdAndCoffeeChatInfo_CoffeeChatInfoId(userId, coffeChatInfoId)) {
             throw new CustomException(ErrorCode.COFFEE_CHAT_APPLICATION_ALREADY_EXISTS);
         }
+        
+        log.debug("커피챗 신청 Lock : userId: {}", userId);
+        // 커피챗 신청 시, 해당 시간대의 커피챗에 다른 사용자가 신청 요청하지 못하도록 동시성 제어
+        if (coffeeChatAppRepository.existsByCoffeeChatInfo_CoffeeChatInfoIdAndCoffeeChatStartTime(
+            coffeChatInfoId, request.coffeeChatStartTime())
+        ) {
+            throw new CustomException(ErrorCode.COFFEE_CHAT_APPLICATION_TIME_ALREADY_EXISTS);
+        }
+        log.debug("커피챗 신청 Lock 해제 : userId: {}", userId);
+
 
         User user = getUser(userId);
-        CoffeeChatInfo coffeeChatInfo = getCoffeeChatInfo(request.coffeeChatInfoId());
+        CoffeeChatInfo coffeeChatInfo = getCoffeeChatInfo(coffeChatInfoId);
 
         // 멘토 타입에 따른 커피챗 포인트 차감. 포인트 부족 시 커피챗 신청 실패 처리
         MentorType mentorType = coffeeChatInfo.getMentorType();
@@ -70,8 +81,6 @@ public class CoffeeChatApplicationService {
 
         CoffeeChatApplication coffeeChatApp = CoffeeChatApplication.of(user, coffeeChatInfo, request);
         coffeeChatAppRepository.save(coffeeChatApp);
-
-        // TODO: 커피챗 신청 성공 시, 해당 시간대의 커피챗에 다른 사용자가 신청 요청하지 못하도록 동시성 제어 필요
 
         return CoffeeChatApplicationResponseDto.from(coffeeChatApp);
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatApplicationService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatApplicationService.java
@@ -122,13 +122,16 @@ public class CoffeeChatApplicationService {
     }
 
     @Transactional
-    public void deleteCoffeeChatApp(Long userId, Long coffeeChatAppId) {
+    public void cancelCoffeeChatApp(Long userId, Long coffeeChatAppId) {
         CoffeeChatApplication coffeeChatApp = getCoffeeChatApplication(coffeeChatAppId);
 
         validateCoffeeChatApplicant(userId, coffeeChatApp.getMentee().getUserId());
         validateCoffeeChatInfo(coffeeChatApp.getCoffeeChatInfo().getCoffeeChatInfoId());
 
-        coffeeChatAppRepository.delete(coffeeChatApp);
+        coffeeChatApp.setStatus(StatusType.CANCELED);
+        // TODO: 신청 취소에 관한 세부 정책 적용 필요
+
+
     }
 
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/libs/exception/ErrorCode.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/libs/exception/ErrorCode.java
@@ -13,7 +13,6 @@ public enum ErrorCode {
     INSUFFICIENT_POINT(400, "잔여 포인트가 부족합니다."),
     EXCEEDS_MAX_LENGTH(400, "최대 길이를 초과했습니다."),
     COFFEE_CHAT_STATUS_NOT_PENDING(400, "대기 중 상태가 아니므로 상태를 변경할 수 없습니다."),
-    INSUFFICIENT_POINT_FOR_CHAT(400, "커피챗을 신청 할 포인트가 부족합니다."),
 
     /* 401 UNAUTHORIZED */
     INVALID_TOKEN(401, "유효한 토큰이 아닙니다."),

--- a/boottalk/src/main/java/com/icandoit/boottalk/libs/exception/ErrorCode.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/libs/exception/ErrorCode.java
@@ -40,6 +40,7 @@ public enum ErrorCode {
     COFFEE_CHAT_ALREADY_EXISTS(409, "이미 생성된 커피챗이 있습니다."),
     ALREADY_CREATED_COFFEE_CHAT_TIME(409, "해당 유저의 커피챗 시간이 등록되어 있습니다."),
     COFFEE_CHAT_APPLICATION_ALREADY_EXISTS(409, "이미 해당 커피챗에 신청되었습니다."),
+    COFFEE_CHAT_APPLICATION_TIME_ALREADY_EXISTS(400, "이미 신청된 시간입니다."),
 
     /* 500 INTERNAL_SERVER_ERROR */
     INTERNAL_SERVER_ERROR(500, "서버 오류가 발생했습니다."),

--- a/boottalk/src/main/java/com/icandoit/boottalk/point_history/service/CreatePointHistoryService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/point_history/service/CreatePointHistoryService.java
@@ -12,17 +12,20 @@ import com.icandoit.boottalk.point_history.domain.type.EventType;
 import com.icandoit.boottalk.point_history.domain.type.PointType;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class CreatePointHistoryService {
 
 	private final PointHistoryRepository pointHistoryRepository;
 
 
 	public PointHistoryDto createPointHistory(EventType eventType, long userId, int changedPoint) {
-
 		int currentPoint = getCurrentPoint(userId);
+
+        log.info("eventType:{}, userId: {}, currentPoint: {}, changedPoint: {}", eventType, userId, currentPoint, changedPoint);
 
 		//포인트 사용
 		if (eventType.getPointType() == PointType.USED) {
@@ -48,7 +51,7 @@ public class CreatePointHistoryService {
 				.build()));
 	}
 
-	public int getCurrentPoint(long userId) {
+	private int getCurrentPoint(long userId) {
 
 		PointHistory pointHistory = pointHistoryRepository.findTopByUserIdOrderByPointHistoryIdDesc(userId)
 			.orElse(null);

--- a/boottalk/src/test/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatApplicationConcurrencyTest.java
+++ b/boottalk/src/test/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatApplicationConcurrencyTest.java
@@ -9,6 +9,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.icandoit.boottalk.bootcamp.entity.BootcampCategoryType;
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatApplicationCreateDto;
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatApplicationResponseDto;
@@ -60,12 +62,16 @@ public class CoffeeChatApplicationConcurrencyTest {
     void setUp() {
         menteeList = new ArrayList<>();
 
-        mentor = userRepository.save(User.builder()
-            .userName("테스트 멘토")
-            .email("mentor@example.com")
-            .resourceUserId("mentor")
-            .desiredCareer(BootcampCategoryType.APPLICATION_SW_ENGINEERING)
-            .build());
+        String mentorName = "test_mentor";
+        mentor = userRepository.findByUserName(mentorName)
+            .orElseGet(() -> userRepository.save(
+                User.builder()
+                    .userName(mentorName)
+                    .email(mentorName)
+                    .resourceUserId(mentorName)
+                    .desiredCareer(BootcampCategoryType.APPLICATION_SW_ENGINEERING)
+                    .build()
+            ));
 
         chatInfo = coffeeChatInfoRepository.save(CoffeeChatInfo.of(
             mentor,
@@ -75,21 +81,29 @@ public class CoffeeChatApplicationConcurrencyTest {
             "현업자 백엔드 멘토입니다."
         ));
 
-        for (int i = 0; i < THREAD_COUNT; i++){
+        for (int i = 0; i < THREAD_COUNT; i++) {
             String menteeName = "test_mentee" + (i + 1);
-            User mentee = userRepository.save(User.builder()
-                .userName(menteeName)
-                .email(menteeName)
-                .resourceUserId(menteeName)
-                .desiredCareer(BootcampCategoryType.APPLICATION_SW_ENGINEERING)
-                .build());
 
-            // 초기 포인트 적립
-            createPointHistoryService.createPointHistory(EventType.SIGN_UP, mentee.getUserId(), 5);
+            // 유저가 이미 있는지 확인
+            User mentee = userRepository.findByUserName(menteeName)
+                .orElseGet(() -> {
+                    // 없으면 새로 생성
+                    User newUser = userRepository.save(
+                        User.builder()
+                            .userName(menteeName)
+                            .email(menteeName)
+                            .resourceUserId(menteeName)
+                            .desiredCareer(BootcampCategoryType.APPLICATION_SW_ENGINEERING)
+                            .build());
+
+                    // 초기 포인트 적립
+                    createPointHistoryService.createPointHistory(EventType.SIGN_UP, newUser.getUserId(), 5);
+
+                    return newUser;
+                });
 
             menteeList.add(mentee);
         }
-
 
     }
 

--- a/boottalk/src/test/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatApplicationConcurrencyTest.java
+++ b/boottalk/src/test/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatApplicationConcurrencyTest.java
@@ -1,0 +1,167 @@
+package com.icandoit.boottalk.coffeeChat.service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.icandoit.boottalk.bootcamp.entity.BootcampCategoryType;
+import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatApplicationCreateDto;
+import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatApplicationResponseDto;
+import com.icandoit.boottalk.coffeeChat.entity.CoffeeChatInfo;
+import com.icandoit.boottalk.coffeeChat.entity.enums.JobType;
+import com.icandoit.boottalk.coffeeChat.entity.enums.MentorType;
+import com.icandoit.boottalk.coffeeChat.repository.CoffeeChatApplicationRepository;
+import com.icandoit.boottalk.coffeeChat.repository.CoffeeChatInfoRepository;
+import com.icandoit.boottalk.libs.exception.CustomException;
+import com.icandoit.boottalk.point_history.domain.type.EventType;
+import com.icandoit.boottalk.point_history.service.CreatePointHistoryService;
+import com.icandoit.boottalk.user.domain.entity.User;
+import com.icandoit.boottalk.user.domain.repository.UserRepository;
+
+
+@SpringBootTest
+public class CoffeeChatApplicationConcurrencyTest {
+
+    private final int THREAD_COUNT = 1000;
+    private final ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
+
+    @Autowired
+    private CoffeeChatApplicationService coffeeChatApplicationService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private CoffeeChatInfoRepository coffeeChatInfoRepository;
+
+    @Autowired
+    private CoffeeChatApplicationRepository coffeeChatApplicationRepository;
+
+    @Autowired
+    private CreatePointHistoryService createPointHistoryService;
+
+    private List<User> menteeList;
+    private User mentor;
+    private CoffeeChatInfo chatInfo;
+
+    @BeforeEach
+    void setUp() {
+        menteeList = new ArrayList<>();
+
+        mentor = userRepository.save(User.builder()
+            .userName("테스트 멘토")
+            .email("mentor@example.com")
+            .resourceUserId("mentor")
+            .desiredCareer(BootcampCategoryType.APPLICATION_SW_ENGINEERING)
+            .build());
+
+        chatInfo = coffeeChatInfoRepository.save(CoffeeChatInfo.of(
+            mentor,
+            mentor.getUserName(),
+            MentorType.PROFESSIONAL,
+            JobType.BACKEND,
+            "현업자 백엔드 멘토입니다."
+        ));
+
+        for (int i = 0; i < THREAD_COUNT; i++){
+            String menteeName = "test_mentee" + (i + 1);
+            User mentee = userRepository.save(User.builder()
+                .userName(menteeName)
+                .email(menteeName)
+                .resourceUserId(menteeName)
+                .desiredCareer(BootcampCategoryType.APPLICATION_SW_ENGINEERING)
+                .build());
+
+            // 초기 포인트 적립
+            createPointHistoryService.createPointHistory(EventType.SIGN_UP, mentee.getUserId(), 5);
+
+            menteeList.add(mentee);
+        }
+
+
+    }
+
+    @Test
+    @DisplayName("동일한 커피챗의 동일한 시간대에 여러 명이 신청 시, 1명만 신청 할 수 있음")
+    public void onlyOneUserCanApplyForSameTimeSlotInSameCoffeeChat() throws InterruptedException {
+
+        // 테스트 대상 요청 DTO 생성 (동일한 시간대에 대해 여러 명이 신청 시도)
+        CoffeeChatApplicationCreateDto request = new CoffeeChatApplicationCreateDto(
+            chatInfo.getCoffeeChatInfoId(),
+            "커피챗 신청합니다.",
+            LocalDateTime.of(2025, 4, 5, 10, 30),
+            LocalDateTime.of(2025, 4, 5, 11, 0)
+        );
+
+        // 모든 스레드가 작업을 완료할 떄 까지 기다리기 위한 CountDownLatch
+        CountDownLatch latch = new CountDownLatch(THREAD_COUNT);
+
+        // 각 스레드의 실행 결과(Future)를 담기 위한 리스트
+        // Future는 비동기 작업의 결과를 나중에 조회할 수 있도록 도와주는 객체
+        List<Future<CoffeeChatApplicationResponseDto>> futures = new ArrayList<>();
+
+        // THREAD_COUNT 수 만큼의 멘티가 동시에 같은 시간대의 커피챗을 신청 시도
+        for (int i = 0; i < THREAD_COUNT; i++) {
+            final int menteeNumber = i;
+
+            // submit() 은 작업 결과를 받을 수 있는 Fure 를 반환함
+            Future<CoffeeChatApplicationResponseDto> future = executorService.submit(() -> {
+                try {
+                    // 각 멘티가 커피챗 신청 시도
+                    return coffeeChatApplicationService.createCoffeeChatApp(
+                        menteeList.get(menteeNumber).getUserId(), request);
+                } finally {
+                    // 현재 스레드 완료 ->  latch 감소
+                    latch.countDown();
+                }
+            });
+            futures.add(future);
+        }
+
+        // 모든 스레드가 작업을 마칠 때까지 대기
+        latch.await();
+
+        int successCount = 0;
+        int failCount = 0;
+        // 각 스레드의 결과 확인
+        for (Future<CoffeeChatApplicationResponseDto> future: futures) {
+            try{
+                CoffeeChatApplicationResponseDto result = future.get();
+                System.out.println("신청 성공 : " + result);
+                successCount++;
+            }catch (ExecutionException e){
+                failCount++;
+                Throwable cause = e.getCause();
+                if (cause instanceof CustomException customEx) {
+                    System.out.println("신청 실패 : " + customEx.getErrorCode().name());
+                }
+            } catch (Exception e){
+                e.printStackTrace();
+             }
+        }
+
+        System.out.println("=== 최종 결과 ====");
+        System.out.println("성공 건수: " + successCount);
+        System.out.println("실패 건수: " + failCount);
+
+        Assertions.assertEquals(1, successCount); // 딱 한 명만 성공해야 함
+        Assertions.assertEquals(THREAD_COUNT - 1, failCount);
+
+
+    }
+
+
+
+}


### PR DESCRIPTION
## 🔍 주요 변경 사항
- 커피챗 신청 상태를 CANCELED, COMPLETED 추가하여 더 세분화 함
    - 커피챗 재신청 시, 신청 상태에 따라 다르게 처리되기 위함
- 커피챗 신청 내역을 DB에서 삭제하지 않고, 신청 상태를 취소(CANCELED)로 변경
- 커피챗 신청 메소드 안에 현재 포인트 불러오는 코드 삭제
   - 이미 CreatePointHistoryService.createPointHistory() 에 구현되어 있으므로, 중복되는 코드 삭제



