### PR TITLE
feat : 리뷰 컨트롤러 인증(authorization) 추가

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/review/controller/ReviewController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/review/controller/ReviewController.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -20,6 +21,7 @@ import com.icandoit.boottalk.review.dto.ReviewCreateRequestDto;
 import com.icandoit.boottalk.review.dto.ReviewResponseDto;
 import com.icandoit.boottalk.review.dto.ReviewUpdateRequestDto;
 import com.icandoit.boottalk.review.service.ReviewService;
+import com.icandoit.boottalk.social_login.dto.CustomOAuth2User;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -33,8 +35,12 @@ public class ReviewController {
 
 	// 리뷰 등록
 	@PostMapping
-	public ResponseEntity<ReviewResponseDto> createReview(@RequestBody @Valid ReviewCreateRequestDto request) {
-		Long userId = 1L; // test
+	public ResponseEntity<ReviewResponseDto> createReview(
+		@AuthenticationPrincipal CustomOAuth2User user,
+		@RequestBody @Valid ReviewCreateRequestDto request) {
+
+		Long userId = user.getServiceUserId();
+
 		return ResponseEntity.ok(reviewService.createReview(request, userId));
 	}
 
@@ -59,10 +65,11 @@ public class ReviewController {
 	// 내 리뷰 목록
 	@GetMapping("/my")
 	public ResponseEntity<PagedResponseDto<ReviewResponseDto>> getMyReviews(
+		@AuthenticationPrincipal CustomOAuth2User user,
 		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "10") int size
 	) {
-		Long userId = 1L; // 테스트용
+		Long userId = user.getServiceUserId();
 		Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
 		Page<ReviewResponseDto> reviewPage = reviewService.getMyReviews(userId, pageable);
 
@@ -71,17 +78,22 @@ public class ReviewController {
 
 	// 내 리뷰 수정
 	@PutMapping("/my/{reviewId}")
-	public ResponseEntity<ReviewResponseDto> updateReview(@PathVariable Long reviewId,
+	public ResponseEntity<ReviewResponseDto> updateReview(
+		@AuthenticationPrincipal CustomOAuth2User user,
+		@PathVariable Long reviewId,
 		@RequestBody @Valid ReviewUpdateRequestDto request) {
-		Long userId = 1L; // test
-		return ResponseEntity.ok(reviewService.updateReview(request, reviewId, userId));
 
+		Long userId = user.getServiceUserId();
+
+		return ResponseEntity.ok(reviewService.updateReview(request, reviewId, userId));
 	}
 
 	// 내 리뷰 삭제
 	@DeleteMapping("/my/{reviewId}")
-	public ResponseEntity<Void> deleteReview(@PathVariable Long reviewId) {
-		Long userId = 1L; // test
+	public ResponseEntity<Void> deleteReview(
+		@AuthenticationPrincipal CustomOAuth2User user,
+		@PathVariable Long reviewId) {
+		Long userId = user.getServiceUserId();
 		reviewService.deleteReview(reviewId, userId);
 		return ResponseEntity.ok().build();
 	}


### PR DESCRIPTION
## 🔍 주요 변경 사항
- 기존 리뷰 컨트롤러에 @AuthenticationPrincipal 애노테이션을 활용하여 인증된 사용자 정보(CustomOAuth2User)를 주입하도록 수정.
- 전체 리뷰 조회 API는 인증 없이 접근할 수 있도록 유지하였음.

## 💡 변경 이유
- 리뷰 작성 및 수정/삭제 API에 인증/인가 처리가 누락되어 있던 보안 취약점을 보완하기 위함.
- 인증된 사용자 정보가 포함되면, 사용자의 본인 리뷰에 대한 수정/삭제 등 향후 기능 확장이 용이해짐.

## 🚀 개선 결과
- 인증되지 않은 사용자의 접근이 차단되어 리뷰 작성/수정/삭제 기능에 보안이 강화됨.
- 모든 리뷰 관련 API 호출 시, 현재 로그인한 사용자의 정보가 컨트롤러에 주입되어, 사용자의 권한 확인 및 추후 사용자 기반 리뷰 관리 기능 확장이 가능해짐.

## 📂 관련 파일 및 클래스
- **Controller:**  
  - `ReviewController.java`