### PR TITLE
feat : CoffeeChatInfo + Times 복합 API 추가

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatInfoController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatInfoController.java
@@ -3,12 +3,10 @@ package com.icandoit.boottalk.coffeeChat.controller;
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatInfoRequestDto;
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatInfoResponseDto;
 import com.icandoit.boottalk.coffeeChat.service.CoffeeChatInfoService;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,16 +18,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class CoffeeChatInfoController {
 
     private final CoffeeChatInfoService coffeeChatInfoService;
-
-
-    @PostMapping
-    public ResponseEntity<CoffeeChatInfoResponseDto> createCoffeeChatInfo(
-        @RequestBody @Valid CoffeeChatInfoRequestDto requestDto
-    ) {
-        // todo : 사용자 인증 사용 시 수정
-        Long userId = 1L;
-        return ResponseEntity.ok(coffeeChatInfoService.createCoffeeChatInfo(userId, requestDto));
-    }
 
     @GetMapping
     public ResponseEntity<CoffeeChatInfoResponseDto> getMyCoffeeChatInfo() {

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatRegisterController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatRegisterController.java
@@ -1,0 +1,31 @@
+package com.icandoit.boottalk.coffeeChat.controller;
+
+import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatRegisterRequestDto;
+import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatRegisterResponseDto;
+import com.icandoit.boottalk.coffeeChat.service.CoffeeChatRegisterService;
+import com.icandoit.boottalk.social_login.dto.CustomOAuth2User;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/coffee-chats")
+@RequiredArgsConstructor
+public class CoffeeChatRegisterController {
+
+    private final CoffeeChatRegisterService registerService;
+
+    @PostMapping("/register")
+    public ResponseEntity<CoffeeChatRegisterResponseDto> registerCoffeeChat(
+        @AuthenticationPrincipal CustomOAuth2User user,
+        @RequestBody @Valid CoffeeChatRegisterRequestDto requestDto
+    ) {
+        return ResponseEntity.ok(registerService.register(user.getServiceUserId(),
+            requestDto));
+    }
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatTimeController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatTimeController.java
@@ -9,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,14 +21,6 @@ public class CoffeeChatTimeController {
 
     private final CoffeeChatTimeService coffeeChatTimeService;
 
-    @PostMapping
-    public ResponseEntity<List<CoffeeChatTimeResponseDto>> createCoffeeChatTimes(
-        @RequestBody @Valid CoffeeChatTimeMapDto requestDto) {
-        // todo : 사용자 인증 사용 시 수정
-        Long userId = 1L;
-        return ResponseEntity.ok(coffeeChatTimeService.createCoffeeChatTimes(userId, requestDto));
-    }
-
     // 멘토 자신의 시간을 조회
     @GetMapping
     public ResponseEntity<List<CoffeeChatTimeResponseDto>> getMyCoffeeChatTimes() {
@@ -40,7 +31,8 @@ public class CoffeeChatTimeController {
 
     //mentorId를 받아 커피챗 가능 시간 조회
     @GetMapping("/{mentorId}")
-    public ResponseEntity<List<CoffeeChatTimeResponseDto>> getMentorAvailableChatTimes(@PathVariable Long mentorId) {
+    public ResponseEntity<List<CoffeeChatTimeResponseDto>> getMentorAvailableChatTimes(
+        @PathVariable Long mentorId) {
 
         return ResponseEntity.ok(coffeeChatTimeService.getMentorAvailableChatTimes(mentorId));
     }

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/dto/CoffeeChatRegisterRequestDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/dto/CoffeeChatRegisterRequestDto.java
@@ -1,0 +1,8 @@
+package com.icandoit.boottalk.coffeeChat.dto;
+
+public record CoffeeChatRegisterRequestDto(
+    CoffeeChatInfoRequestDto info,
+    CoffeeChatTimeMapDto time
+) {
+
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/dto/CoffeeChatRegisterResponseDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/dto/CoffeeChatRegisterResponseDto.java
@@ -1,0 +1,13 @@
+package com.icandoit.boottalk.coffeeChat.dto;
+
+import java.util.List;
+
+public record CoffeeChatRegisterResponseDto(
+    CoffeeChatInfoResponseDto info,
+    List<CoffeeChatTimeResponseDto> times
+) {
+
+    public static CoffeeChatRegisterResponseDto of(CoffeeChatInfoResponseDto info, List<CoffeeChatTimeResponseDto> times) {
+        return new CoffeeChatRegisterResponseDto(info, times);
+    }
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatRegisterService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatRegisterService.java
@@ -1,0 +1,32 @@
+package com.icandoit.boottalk.coffeeChat.service;
+
+import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatInfoResponseDto;
+import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatRegisterRequestDto;
+import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatRegisterResponseDto;
+import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatTimeResponseDto;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CoffeeChatRegisterService {
+
+    private final CoffeeChatInfoService coffeeChatInfoService;
+    private final CoffeeChatTimeService coffeeChatTimeService;
+
+    @Transactional
+    public CoffeeChatRegisterResponseDto register(Long userId, CoffeeChatRegisterRequestDto requestDto) {
+
+        // 1. 커피챗 정보 등록
+        CoffeeChatInfoResponseDto infoDto = coffeeChatInfoService.createCoffeeChatInfo(
+            userId, requestDto.info());
+
+        // 2. 커피챗 시간 등록
+        List<CoffeeChatTimeResponseDto> timeDtos = coffeeChatTimeService.createCoffeeChatTimes(
+            userId, requestDto.time());
+
+        return CoffeeChatRegisterResponseDto.of(infoDto, timeDtos);
+    }
+}


### PR DESCRIPTION
## 🔍 주요 변경 사항

- 커피챗 정보를 생성하기 위한 두 API를 하나의 복합 API로 요청
-> POST `/api/coffee-chats/register`
- 기존 API 제거
  - CoffeeChatInfo create API (POST `/api/coffee-chats/info`)
  - CoffeeChatTime create API (POST `/api/coffee-chats/times`)

---

## 💡 변경 이유

초기 기획 단계에서는
커피챗 유저 정보 등록과 멘토링 가능 시간 등록이 각기 다른 UI 화면에서 이루어질 예정이었음

이에 따라 각 기능은 독립적인 API로 분리되었고, 이는
백엔드에서도 **SRP(Single Responsibility Principle, 단일 책임 원칙)**을 따르는 구조로 설계함

각 API는 다음과 같은 역할을 가진다:

POST /api/coffee-chats/info: 유저의 멘토 정보 등록

POST /api/coffee-chats/times: 유저의 멘토링 가능 시간 등록

이후 기획 변경으로 두 기능이 하나의 UI에서 동시에 처리되면서 복합 API가 필요로 인해 복합 API 추가 
