### PR TITLE
Feat: 커피챗 신청 상태별 신청 내역 및 시간 중복 예외 처리 기능 추가

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/repository/CoffeeChatApplicationRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/repository/CoffeeChatApplicationRepository.java
@@ -27,10 +27,34 @@ public interface CoffeeChatApplicationRepository extends JpaRepository<CoffeeCha
 """)
 	Page<CoffeeChatApplication> findApprovedChatsByUserId(@Param("userId") Long userId, Pageable pageable);
 
-	boolean existsByMentee_UserIdAndCoffeeChatInfo_CoffeeChatInfoId(Long userId, Long coffeeChatInfoId);
+	// 특정 유저가 해당 커피챗에 대해 이미 신청 중인 상태인지 확인
+	// (가장 최신 신청 상태가 대기 또는 수락인 경우 중복 신청으로 간주)
+	@Query("""
+		SELECT CASE WHEN COUNT(ca) > 0 THEN true ELSE false END
+		FROM CoffeeChatApplication ca
+		WHERE ca.mentee.userId = :userId
+		AND ca.coffeeChatInfo.coffeeChatInfoId = :coffeeChatInfoId
+		AND ca.status IN ('PENDING', 'APPROVED')
+		ORDER BY ca.id DESC LIMIT 1
+	""")
+	boolean existsLatestPendingOrApprovedApplication(
+		@Param("userId") Long userId,
+		@Param("coffeeChatInfoId") Long coffeeChatInfoId);
 
+	// 해당 시간대에 이미 다른 신청자가 대기 또는 수락 상태로 신청한 내역이 있는지 확인
+	// (중복 예약 방지를 위해 Lock 처리)
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
-	boolean existsByCoffeeChatInfo_CoffeeChatInfoIdAndCoffeeChatStartTime(
-		Long coffeeChatInfoId, LocalDateTime coffeeChatStartTime);
+	@Query("""
+		SELECT CASE WHEN COUNT(ca) > 0 THEN true ELSE false END
+		FROM CoffeeChatApplication ca
+		WHERE ca.coffeeChatInfo.coffeeChatInfoId = :coffeeChatInfoId
+		AND ca.coffeeChatStartTime = :coffeeChatStartTime
+		AND ca.status IN ('PENDING', 'APPROVED')
+	""")
+	boolean isTimeSlotAlreadyTaken(
+		@Param("coffeeChatInfoId") Long coffeeChatInfoId,
+		@Param("coffeeChatStartTime") LocalDateTime coffeeChatStartTime);
+
+	boolean existsByMentee_UserIdAndCoffeeChatInfo_CoffeeChatInfoId(Long userId, Long coffeeChatInfoId);
 
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatApplicationService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatApplicationService.java
@@ -46,20 +46,20 @@ public class CoffeeChatApplicationService {
     public CoffeeChatApplicationResponseDto createCoffeeChatApp(Long userId, CoffeeChatApplicationCreateDto request) {
 
         Long coffeChatInfoId = request.coffeeChatInfoId();
-        
-        if (coffeeChatAppRepository.existsByMentee_UserIdAndCoffeeChatInfo_CoffeeChatInfoId(userId, coffeChatInfoId)) {
+
+        // 해당 커피챗에 대해 대기 또는 수락 상태의 신청이 이미 존재하면 예외 처리 (중복 신청 방지)
+        if (coffeeChatAppRepository.existsLatestPendingOrApprovedApplication(userId, coffeChatInfoId)) {
             throw new CustomException(ErrorCode.COFFEE_CHAT_APPLICATION_ALREADY_EXISTS);
         }
-        
-        log.debug("커피챗 신청 Lock : userId: {}", userId);
-        // 커피챗 신청 시, 해당 시간대의 커피챗에 다른 사용자가 신청 요청하지 못하도록 동시성 제어
-        if (coffeeChatAppRepository.existsByCoffeeChatInfo_CoffeeChatInfoIdAndCoffeeChatStartTime(
-            coffeChatInfoId, request.coffeeChatStartTime())
-        ) {
+
+        log.debug("커피챗 신청 Lock 시작: userId: {}", userId);
+
+        // 동일 시간대에 다른 사용자의 커피챗 신청이 존재하면 예외 처리 (동시성 제어용 Lock 설정)
+        if (coffeeChatAppRepository.isTimeSlotAlreadyTaken(coffeChatInfoId, request.coffeeChatStartTime())) {
             throw new CustomException(ErrorCode.COFFEE_CHAT_APPLICATION_TIME_ALREADY_EXISTS);
         }
-        log.debug("커피챗 신청 Lock 해제 : userId: {}", userId);
 
+        log.debug("커피챗 신청 Lock 해제: userId: {}", userId);
 
         User user = getUser(userId);
         CoffeeChatInfo coffeeChatInfo = getCoffeeChatInfo(coffeChatInfoId);

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatReceivedService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatReceivedService.java
@@ -53,7 +53,6 @@ public class CoffeeChatReceivedService {
         Long mentoId = coffeeChatApp.getCoffeeChatInfo().getMentor().getUserId();
 
         validateCoffeeChatOwner(mentoId, userId);
-        validatePendingStatus(coffeeChatApp.getStatus());
 
         StatusType changeStatus = request.changeStatus();
         coffeeChatApp.setStatus(changeStatus); // 상태 변경
@@ -65,13 +64,6 @@ public class CoffeeChatReceivedService {
         }
         return CoffeeChatAppStatusResponseDto.from(coffeeChatApp);
 
-    }
-
-    // 커피챗 신청이 대기 중 상태가 아닐 경우 상태 요청 변경 방지
-    private void validatePendingStatus(StatusType currentStatus) {
-        if (currentStatus != StatusType.PENDING) {
-            throw new CustomException(ErrorCode.COFFEE_CHAT_STATUS_NOT_PENDING);
-        }
     }
 
     // 커피챗 정보의 작성자가 요청한 사용자와 일치하는지 확인


### PR DESCRIPTION
## 🔍 주요 변경 사항
- 멘티가 이미 신청한 커피챗의 최신 신청 상태가 `PENDING` 또는 `APPROVED`인 경우, 중복 신청 예외 처리 (`COFFEE_CHAT_APPLICATION_ALREADY_EXISTS`)
- 같은 커피챗 내 동일 시간대에 다른 사용자의 신청 상태가 `PENDING` 또는 `APPROVED`인 경우, 시간 중복 예외 처리 (`COFFEE_CHAT_APPLICATION_TIME_ALREADY_EXISTS`)


---

## 💡 변경 이유
- 동일 커피챗에 멘티가 중복 신청하지 않도록 제어할 필요가 있음
- 동일 시간대에 중복된 커피챗이 발생하지 않도록 동시성 제어 필요

---

## 🚀 개선 결과
- 멘티가 `PENDING` 또는 `APPROVED` 상태로 이미 신청한 커피챗에 대해 다시 신청하는 것을 방지할 수 있음
- 동일 시간대에 다른 사용자의 커피챗 신청 상태가 `PENDING` 또는 `APPROVED`일 경우, 신청 불가하도록 제어할 수 있음

---
### ✅ PENDING / APPROVED 상태일 때 중복 신청을 예외 처리하는 이유

- `PENDING` (대기): 멘토가 아직 응답하지 않은 상태에서 또 신청하는 것은 중복으로 간주될 수 있습니다.  
  따라서 멘티가 기존 신청을 취소한 뒤 다시 신청하도록 유도하는 것이 서비스 정책상 더 적절하다고 보았습니다.

- `APPROVED` (수락): 커피챗이 이미 수락된 상태에서 동일한 커피챗에 또 신청하는 것은 중복된 신청으로 이어질 수 있어, 이를 제한합니다.

&nbsp;&nbsp;


### ☑️ 그 외 상태 (`CANCELED`, `REJECTED`, `COMPLETED`)는 중복 허용

- `CANCELED` (취소): 멘티가 자발적으로 취소한 경우로, 다시 신청하는 것은 자연스러운 시도로 볼 수 있습니다.
- `REJECTED` (거절): 멘토가 거절했지만, 이후에 상황이 바뀌어 다시 신청하는 것은 허용 가능합니다.
- `COMPLETED` (완료): 이미 진행된 커피챗이 만족스러웠다면, 같은 멘토에게 다시 신청하고 싶을 수 있습니다.

&nbsp;

이러한 상태별 정책을 반영하여, **중복 신청 예외 처리 로직을 상태 기준으로 세분화**하였습니다.

---


## ✅ 테스트 시나리오

### ☕ 커피챗 신청 조건별 예외 및  성공 시나리오 (API 테스트로 진행)

**본인 신청 이력 관련**
- [X] 신청 요청한 커피챗에 이전 신청 내역 없음 -> 신청 가능
- [X] 신청 요청한 커피챗에 이전 신청 상태가 REJECTED/CANCELED/COMPLETED -> 신청 가능
- [X] 신청 요청한 커피챗에 이전 신청 상태가 PENDING/APPROVED -> 중복 예외 ("이미 해당 커피챗에 신청되었습니다.")

**동일 시간대 타인 신청 관련**
- [X] 신청 요청한 커피챗에 다른 사용자가 같은 시간대 REJECTED/CANCELED/COMPLETED 상태 -> 신청 가능
- [X] 신청 요청한 커피챗에 다른 사용자가 같은 시간대 PENDING/APPROVED 상태 -> 시간 중복 예외 ("이미 신청된 시간입니다.")


Closes #55
