### PR TITLE
Feat/상단 내비 바 사용자 정보 표시를 위한 기능 추가

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/point_history/domain/repository/PointHistoryRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/point_history/domain/repository/PointHistoryRepository.java
@@ -17,4 +17,6 @@ public interface PointHistoryRepository extends JpaRepository<PointHistory, Long
 
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	Optional<PointHistory> findTopByUserIdOrderByPointHistoryIdDesc(long userId);
+
+	Optional<PointHistory> findFirstByUserIdOrderByPointHistoryIdDesc(long userId);
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/point_history/service/CreatePointHistoryService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/point_history/service/CreatePointHistoryService.java
@@ -52,9 +52,22 @@ public class CreatePointHistoryService {
 				.build()));
 	}
 
+	// 포인트 내역을 생성할 때 사용 (이 떄는 락이 필요)
 	private int getCurrentPoint(long userId) {
 
 		PointHistory pointHistory = pointHistoryRepository.findTopByUserIdOrderByPointHistoryIdDesc(userId)
+			.orElse(null);
+
+		if(pointHistory == null) {
+			return 0;
+		}
+
+		return pointHistory.getCurrentPoint();
+	}
+
+	// 내비게이션 상단 바에 표시될 포인트를 위한 메서드 (이 때는 굳이 학이 필요없음)
+	public int getCurrentPointToNavi(long userId) {
+		PointHistory pointHistory = pointHistoryRepository.findFirstByUserIdOrderByPointHistoryIdDesc(userId)
 			.orElse(null);
 
 		if(pointHistory == null) {

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/dto/CustomOAuth2User.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/dto/CustomOAuth2User.java
@@ -38,7 +38,7 @@ public class CustomOAuth2User implements OAuth2User {
 	@Override
 	public String getName() {
 
-		return userAuthDto.resourceUserId();
+		return userAuthDto.userName();
 	}
 
 	public Long getServiceUserId() {

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/dto/UserAuthDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/dto/UserAuthDto.java
@@ -2,23 +2,20 @@ package com.icandoit.boottalk.social_login.dto;
 
 import com.icandoit.boottalk.user.domain.entity.User;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 
 @Builder
 public record UserAuthDto(
 	Long serviceUserId,
-	String resourceUserId,
+	String userName,
 	UserRole role
 ) {
 
 	public static UserAuthDto from(User user, UserRole role) {
 		return UserAuthDto.builder()
 			.serviceUserId(user.getUserId())
-			.resourceUserId(user.getResourceUserId())
+			.userName(user.getUserName())
 			.role(role)
 			.build();
 	}

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/jwt/JwtProvider.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/jwt/JwtProvider.java
@@ -40,11 +40,11 @@ public class JwtProvider {
 
 	//회원 토큰
 	//TODO 사용자 정보를 암호화하여 토큰에 저장
-	public String createToken(Long serviceUserId, String resourceUserId, String userRole) {
+	public String createToken(Long serviceUserId, String userName, String userRole) {
 
 		return Jwts.builder()
 			.claim("serviceUserId", serviceUserId.toString())
-			.claim("resourceUserId", resourceUserId)
+			.claim("userName", userName)
 			.claim("role", userRole)
 			.issuedAt(new Date(System.currentTimeMillis()))
 			.expiration(new Date(System.currentTimeMillis() + tokenValidTime))
@@ -96,7 +96,7 @@ public class JwtProvider {
 			.serviceUserId(
 				Long.valueOf(Objects.requireNonNull(
 					claims.get("serviceUserId", String.class))))
-			.resourceUserId(claims.get("resourceUserId", String.class))
+			.userName(claims.get("userName", String.class))
 			.role(UserRole.valueOf(claims.get("role", String.class)))
 			.build();
 	}

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/controller/ManageController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/controller/ManageController.java
@@ -9,12 +9,13 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.icandoit.boottalk.bootcamp.dto.GetCertificationResponseDto;
 import com.icandoit.boottalk.bootcamp.service.BootcampCertificationService;
+import com.icandoit.boottalk.point_history.service.CreatePointHistoryService;
 import com.icandoit.boottalk.social_login.dto.CustomOAuth2User;
+import com.icandoit.boottalk.user.domain.dto.NaviUserInfoDto;
 import com.icandoit.boottalk.user.domain.dto.UserDto;
 import com.icandoit.boottalk.user.domain.dto.UserInfoDto;
 import com.icandoit.boottalk.user.domain.form.UpdateForm;
@@ -28,6 +29,7 @@ import lombok.RequiredArgsConstructor;
 public class ManageController {
 
 	private final ManageService manageService;
+	private final CreatePointHistoryService createPointHistoryService;
 	private final BootcampCertificationService bootcampCertificationService;
 
 	@GetMapping
@@ -39,6 +41,12 @@ public class ManageController {
 			= bootcampCertificationService.getMyCertifications(userId);
 
 		return ResponseEntity.ok(UserInfoDto.from(userDto, myCertifications));
+	}
+
+	@GetMapping("/navi")
+	public ResponseEntity<NaviUserInfoDto> getNavi(@AuthenticationPrincipal CustomOAuth2User user) {
+		return ResponseEntity.ok(NaviUserInfoDto.from(user.getName(),
+			createPointHistoryService.getCurrentPointToNavi(user.getServiceUserId())));
 	}
 
 	@PutMapping

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/dto/NaviUserInfoDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/dto/NaviUserInfoDto.java
@@ -1,0 +1,15 @@
+package com.icandoit.boottalk.user.domain.dto;
+
+import lombok.Builder;
+
+@Builder
+public record NaviUserInfoDto (
+	String userName,
+	Integer point
+){
+	public static NaviUserInfoDto from(String userName, Integer point) {
+		return NaviUserInfoDto.builder()
+			.userName(userName)
+			.point(point).build();
+	}
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/user_test/controller/UserTestController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user_test/controller/UserTestController.java
@@ -1,7 +1,6 @@
 package com.icandoit.boottalk.user_test.controller;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,8 +32,6 @@ public class UserTestController {
 			jwtProvider.createToken(authUser.getServiceUserId(), authUser.getName(), UserRole.USER.name()));
 	}
 
-
-	//로그인 (회원가입된 이름으로 로그인)
 
 	@PostMapping("/login")
 	public ResponseEntity<String> login(@RequestParam Long userId) {

--- a/boottalk/src/main/java/com/icandoit/boottalk/user_test/service/UserTestService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user_test/service/UserTestService.java
@@ -39,9 +39,9 @@ public class UserTestService {
 		);
 
 		if (user.isAdmin()) {
-			return jwtProvider.createToken(user.getUserId(), user.getResourceUserId(), UserRole.ADMIN.name());
+			return jwtProvider.createToken(user.getUserId(), user.getUserName(), UserRole.ADMIN.name());
 		}
 
-		return jwtProvider.createToken(user.getUserId(), user.getResourceUserId(), UserRole.USER.name());
+		return jwtProvider.createToken(user.getUserId(), user.getUserName(), UserRole.USER.name());
 	}
 }


### PR DESCRIPTION
## 🔍 주요 변경 사항

- 서비스 페이지 상단 내비 바에 표시될 사용자 이름과 포인트 표시를 위한 기능 구현
  -` GET "/api/users/my/navi" `api 요청을 받으면 `getNavi(`) 메서드를 통해 사용자 이름과 현재 포인트 데이터를 가져옴
  - 이 때 `NaviUserInfoDto` 형식으로 반환
  - 현재포인트 정보를 가져올 때 기존 코드를 재활용하는 것이 아니라 `getCurrentPointToNavi()` 새로운 메서드를 생성하고 jpa 메서드도 락이 제외된 버전(`findFirstByUserIdOrderByPointHistoryIdDesc()`)으로 새로 생성하여 현재포인트를 가져오도록 함.
- 기존 사용자 인증 시 `ContextHolder`에 저장되었던 사용자 정보 중에서 `resourceUserId` 대신에 `userName`으로 변경. 이에 따라 토큰에 저장될 정보도 변경됨
---

## 💡 변경 이유

- 기존 코드를 재활용 하지 않고 새로운 메서드를 생성하는 이유는 다음과 같음
   - UI 표시용 조회는 락이 필요 없다고 판단.
   - 불필요한 락 획득/해제 오버헤드 제거 가능 
   - 중첩 트랜잭션 방지
- resourcUserId는 사용자 정보에 담아도 따로 사용하는 곳이 없었음. 그러나 userName은 상단 내비 바에 표시되어 사용되기 때문에 변경함
---

## 🚀 개선 결과



---

## 📂 관련 클래스 및 변경 파일

- PointHistoryRepository
- CreatePointHistoryService
- ManageController
- NaviUserInfoDto
- JwtProvider
- UserAuthDto
- CustomOAuth2User


- UserTestController
- UserTestService
---

## ✅ 테스트 시나리오(예정) 



---

## 💡 참고 블로그



--- 

## 🖼️ 스크린샷
-` GET "/api/users/my/navi"  api 요청 시
![image](https://github.com/user-attachments/assets/56352cfa-99a1-4f3a-bbff-b908d848ef81)
- 토큰을 파싱한 결과
<img width="1210" alt="image" src="https://github.com/user-attachments/assets/b93dbec8-013c-4824-add0-26959c86280e" />



