### PR TITLE
Feat/소셜 로그인 프론트 엔드 연동을 위한 설정값 추가

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/SecurityConfiguration.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/SecurityConfiguration.java
@@ -47,10 +47,15 @@ public class SecurityConfiguration {
 			.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
 			//oauth2 로그인 설정
 			.oauth2Login(oauth2 -> oauth2
+				.loginPage("http://localhost:3000/login")
 				.userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig
 					.userService(customUserService)) // 네이버로부터 사용자 정보()를 받아올 클래스
 				.successHandler(customSuccessHandler) // 로그인 성공 시 토큰을 발급하는 클래스
-				.clientRegistrationRepository(customClientRegistrationRepository.clientRegistrationRepository())); // 부트톡 서버와 네이버 서버간 인증코드와 엑세스 토큰을 주고 받기 위한 설정이 저장된 클래스
+				.clientRegistrationRepository(customClientRegistrationRepository.clientRegistrationRepository())) // 부트톡 서버와 네이버 서버간 인증코드와 엑세스 토큰을 주고 받기 위한 설정이 저장된 클래스
+			.logout(logout -> logout.logoutUrl("/logout")
+				.logoutSuccessUrl("/")
+				.clearAuthentication(true));
+
 
 		return http.build();
 	}

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/SecurityConfiguration.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/SecurityConfiguration.java
@@ -47,13 +47,17 @@ public class SecurityConfiguration {
 			.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
 			//oauth2 로그인 설정
 			.oauth2Login(oauth2 -> oauth2
-				.loginPage("http://localhost:3000/login")
+				.loginPage("http://localhost:3000/login") // 사용자 인증이 필요한 경우 해당 페이지로 이동함.
+				.authorizationEndpoint(endpoint -> endpoint. // 프론트엔드쪽에서 로그인 버튼을 눌렀을 때
+					baseUri("/api/oauth2/authorization/naver")) // 해당 엔드포인트로 요청을 보내면 네이버 로그인 페이지로 리디렉션
 				.userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig
 					.userService(customUserService)) // 네이버로부터 사용자 정보()를 받아올 클래스
 				.successHandler(customSuccessHandler) // 로그인 성공 시 토큰을 발급하는 클래스
 				.clientRegistrationRepository(customClientRegistrationRepository.clientRegistrationRepository())) // 부트톡 서버와 네이버 서버간 인증코드와 엑세스 토큰을 주고 받기 위한 설정이 저장된 클래스
 			.logout(logout -> logout.logoutUrl("/logout")
-				.logoutSuccessUrl("/")
+				.logoutSuccessHandler((request, response, auth) -> {
+					response.sendRedirect("http://localhost:3000"); // 로그아웃 성공 시 메인페이지로 이동
+				})
 				.clearAuthentication(true));
 
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/jwt/JwtFilter.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/jwt/JwtFilter.java
@@ -67,11 +67,11 @@ public class JwtFilter extends OncePerRequestFilter {
 						// 응답 헤더에 토큰 추가
 						response.setHeader(TOKEN_HEADER, TOKEN_PREFIX + token);
 
-						// TODO 추후 프론트 엔드에서 헤더에 토큰 값을 담아서 요청을 보내도록 설정 시 쿠키 삭제 활성화
-						// Cookie deleteCookie = new Cookie(TOKEN_HEADER, null);
-						// deleteCookie.setMaxAge(0); // 쿠키 만료
-						// deleteCookie.setPath("/"); // 쿠키의 경로를 원래 쿠키와 동일하게 설정
-						// response.addCookie(deleteCookie);
+						// 헤더에 토큰을 옮긴 후에 쿠키에서는 삭제
+						Cookie deleteCookie = new Cookie(TOKEN_HEADER, null);
+						deleteCookie.setMaxAge(0); // 쿠키 만료
+						deleteCookie.setPath("/"); // 쿠키의 경로를 원래 쿠키와 동일하게 설정
+						response.addCookie(deleteCookie);
 
 						break;
 					}

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/oauth2/CustomSuccessHandler.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/oauth2/CustomSuccessHandler.java
@@ -13,7 +13,6 @@ import com.icandoit.boottalk.social_login.dto.CustomOAuth2User;
 import com.icandoit.boottalk.social_login.dto.UserRole;
 import com.icandoit.boottalk.social_login.jwt.JwtProvider;
 
-import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -30,7 +29,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
 	@Override
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
-		Authentication authentication) throws IOException, ServletException {
+		Authentication authentication) throws IOException {
 
 		//CustomOAuth2UserService.loadUser 에서 반환된 사용자 정보 가져오기
 		CustomOAuth2User userDetails = (CustomOAuth2User) authentication.getPrincipal();

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/oauth2/CustomSuccessHandler.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/oauth2/CustomSuccessHandler.java
@@ -50,10 +50,10 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
 		// 신규회원인 경우,추가정보 입력 url로 리다이렉션
 		if (UserRole.valueOf(role).equals(UserRole.NEW_USER)) {
-			response.sendRedirect("http://localhost:8080/new");
+			response.sendRedirect("http://localhost:3000/social-register");
 		} else {
 			// 기존 회원의 경우, 메인페이지로 리다이렉션
-			response.sendRedirect("http://localhost:8080/");
+			response.sendRedirect("http://localhost:3000/");
 		}
 	}
 


### PR DESCRIPTION
## 🔍 주요 변경 사항

- 로그인 시 커스텀 로그인 페이지로 이동 후에 소셜 로그인을 할 수 있도록 함.
- 로그아웃 시에 다시 메인페이지로 리디레션
  - 이 때 ContextHolder에서 사용자 정보 삭제 
- 로그인 후 신규회원인 경우 "http://localhost:3000/social-register"  페이지로 리디렉션
- 기존회원인 경우 ""http://localhost:3000/" 페이지로 리디렉션
---

## 💡 변경 이유

- 프론트엔드와 연동하기 위함.

---

## 🚀 개선 결과



---

## 📂 관련 클래스 및 변경 파일



---

## ✅ 테스트 시나리오(예정) 



---

## 💡 참고 블로그



--- 

## 🖼️ 스크린샷



