### PR TITLE
Feat/관리자 권한 설정을 위한 기능 추가

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/SecurityConfiguration.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/SecurityConfiguration.java
@@ -2,7 +2,7 @@ package com.icandoit.boottalk.social_login.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -20,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
+@EnableMethodSecurity
 public class SecurityConfiguration {
 
 	private final CustomClientRegistrationRepository customClientRegistrationRepository;

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/service/CustomUserService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/service/CustomUserService.java
@@ -33,8 +33,6 @@ public class CustomUserService extends DefaultOAuth2UserService {
 		OAuth2User oAuth2User = super.loadUser(userRequest);
 		log.info("UserInfo from Service: {}", oAuth2User);
 
-		String registrationId = userRequest.getClientRegistration().getRegistrationId();
-
 		// 네이버의 경우 사용자 정보를 이중맵형식으로 전달받기 때문에 아래와 같이 작성
 		NaverResponse naverResponse = NaverResponse.from((Map<String, Object>) oAuth2User.getAttributes().get("response"));
 
@@ -56,8 +54,11 @@ public class CustomUserService extends DefaultOAuth2UserService {
 			));
 		}
 
-		// 기존 회원인 경우 인증 성공
-		//TODO 회원 권한(관리자, 일반)을 구별할 수 있는 기능 필요
+		// 관리자와 일반 회원을 구분하여 권한 부여
+		if (user.isAdmin()) {
+			return new CustomOAuth2User(UserAuthDto.from(user, ADMIN));
+		}
+
 		return new CustomOAuth2User(UserAuthDto.from(user, USER));
 	}
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/entity/User.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/entity/User.java
@@ -48,6 +48,8 @@ public class User extends BaseEntity {
 	@Setter
 	private Timestamp deletedAt;
 
+	private boolean admin;
+
 
 	public User updateOf(UpdateForm form) {
 		this.profileImage = form.profileImage();

--- a/boottalk/src/main/java/com/icandoit/boottalk/user_test/controller/UserTestController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user_test/controller/UserTestController.java
@@ -7,7 +7,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.icandoit.boottalk.notification.service.SseEmitterService;
 import com.icandoit.boottalk.social_login.dto.CustomOAuth2User;
 import com.icandoit.boottalk.social_login.dto.UserRole;
 import com.icandoit.boottalk.social_login.jwt.JwtProvider;
@@ -36,13 +35,12 @@ public class UserTestController {
 
 	//로그인 (회원가입된 이름으로 로그인)
 	@PostMapping("/login")
-	public ResponseEntity<String> login(@RequestParam String username) {
-		CustomOAuth2User authUser = userTestService.login(username);
+	public ResponseEntity<String> login(@RequestParam Long userId) {
 
 		return ResponseEntity.ok(
-			jwtProvider.createToken(authUser.getServiceUserId(), authUser.getName(), UserRole.USER.name()));
-
+			userTestService.login(userId));
 	}
+
 
 
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/user_test/service/UserTestService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user_test/service/UserTestService.java
@@ -7,9 +7,10 @@ import com.icandoit.boottalk.libs.exception.ErrorCode;
 import com.icandoit.boottalk.social_login.dto.CustomOAuth2User;
 import com.icandoit.boottalk.social_login.dto.UserAuthDto;
 import com.icandoit.boottalk.social_login.dto.UserRole;
+import com.icandoit.boottalk.social_login.jwt.JwtProvider;
 import com.icandoit.boottalk.user.domain.entity.User;
-import com.icandoit.boottalk.user_test.form.TestSignUpForm;
 import com.icandoit.boottalk.user.domain.repository.UserRepository;
+import com.icandoit.boottalk.user_test.form.TestSignUpForm;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 public class UserTestService {
 
 	private final UserRepository userRepository;
+	private final JwtProvider jwtProvider;
 
 	public CustomOAuth2User signUp(TestSignUpForm form) {
 		User user = userRepository.save(User.builder()
@@ -31,11 +33,15 @@ public class UserTestService {
 		return new CustomOAuth2User(UserAuthDto.from(user, UserRole.USER));
 	}
 
-	public CustomOAuth2User login(String username) {
-		User user = userRepository.findByUserName(username).orElseThrow(
+	public String login(Long userId) {
+		User user = userRepository.findById(userId).orElseThrow(
 			() -> new CustomException(ErrorCode.USER_NOT_FOUND)
 		);
 
-		return new CustomOAuth2User(UserAuthDto.from(user, UserRole.USER));
+		if (user.isAdmin()) {
+			return jwtProvider.createToken(user.getUserId(), user.getResourceUserId(), UserRole.ADMIN.name());
+		}
+
+		return jwtProvider.createToken(user.getUserId(), user.getResourceUserId(), UserRole.USER.name());
 	}
 }


### PR DESCRIPTION
## 🔍 주요 변경 사항
- `User` 엔티티에 관리자 구분을 위해 boolean admin 속성 추가
- `CustomUserService`에서 가져온 user의 admin 값이 true인 경우 ADMIN 권한 부여
- 권한에 따라 api 접근을 할 수 있도록  `SecurityConfiguration` 에 `@EnableMethodSecurity` 어노테이션 추가
  - 추후 사용자에게 부여된 권한 종류에 따라 api접근을 제한하고 싶은 경우 해당 api 에 `@PreAuthorize("hasAuthority('권한종류')")` 를 추가하여 사용
- 관리자 권한 설정을 테스트 하기 위해 `UserTestService`, `UserTestController`에도 이를 반영

---

## 💡 변경 이유

- 추후 수료증 인증 승인을 위한 관리자 페이지가 생성되어야 함에 따라 관리자만 요청가능한 api가 생성됨. 
- 이 때 권한에 따라 접근이 제한되어야 함.

---

## 🚀 개선 결과



---

## 📂 관련 클래스 및 변경 파일
- `User`
- `CustomUserService`
- `SecurityConfiguration`
- `UserTestService`
- `UserTestController`
---

## ✅ 테스트 시나리오(예정) 

- 관리자 권한을 지닌 계정으로 로그인
- 관리자만 접근할 수 있는 api 요청
- 관라지가 아닌 경우 해당 api 요청 시 거부됨

---

## 💡 참고 블로그



--- 

## 🖼️ 스크린샷
- 박태영 사용자는 관리자임
![image](https://github.com/user-attachments/assets/b3fa9d32-155c-4d08-a80e-273dd6b31e70)
- 테스트를 위해 임의로 메서드를 정해 @PreAuthorize("hasAuthority('ADMIN')") 추가
![image](https://github.com/user-attachments/assets/669b352e-c77f-4576-bff2-d32573b5717f)
- 관리자 계정 토큰은 요청 가능
![image](https://github.com/user-attachments/assets/faad9561-3e55-44ee-9fa3-e7e3565e6824)
- 관리자 계정이 아닌 일반 사용자는 요청이 거부됨 (웹 실행창에 Access denied 에러 뜨는 것을 확인함.)
![image](https://github.com/user-attachments/assets/6a93e545-576f-4d78-bc1a-bad27c49ef2f)


