### PR TITLE
Feat/내 알림 조회, 알림 확인 처리 기능 구현

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/libs/exception/ErrorCode.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/libs/exception/ErrorCode.java
@@ -38,9 +38,13 @@ public enum ErrorCode {
     /* 409 Conflict */
     COFFEE_CHAT_ALREADY_EXISTS(409, "이미 생성된 커피챗이 있습니다."),
 
+    /* SERVICE_UNAVAILABLE */
+    SSE_CONNECTION_FAILED(503, "SSE 연결 오류가 발생하였습니다."),
+
     /* 500 INTERNAL_SERVER_ERROR */
     INTERNAL_SERVER_ERROR(500, "서버 오류가 발생했습니다."),
     TOKEN_PARSING_ERROR(500, "토큰 파싱 과정에서 오류가 발생했습니다.");
+
 
     private final Integer httpStatus;
     private final String message;

--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/controller/NotificationController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/controller/NotificationController.java
@@ -1,0 +1,55 @@
+package com.icandoit.boottalk.notification.controller;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.icandoit.boottalk.notification.dto.NotificationResponseDto;
+import com.icandoit.boottalk.notification.service.NotificationService;
+import com.icandoit.boottalk.social_login.dto.CustomOAuth2User;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notifications")
+public class NotificationController {
+
+	private final NotificationService notificationService;
+
+	//sse 연결
+	@PostMapping(value = "/sse-connect", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+	public SseEmitter connect(@AuthenticationPrincipal CustomOAuth2User user,
+		@RequestHeader(value = "Last-Event-ID", required = false) String lastEventId) {
+
+		return notificationService.connect(user.getServiceUserId(), lastEventId);
+	}
+
+	//알림 조회창 열었을 때 조회될 알림들 반환
+	@GetMapping
+	public ResponseEntity<List<NotificationResponseDto>> getNotifications(
+		@AuthenticationPrincipal CustomOAuth2User user
+	) {
+		return ResponseEntity.ok(notificationService.getNotifications(user.getServiceUserId()));
+	}
+
+	//알림 조회창이 닫힐 시에 조회된 모든 알림들을 확인 처리함.
+	@PatchMapping
+	public ResponseEntity<String> checkedNotification(
+		@AuthenticationPrincipal CustomOAuth2User user,
+		@RequestParam LocalDateTime time) {
+		notificationService.checkedNotification(user.getServiceUserId(), time);
+		return ResponseEntity.ok("알림을 확인하였습니다.");
+	}
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/controller/NotificationController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/controller/NotificationController.java
@@ -1,7 +1,6 @@
 package com.icandoit.boottalk.notification.controller;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -15,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import com.icandoit.boottalk.notification.dto.NotificationResponseDto;
+import com.icandoit.boottalk.notification.dto.AllNotificationResponseDto;
 import com.icandoit.boottalk.notification.service.NotificationService;
 import com.icandoit.boottalk.social_login.dto.CustomOAuth2User;
 
@@ -36,9 +35,9 @@ public class NotificationController {
 		return notificationService.connect(user.getServiceUserId(), lastEventId);
 	}
 
-	//알림 조회창 열었을 때 조회될 알림들 반환
+	//알림 조회창 열었을 때 사용자 알림 반환
 	@GetMapping
-	public ResponseEntity<List<NotificationResponseDto>> getNotifications(
+	public ResponseEntity<AllNotificationResponseDto> getNotifications(
 		@AuthenticationPrincipal CustomOAuth2User user
 	) {
 		return ResponseEntity.ok(notificationService.getNotifications(user.getServiceUserId()));
@@ -49,7 +48,8 @@ public class NotificationController {
 	public ResponseEntity<String> checkedNotification(
 		@AuthenticationPrincipal CustomOAuth2User user,
 		@RequestParam LocalDateTime time) {
-		notificationService.checkedNotification(user.getServiceUserId(), time);
+		notificationService.checkedAllNotification(user.getServiceUserId(), time);
 		return ResponseEntity.ok("알림을 확인하였습니다.");
 	}
+
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/dto/AllNotificationResponseDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/dto/AllNotificationResponseDto.java
@@ -11,12 +11,7 @@ public record AllNotificationResponseDto(
 ) {
 	public static AllNotificationResponseDto from(
 		List<NotificationResponseDto> notificationList) {
-		int count = 0;
-		for (NotificationResponseDto notificationResponseDto : notificationList) {
-			if (!notificationResponseDto.checked()) {
-				count += 1;
-			}
-		}
+		int count = (int)notificationList.stream().filter(n -> !n.checked()).count();
 		return AllNotificationResponseDto.builder()
 			.notificationResponseDtoList(notificationList)
 			.uncheckedCount(count).build();

--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/dto/AllNotificationResponseDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/dto/AllNotificationResponseDto.java
@@ -1,0 +1,24 @@
+package com.icandoit.boottalk.notification.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+
+@Builder
+public record AllNotificationResponseDto(
+	List<NotificationResponseDto> notificationResponseDtoList,
+	int uncheckedCount
+) {
+	public static AllNotificationResponseDto from(
+		List<NotificationResponseDto> notificationList) {
+		int count = 0;
+		for (NotificationResponseDto notificationResponseDto : notificationList) {
+			if (!notificationResponseDto.checked()) {
+				count += 1;
+			}
+		}
+		return AllNotificationResponseDto.builder()
+			.notificationResponseDtoList(notificationList)
+			.uncheckedCount(count).build();
+	}
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/entity/Notification.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/entity/Notification.java
@@ -1,9 +1,5 @@
 package com.icandoit.boottalk.notification.entity;
 
-import java.sql.Timestamp;
-
-import org.springframework.data.annotation.CreatedDate;
-
 import com.icandoit.boottalk.libs.entity.BaseEntity;
 import com.icandoit.boottalk.notification.dto.NotificationRequestDto;
 import com.icandoit.boottalk.notification.type.NotificationType;

--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/entity/Notification.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/entity/Notification.java
@@ -15,6 +15,8 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -25,6 +27,11 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
+@Table(
+	indexes = {
+		@Index(name = "idx_userId", columnList = "userId")
+	}
+)
 public class Notification extends BaseEntity {
 
 	@Id
@@ -34,10 +41,13 @@ public class Notification extends BaseEntity {
 	long userId;
 
 	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
 	NotificationType type;
 
+	@Column(nullable = false)
 	String message;
 
+	@Column(nullable = false)
 	String url;
 
 	boolean checked;

--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/repository/NotificationRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/repository/NotificationRepository.java
@@ -13,8 +13,8 @@ import com.icandoit.boottalk.notification.entity.Notification;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
-	@Query("SELECT n FROM Notification n WHERE n.userId = :userId ORDER BY n.createdAt DESC LIMIT 20")
-	List<Notification> findUncheckedNotificationByUserId(@Param("userId") long userId);
+	@Query("SELECT n FROM Notification n WHERE n.userId = :userId ORDER BY n.createdAt DESC LIMIT 10")
+	List<Notification> findAllNotificationByUserId(@Param("userId") long userId);
 
 	@Query("SELECT n FROM Notification n WHERE n.userId = :userId AND n.createdAt > :time")
 	List<Notification> findByMissedNotifications(@Param("userId")long userId, @Param("time") LocalDateTime time);

--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/repository/NotificationRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/repository/NotificationRepository.java
@@ -1,8 +1,28 @@
 package com.icandoit.boottalk.notification.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.icandoit.boottalk.notification.entity.Notification;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+	@Query("SELECT n FROM Notification n WHERE n.userId = :userId ORDER BY n.createdAt DESC LIMIT 20")
+	List<Notification> findUncheckedNotificationByUserId(@Param("userId") long userId);
+
+	@Query("SELECT n FROM Notification n WHERE n.userId = :userId AND n.createdAt > :time")
+	List<Notification> findByMissedNotifications(@Param("userId")long userId, @Param("time") LocalDateTime time);
+
+
+	@Modifying
+	@Transactional
+	@Query("UPDATE Notification n SET n.checked = true " +
+		"WHERE n.userId = :userId AND n.checked = false AND n.createdAt < :time")
+	int checkedAllNotification(@Param("userId") long userId, @Param("time") LocalDateTime time);
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/service/NotificationService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/service/NotificationService.java
@@ -1,5 +1,9 @@
 package com.icandoit.boottalk.notification.service;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -7,24 +11,64 @@ import com.icandoit.boottalk.notification.dto.NotificationRequestDto;
 import com.icandoit.boottalk.notification.dto.NotificationResponseDto;
 import com.icandoit.boottalk.notification.entity.Notification;
 import com.icandoit.boottalk.notification.repository.NotificationRepository;
+import com.icandoit.boottalk.notification.util.DateTimeFormatterUtil;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class NotificationService {
 
 	private final NotificationRepository notificationRepository;
+	private final DateTimeFormatterUtil dateTimeFormatterUtil;
 	private final SseEmitterService emitterService;
 
 
+	//SSE 연결
+	public SseEmitter connect(long userId, String lastEventId) {
+
+		SseEmitter sseEmitter = emitterService.subscribe(userId);
+
+		//SSE 연결이 비정상적으로 종료되었을 때 lastEventId를 통해 놓친 알림 전송
+		//lastEventId 이후에 온 알림이 있다면 해당 알림을 다시 실시간으로 전송
+		if (lastEventId != null) {
+			List<Notification> notifications = notificationRepository.findByMissedNotifications(
+				userId, dateTimeFormatterUtil.parseTime(lastEventId));
+			if (!notifications.isEmpty()) {
+				for (Notification notification : notifications) {
+					emitterService.sendToClient(userId, NotificationResponseDto.from(notification));
+				}
+			}
+		}
+
+		return sseEmitter;
+	}
+
+
 	// 알림을 저장하고 알림 대상자에게 전송
-	public NotificationResponseDto sendNotification(long userId, NotificationRequestDto requestDto) {
+	public NotificationResponseDto sendLiveNotification(long userId, NotificationRequestDto requestDto) {
 		NotificationResponseDto responseDto = NotificationResponseDto
 			.from(notificationRepository.save(Notification.of(userId, requestDto)));
 
 		emitterService.sendToClient(userId, responseDto);
 
 		return responseDto;
+	}
+
+	// 알림조회창에 들어갈 알림 조회
+	public List<NotificationResponseDto> getNotifications(long userId) {
+		return notificationRepository.findUncheckedNotificationByUserId(userId)
+			.stream().map(NotificationResponseDto::from).collect(Collectors.toList());
+	}
+
+
+	// 일괄 확인 처리
+	// 확인한 알림 중에서 가장 최신 알림의 생성일자를 받아와 해당 일자 이전인 알림만 확인 처리
+	// 아니면 알림창을 닫을 때의 시간 데이터를 가져와서 처리
+	public void checkedNotification(long userId, LocalDateTime time) {
+		int checkedCount = notificationRepository.checkedAllNotification(userId, time);
+		log.debug("확인 처리된 알림 개수 : {}", checkedCount);
 	}
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/service/NotificationService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/service/NotificationService.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import com.icandoit.boottalk.notification.dto.AllNotificationResponseDto;
 import com.icandoit.boottalk.notification.dto.NotificationRequestDto;
 import com.icandoit.boottalk.notification.dto.NotificationResponseDto;
 import com.icandoit.boottalk.notification.entity.Notification;
@@ -57,17 +58,17 @@ public class NotificationService {
 		return responseDto;
 	}
 
-	// 알림조회창에 들어갈 알림 조회
-	public List<NotificationResponseDto> getNotifications(long userId) {
-		return notificationRepository.findUncheckedNotificationByUserId(userId)
-			.stream().map(NotificationResponseDto::from).collect(Collectors.toList());
+	// 알림조회창에 들어갈 알림내역과 확인하지 않은 알림 개수 반환
+	public AllNotificationResponseDto getNotifications(long userId) {
+		return AllNotificationResponseDto.from(notificationRepository.findAllNotificationByUserId(userId)
+			.stream().map(NotificationResponseDto::from).collect(Collectors.toList()));
 	}
 
 
 	// 일괄 확인 처리
 	// 확인한 알림 중에서 가장 최신 알림의 생성일자를 받아와 해당 일자 이전인 알림만 확인 처리
 	// 아니면 알림창을 닫을 때의 시간 데이터를 가져와서 처리
-	public void checkedNotification(long userId, LocalDateTime time) {
+	public void checkedAllNotification(long userId, LocalDateTime time) {
 		int checkedCount = notificationRepository.checkedAllNotification(userId, time);
 		log.debug("확인 처리된 알림 개수 : {}", checkedCount);
 	}

--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/service/SseEmitterService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/service/SseEmitterService.java
@@ -1,16 +1,19 @@
 package com.icandoit.boottalk.notification.service;
 
+import static com.icandoit.boottalk.libs.exception.ErrorCode.*;
+
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.Map;
 
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import com.icandoit.boottalk.notification.dto.NotificationRequestDto;
+import com.icandoit.boottalk.libs.exception.CustomException;
 import com.icandoit.boottalk.notification.dto.NotificationResponseDto;
-import com.icandoit.boottalk.notification.repository.NotificationRepository;
 import com.icandoit.boottalk.notification.repository.SseEmitterRepository;
+import com.icandoit.boottalk.notification.util.DateTimeFormatterUtil;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,7 +27,9 @@ public class SseEmitterService {
 	private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 60;
 
 	private final SseEmitterRepository emitterRepository;
-	private final NotificationRepository notificationRepository;
+
+	//SSE eventId를 LocalDateTime 으로 설정하기 위한 포맷
+	private final DateTimeFormatterUtil dateTimeFormatter;
 
 	// 클라이언트와 연결을 생성하는 메서드
 	public SseEmitter subscribe(long userId) {
@@ -41,8 +46,8 @@ public class SseEmitterService {
 		return sseEmitter;
 	}
 
-	// 연결을 유지하기 위한 하트비트
-	// TODO 주기적으로 동작할 수 있게끔
+	// 클라이언트들의 연결을 유지하기 위한 하트비트 1분마다 전송
+	@Scheduled(fixedRate = 60 * 1000)
 	private void sendHeartbeats() {
 		emitterRepository.getEmitters().forEach((userId, emitter) -> {
 			try {
@@ -53,6 +58,7 @@ public class SseEmitterService {
 				log.debug("하트비트 전송 성공: 사용자 Id: {}", userId);
 			} catch (IOException e) {
 				log.error("하트비트 전송 실패: 사용자 Id: {}, 원인: {}", userId, e.getMessage());
+				throw new CustomException(SSE_CONNECTION_FAILED);
 			}
 		});
 	}
@@ -62,7 +68,6 @@ public class SseEmitterService {
 		SseEmitter sseEmitter = emitterRepository.findById(userId)
 			.orElse(null);
 		//알림을 보낼 대상이 현재 연결이되지 않은 경우
-		//TODO 추후에 대상이 다시 연결되었을 때 못받은 알림부터 받을 수 있도록 해야 함.
 		if (sseEmitter == null) {
 			log.info("알림 대상자 SSE 연결 비활성: 대상자 Id : {}", userId);
 			return;
@@ -70,12 +75,13 @@ public class SseEmitterService {
 		try {
 			sseEmitter.send(
 				SseEmitter.event()
-					.id(userId.toString()) //TODO 잠깐 연결이 끊어졌을때 해당 Id를 기준으로 못받은 알림이 있는 지 확인.
+					.id(dateTimeFormatter.formatTime(notification.createdAt())) //잠깐 연결이 끊어졌을때 해당 Id를 기준으로 못받은 알림이 있는 지 확인.
 					.name("notification") //이벤트 타입을 지정 클라이언트 측에서 해당 이벤트 타입에 따라 처리 가능
 					.data(notification)
 			);
 		} catch (IOException e) {
 			log.error("SSE 알림 전송 실패: 대상자 Id: {}, 원인: {}", userId, e.getMessage());
+			throw new CustomException(SSE_CONNECTION_FAILED);
 		}
 	}
 
@@ -83,7 +89,7 @@ public class SseEmitterService {
 		try {
 			emitter.send(
 				SseEmitter.event()
-					.id("connect_" + userId)
+					.id(dateTimeFormatter.formatTime(LocalDateTime.now()))
 					.name("connect")
 					.data(Map.of(
 						"message", "SSE 연결 성공",
@@ -94,7 +100,7 @@ public class SseEmitterService {
 			log.info("SSE 연결 성공: 사용자 Id: {}", userId);
 		} catch (IOException e) {
 			log.error("SSE 연결 실패: 사용자 Id: {}, 원인: {}", userId, e.getMessage());
+			throw new CustomException(SSE_CONNECTION_FAILED);
 		}
 	}
-
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/util/DateTimeFormatterUtil.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/util/DateTimeFormatterUtil.java
@@ -1,0 +1,29 @@
+package com.icandoit.boottalk.notification.util;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class DateTimeFormatterUtil {
+
+	private final java.time.format.DateTimeFormatter dateTimeFormatter = java.time.format.DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSSSSS");
+
+	public String formatTime(LocalDateTime localDateTime) {
+		return localDateTime.format(dateTimeFormatter);
+	}
+
+	public LocalDateTime parseTime(String eventId) {
+		try {
+			return LocalDateTime.parse(eventId, dateTimeFormatter);
+		} catch (DateTimeParseException e) {
+			log.error("유효하지 않은 이벤트 ID: {}", eventId);
+			return LocalDateTime.now().minusSeconds(10);
+			// 파싱에러가 생겼을 때는 현재 시간 10초전을 기준으로 놓친알림을 탐색할 수 있도록 함.
+		}
+	}
+}


### PR DESCRIPTION
## 🔍 주요 변경 사항
- 알림 기능 요청을 처리하기 위한 `NotificationController` 생성 
  -  "`/api/notification"` api 요청이 들어왔을 경우 각 메서드(POST, GET, PATCH)에 따라 처리
  - `@AuthenticationPrincipal` 를 통해 인증된 사용자의 정보를 가져올 수 있도록 함. 
  - `connect` 메서드의 `@RequestHeader(value = "Last-Event-ID", required = false) String lastEventId` 는 연결이 비정상적으로 끊겨 연결을 재시도 할 때 클라이언트에서 마지막으로 받은 알림 Id를 해당 헤더값으로 전달해주기 때문에 추가. 정상적으로 종료되고 연결되는 경우에는 값이 없을 수도 있기 때문에 required = false로 설정
- `NotificationService`
  - `connect` 메서드를 통해 sse 연결을 시도. 만약 연결이 비정상적으로 종료되어 재시도 하는 경우 Last-Event-ID 값을 전달받음. 이때 해당 ID 이후에 온 알림이 있다면 실시간 전송.
  - `getNotifications` 를 통해 나(사용자)에게 온 지난 알림 내역들과 확인하지 않은 알림 개수를 확인 가능.  
  - `checkedNotification` 메서드를 통해 최근 알림 포함 이전 알림내역들을 일괄적으로 확인 처리 (checked(false) -> (true))
- `NotificationRepository`
  - `findUncheckedNotificationByUserId` 를 통해 지난 알림 내역들 최근순으로 최대 20개로 가져옴
    - 알림창을 눌렀을 때 읽지 않은 알림 뿐만 아니라 지난 알림들도 조회될 수 있도록 하기 위해.  (보통 다른 서비스들도 알림창을 확인했을 때 확인한 알림들도 확인할 수 있도록 함.)
    - TODO : UncheckedNotification 이름 수정 필요
  - `findByMissedNotifications` 를 통해 받아온 Last-Event-ID 를 기준으로 나중에 생성된 알림들이 있다면 즉, 잠시 연결이 끊어졌을 때 놓친 알림들이 있다면 가져옴 ( => 서비스를 재접속했을 때 그동안 쌓인 알림이 아님). 
    - 이 때 받아온 Last-Event-ID 는 포맷터를 통해 LocalDateTime 타입으로 변환.
  - `checkedAllNotification` 를 통해 알림들을 일괄적으로 확인 처리
    - 알림창을 확인하고 닫을 때 가장 최근에 온 알림의 생성시간 데이터를 받아서 해당 시간을 기준으로 이전 알림들을 일괄적으로 확인 처리
    - 쿼리문으로 처리하는 이유는 서비스레이어에서 처리하는 경우 로우 1개를 확인처리하고 DB에 다시 update -> DB접근이 update때마다 이루어짐. 그러나 쿼리문으로 실행시 단 한번 DB 접근으로 데이터 처리 가능.
- `Notification`
  - `userId`를 기준으로 탐색하는 경우가 많기 때문에 해당 속성에 인덱스를 걸어 성능 향상 기대
  - `@Column `어노테이션을 추가하여 null 값 방지
- `DateTimeFormatterUtil`
  - 알림을 전송할 때 알림 Id 값을 알림이 생성된 시간으로 하기 위해 LocalDateTime 타입을 문자열로 변환해주고 알림 Id 값을 다시 LocalDateTime 형식으로 변환해주는 클래스 생성 
- SseEmitterService의 `sendHeartBeat` 스케쥴러로 관리
  - 클라이언트에 일정시간동안 데이터를 보내지 않으면 연결이 끊기는 것을 방지.
  - 생성된 sseEmitter 들을 통해 연결된 클라이언트들에게 주기적으로 더미데이터를 전송하기 위해 스케쥴러로 관리
---

## 💡 변경 이유

- 알림 기능 보완, 성능 향상 기대

---

## 🚀 개선 결과



---

## 📂 관련 클래스 및 변경 파일
- NotificationController
- NotificationService
- NotificationRepository
- Notification
- SseEmitterService
- AllNotificationResponseDto
---

## ✅ 테스트 시나리오(예정) 
- 사용자가 서비스에 로그인 후 서버와 연결되어 서버에서 알림을 실시간으로 받을 수 있는 상태가 됨. (이 때 비정상적으로 종료된 연결에 대하여 연결을 재시도하는 것이 아니기 때문에 Last-Event-ID는 null)
- 알림창을 열면 받은 알림 내역을 최근 순으로 최대 20개까지 확인 가능 
- 알림을 누르면 해당 알림에 해당하는 페이지로 이동 가능 (알림 내역 반환시 알림데이터에 url도 함께 전달됨)
- 알림창을 닫을 때 가장 최근에 왔던 알림을 기준으로 이전 알림들은 다 확인 처리됨.
- 오류로 인해 잠시 sse 연결이 끊어졌다가 다시 연결되는 경우 클라이언트 측에서 최근에 받은 알림 Id를 헤더에 담아서 전달하며 다시 재연결 시도 -> sse connect 요청됨
- 헤더로 받은 알림 id를 DateTimeFormatterUtil을 이용해서 LocalDateTime 형식으로 변환후 해당 시간 이후 온 알림, 즉 연결 중단으로 인해 놓친 알림들을 다시 실시간 전송 (NotifiactionService.connect() 메소드 실행) 
---

## 💡 참고 블로그



--- 

## 🖼️ 스크린샷
- 알림 조회
![image](https://github.com/user-attachments/assets/7005d181-9d0f-4c9f-a017-17d50e977649)- 알림 확인 처리
![image](https://github.com/user-attachments/assets/124f1f53-194d-421a-866b-993ad95eee7d)
![image](https://github.com/user-attachments/assets/0481c359-41eb-48ab-862b-4ba5b25164f9)
- HeartBeat 
![image](https://github.com/user-attachments/assets/0c7b9728-645f-41c0-8b6d-4abb10121468)
- 비정상적으로 연결이 끊어졌을 때 
![image](https://github.com/user-attachments/assets/d5187a20-f1d4-47c4-9e5a-6f6fa792034f)
- 해당 클라이언트에게 알림이 전송되었다면
![image](https://github.com/user-attachments/assets/a8892c05-6305-4763-942c-f5a8b7bb0ab9)
- 다시 재연결을 했을 때 Last-Event-ID를 전달받아 해당 아이디 이후로 온 알림을 전송
![image](https://github.com/user-attachments/assets/eb8631cb-54a9-484b-bcfc-cc36074c74fb)

