### PR TITLE
feat : 부트캠프 저장 및 알림 전송을 위한 redis 사용

### DIFF
--- a/boottalk/build.gradle
+++ b/boottalk/build.gradle
@@ -50,6 +50,13 @@ dependencies {
 	// swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// quartz
+	implementation 'org.springframework.boot:spring-boot-starter-quartz'
+
+
 	implementation 'org.apache.httpcomponents.client5:httpclient5:5.4.1'
 	implementation 'org.springframework.boot:spring-boot-starter-batch'
 	implementation 'org.springframework:spring-context-support'

--- a/boottalk/src/main/java/com/icandoit/boottalk/batch/config/BootcampBatchJobConfig.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/batch/config/BootcampBatchJobConfig.java
@@ -3,6 +3,7 @@ package com.icandoit.boottalk.batch.config;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.job.builder.SimpleJobBuilder;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.core.step.tasklet.Tasklet;
@@ -14,32 +15,86 @@ import org.springframework.transaction.PlatformTransactionManager;
 import com.icandoit.boottalk.bootcamp.service.Employ24ApiService;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Configuration
 @RequiredArgsConstructor
+@Slf4j
 public class BootcampBatchJobConfig {
 
 	private final Employ24ApiService employ24ApiService;
+	private final JobRepository jobRepository;
+	private final PlatformTransactionManager transactionManager;
 
 	@Bean
-	public Job bootcampFetchJob(JobRepository jobRepository, Step fetchBootcampStep) {
-		return new JobBuilder("bootcampFetchJob", jobRepository)
-			.start(fetchBootcampStep)
-			.build();
+	public Step fetchStep_C0061_19() {
+		return createFetchBootcampStep("C0061", "19");
 	}
 
 	@Bean
-	public Step fetchBootcampStep(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
-		return new StepBuilder("fetchBootcampStep", jobRepository)
-			.tasklet(fetchBootcampTasklet(), transactionManager)
-			.build();
+	public Step fetchStep_C0061_20() {
+		return createFetchBootcampStep("C0061", "20");
 	}
 
 	@Bean
-	public Tasklet fetchBootcampTasklet() {
-		return ((contribution, chunkContext) -> {
-			employ24ApiService.saveAllFromEmploy24();
+	public Step fetchStep_C0104_19() {
+		return createFetchBootcampStep("C0104", "19");
+	}
+
+	@Bean
+	public Step fetchStep_C0104_20() {
+		return createFetchBootcampStep("C0104", "20");
+	}
+
+	@Bean
+	public Step fetchStep_C0105_19() {
+		return createFetchBootcampStep("C0105", "19");
+	}
+
+	@Bean
+	public Step fetchStep_C0105_20() {
+		return createFetchBootcampStep("C0105", "20");
+	}
+
+	// TODO : 알림 전송 Step
+	@Bean
+	public Step notifyNewBootcampStep() {
+		return new StepBuilder("notifyNewBootcampStep", jobRepository)
+			.tasklet((contribution, chunkContext) -> {
+
+				log.info("알림 전송 스텝 실행: 신규 부트캠프 알림 발송 처리");
+				return RepeatStatus.FINISHED;
+			}, transactionManager)
+			.build();
+	}
+
+
+	// Job 구성: 각 Step을 순차적으로 실행하도록 연결합니다.
+	@Bean
+	public Job bootcampFetchJob() {
+		SimpleJobBuilder jobBuilder = new JobBuilder("bootcampFetchJob", jobRepository)
+			.start(fetchStep_C0061_19())
+			.next(fetchStep_C0061_20())
+			.next(fetchStep_C0104_19())
+			.next(fetchStep_C0104_20())
+			.next(fetchStep_C0105_19())
+			.next(fetchStep_C0105_20());
+		// 추가적인 후속 스텝 (예. 알림 전송 스텝)도 연결 가능
+		return jobBuilder.build();
+	}
+
+	// Step 생성 메소드 (공통 로직)
+	private Step createFetchBootcampStep(String categoryCode, String ncsCode) {
+		String stepName = "fetchStep_" + categoryCode + "_" + ncsCode;
+		Tasklet tasklet = (contribution, chunkContext) -> {
+			log.info("Step 시작: {} (categoryCode={}, ncsCode={})", stepName, categoryCode, ncsCode);
+			employ24ApiService.processCategoryAndNcs(categoryCode, ncsCode);
+			log.info("Step 완료: {}", stepName);
 			return RepeatStatus.FINISHED;
-		});
+		};
+
+		return new StepBuilder(stepName, jobRepository)
+			.tasklet(tasklet, transactionManager)
+			.build();
 	}
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/batch/config/QuartzFetchConfig.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/batch/config/QuartzFetchConfig.java
@@ -1,0 +1,21 @@
+package com.icandoit.boottalk.batch.config;
+
+import org.quartz.JobDetail;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.quartz.JobDetailFactoryBean;
+
+@Configuration
+public class QuartzFetchConfig {
+
+	@Bean
+	public JobDetail fetchBootcampJobDetail() {
+		JobDetailFactoryBean factoryBean = new JobDetailFactoryBean();
+		factoryBean.setJobClass(com.icandoit.boottalk.batch.scheduler.FetchBootcampQuartzJob.class);
+		factoryBean.setName("fetchBootcampJobDetail");
+		factoryBean.setDescription("Fetch Bootcamp Data Job Detail");
+		factoryBean.setDurability(true);
+		factoryBean.afterPropertiesSet();
+		return factoryBean.getObject();
+	}
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/batch/config/QuartzFetchTriggersConfig.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/batch/config/QuartzFetchTriggersConfig.java
@@ -1,0 +1,113 @@
+package com.icandoit.boottalk.batch.config;
+
+import java.text.ParseException;
+
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.Trigger;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.quartz.CronTriggerFactoryBean;
+
+@Configuration
+public class QuartzFetchTriggersConfig {
+
+	private final JobDetail fetchBootcampJobDetail;
+
+	public QuartzFetchTriggersConfig(JobDetail fetchBootcampJobDetail) {
+		this.fetchBootcampJobDetail = fetchBootcampJobDetail;
+	}
+
+	@Bean
+	public Trigger fetchTrigger_C0061_19() throws ParseException {
+		CronTriggerFactoryBean triggerFactoryBean = new CronTriggerFactoryBean();
+		triggerFactoryBean.setJobDetail(fetchBootcampJobDetail);
+		// 매일 11시 25분에 실행
+		triggerFactoryBean.setCronExpression("0 25 11 * * ?");
+		triggerFactoryBean.setName("fetchTrigger_C0061_19");
+
+		JobDataMap dataMap = new JobDataMap();
+		dataMap.put("categoryCode", "C0061");
+		dataMap.put("ncsCode", "19");
+		triggerFactoryBean.setJobDataMap(dataMap);
+
+		triggerFactoryBean.afterPropertiesSet();
+		return triggerFactoryBean.getObject();
+	}
+
+	// 나머지 트리거들도 유사하게 정의 (크론 표현식을 5분 간격으로 설정)
+	@Bean
+	public Trigger fetchTrigger_C0061_20() throws ParseException {
+		CronTriggerFactoryBean triggerFactoryBean = new CronTriggerFactoryBean();
+		triggerFactoryBean.setJobDetail(fetchBootcampJobDetail);
+		// 매일 11시 30분에 실행
+		triggerFactoryBean.setCronExpression("0 30 11 * * ?");
+		triggerFactoryBean.setName("fetchTrigger_C0061_20");
+		JobDataMap dataMap = new JobDataMap();
+		dataMap.put("categoryCode", "C0061");
+		dataMap.put("ncsCode", "20");
+		triggerFactoryBean.setJobDataMap(dataMap);
+		triggerFactoryBean.afterPropertiesSet();
+		return triggerFactoryBean.getObject();
+	}
+
+	@Bean
+	public Trigger fetchTrigger_C0104_19() throws ParseException {
+		CronTriggerFactoryBean triggerFactoryBean = new CronTriggerFactoryBean();
+		triggerFactoryBean.setJobDetail(fetchBootcampJobDetail);
+		// 매일 11시 35분에 실행
+		triggerFactoryBean.setCronExpression("0 35 11 * * ?");
+		triggerFactoryBean.setName("fetchTrigger_C0104_19");
+		JobDataMap dataMap = new JobDataMap();
+		dataMap.put("categoryCode", "C0104");
+		dataMap.put("ncsCode", "19");
+		triggerFactoryBean.setJobDataMap(dataMap);
+		triggerFactoryBean.afterPropertiesSet();
+		return triggerFactoryBean.getObject();
+	}
+
+	@Bean
+	public Trigger fetchTrigger_C0104_20() throws ParseException {
+		CronTriggerFactoryBean triggerFactoryBean = new CronTriggerFactoryBean();
+		triggerFactoryBean.setJobDetail(fetchBootcampJobDetail);
+		// 매일 11시 40분에 실행
+		triggerFactoryBean.setCronExpression("0 40 11 * * ?");
+		triggerFactoryBean.setName("fetchTrigger_C0104_20");
+		JobDataMap dataMap = new JobDataMap();
+		dataMap.put("categoryCode", "C0104");
+		dataMap.put("ncsCode", "20");
+		triggerFactoryBean.setJobDataMap(dataMap);
+		triggerFactoryBean.afterPropertiesSet();
+		return triggerFactoryBean.getObject();
+	}
+
+	@Bean
+	public Trigger fetchTrigger_C0105_19() throws ParseException {
+		CronTriggerFactoryBean triggerFactoryBean = new CronTriggerFactoryBean();
+		triggerFactoryBean.setJobDetail(fetchBootcampJobDetail);
+		// 매일 11시 45분에 실행
+		triggerFactoryBean.setCronExpression("0 45 11 * * ?");
+		triggerFactoryBean.setName("fetchTrigger_C0105_19");
+		JobDataMap dataMap = new JobDataMap();
+		dataMap.put("categoryCode", "C0105");
+		dataMap.put("ncsCode", "19");
+		triggerFactoryBean.setJobDataMap(dataMap);
+		triggerFactoryBean.afterPropertiesSet();
+		return triggerFactoryBean.getObject();
+	}
+
+	@Bean
+	public Trigger fetchTrigger_C0105_20() throws ParseException {
+		CronTriggerFactoryBean triggerFactoryBean = new CronTriggerFactoryBean();
+		triggerFactoryBean.setJobDetail(fetchBootcampJobDetail);
+		// 매일 11시 50분에 실행
+		triggerFactoryBean.setCronExpression("0 50 11 * * ?");
+		triggerFactoryBean.setName("fetchTrigger_C0105_20");
+		JobDataMap dataMap = new JobDataMap();
+		dataMap.put("categoryCode", "C0105");
+		dataMap.put("ncsCode", "20");
+		triggerFactoryBean.setJobDataMap(dataMap);
+		triggerFactoryBean.afterPropertiesSet();
+		return triggerFactoryBean.getObject();
+	}
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/batch/config/QuartzNotificationConfig.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/batch/config/QuartzNotificationConfig.java
@@ -1,0 +1,36 @@
+package com.icandoit.boottalk.batch.config;
+
+import java.text.ParseException;
+
+import org.quartz.JobDetail;
+import org.quartz.Trigger;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.quartz.CronTriggerFactoryBean;
+import org.springframework.scheduling.quartz.JobDetailFactoryBean;
+
+@Configuration
+public class QuartzNotificationConfig {
+
+	@Bean
+	public JobDetail notificationJobDetail() {
+		JobDetailFactoryBean factoryBean = new JobDetailFactoryBean();
+		factoryBean.setJobClass(com.icandoit.boottalk.batch.scheduler.NotificationQuartzJob.class);
+		factoryBean.setName("notificationJobDetail");
+		factoryBean.setDescription("Notification Job Detail");
+		factoryBean.setDurability(true);
+		factoryBean.afterPropertiesSet();
+		return factoryBean.getObject();
+	}
+
+	@Bean
+	public Trigger notificationTrigger(JobDetail notificationJobDetail) throws ParseException {
+		CronTriggerFactoryBean triggerFactoryBean = new CronTriggerFactoryBean();
+		triggerFactoryBean.setJobDetail(notificationJobDetail);
+		// 매일 12시에 실행
+		triggerFactoryBean.setCronExpression("0 0 12 * * ?");
+		triggerFactoryBean.setName("notificationTrigger");
+		triggerFactoryBean.afterPropertiesSet();
+		return triggerFactoryBean.getObject();
+	}
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/batch/scheduler/FetchBootcampQuartzJob.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/batch/scheduler/FetchBootcampQuartzJob.java
@@ -1,0 +1,46 @@
+package com.icandoit.boottalk.batch.scheduler;
+
+import java.util.UUID;
+
+import org.quartz.JobDataMap;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.quartz.QuartzJobBean;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FetchBootcampQuartzJob extends QuartzJobBean {
+
+	private final JobLauncher jobLauncher;
+	private final Job bootcampFetchJob;
+
+	@Override
+	protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
+		try {
+			JobDataMap dataMap = context.getMergedJobDataMap();
+			String categoryCode = dataMap.getString("categoryCode");
+			String ncsCode = dataMap.getString("ncsCode");
+
+			JobParameters jobParameters = new JobParametersBuilder()
+				.addString("jobId", UUID.randomUUID().toString())
+				.addString("categoryCode", categoryCode)
+				.addString("ncsCode", ncsCode)
+				.toJobParameters();
+			log.info("Quartz Job 시작: bootcampFetchJob 실행 중...");
+			jobLauncher.run(bootcampFetchJob, jobParameters);
+			log.info("Quartz Job 완료: bootcampFetchJob 실행 완료");
+		} catch (Exception e) {
+			log.error("Quartz Job 실행 실패", e);
+			throw new JobExecutionException(e);
+		}
+	}
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/batch/scheduler/NotificationQuartzJob.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/batch/scheduler/NotificationQuartzJob.java
@@ -1,0 +1,32 @@
+package com.icandoit.boottalk.batch.scheduler;
+
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.scheduling.quartz.QuartzJobBean;
+import org.springframework.stereotype.Component;
+
+import com.icandoit.boottalk.notification.service.NotificationService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationQuartzJob extends QuartzJobBean {
+
+	private final NotificationService notificationService;
+
+	@Override
+	protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
+		try {
+			log.info("Notification Quartz Job 시작: 알림 전송 작업 실행...");
+			// TODO : 실제 알림 전송 기능을 호출 (추후 구현 예정)
+			// notificationService.sendNewBootcampNotifications();
+			log.info("Notification Quartz Job 완료: 알림 전송 작업 종료");
+		} catch (Exception e) {
+			log.error("Notification Quartz Job 실행 실패", e);
+			throw new JobExecutionException(e);
+		}
+	}
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/Employ24ApiService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/Employ24ApiService.java
@@ -36,6 +36,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class Employ24ApiService {
 
+	private final RedisService redisService;
+
 	private static final String HOST = "www.work24.go.kr";
 	private static final String LIST_API_PATH = "/cm/openApi/call/hr/callOpenApiSvcInfo310L01.do";
 	private static final String DETAIL_API_PATH = "/cm/openApi/call/hr/callOpenApiSvcInfo310L02.do";
@@ -66,7 +68,7 @@ public class Employ24ApiService {
 	}
 
 	// 주어진 카테고리와 NCS 코드로 리스트 조회 후 저장 처리
-	private void processCategoryAndNcs(String categoryCode, String ncsCode) {
+	public void processCategoryAndNcs(String categoryCode, String ncsCode) {
 		try {
 			List<BootcampListResponseDto> list = fetchBootcampList(categoryCode, ncsCode);
 			processBootcampList(list);
@@ -104,6 +106,8 @@ public class Employ24ApiService {
 		Bootcamp bootcamp = createBootcampEntity(center, course, dto, category, detail);
 
 		bootcampRepository.save(bootcamp);
+
+		redisService.storeNewBootcampInfo(String.valueOf(bootcamp.getBootcampId()), bootcamp.getBootcampCategoryType());
 		log.info("저장 성공: {}", bootcamp.getBootcampName());
 	}
 
@@ -208,7 +212,7 @@ public class Employ24ApiService {
 
 	// 리스트 API 호출 URL 생성
 	private String buildListApiUrl(String categoryCode, String ncsCode) {
-		LocalDate today = LocalDate.now();
+		LocalDate today = LocalDate.now().plusDays(1);
 		LocalDate end = today.plusDays(7);
 		return UriComponentsBuilder.newInstance()
 			.scheme("https")

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/RedisService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/RedisService.java
@@ -1,0 +1,23 @@
+package com.icandoit.boottalk.bootcamp.service;
+
+import java.time.Duration;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import com.icandoit.boottalk.bootcamp.entity.enums.BootcampCategoryType;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+
+	private final RedisTemplate<String, String> redisTemplate;
+
+	public void storeNewBootcampInfo(String bootcampId, BootcampCategoryType categoryType) {
+		String redisKey = "new:bootcamp:" + categoryType;
+		redisTemplate.opsForList().rightPush(redisKey, bootcampId);
+		redisTemplate.expire(redisKey, Duration.ofHours(2));
+	}
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/common/config/RedisConfig.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/common/config/RedisConfig.java
@@ -1,17 +1,26 @@
 package com.icandoit.boottalk.common.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
 @Configuration
 public class RedisConfig {
 
+	@Value("${spring.data.redis.host}")
+	private String redisHost;
+
+	@Value("${spring.data.redis.port}")
+	private int redisPort;
+
 	@Bean
 	public LettuceConnectionFactory redisConnectionFactory() {
-		// 기본 host와 port를 사용합니다. (필요에 따라 application.properties에서 설정 가능)
-		return new LettuceConnectionFactory();
+		RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(redisHost, redisPort);
+		return new LettuceConnectionFactory(config);
 	}
 
 	@Bean

--- a/boottalk/src/main/java/com/icandoit/boottalk/common/config/RedisConfig.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/common/config/RedisConfig.java
@@ -1,0 +1,22 @@
+package com.icandoit.boottalk.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+	@Bean
+	public LettuceConnectionFactory redisConnectionFactory() {
+		// 기본 host와 port를 사용합니다. (필요에 따라 application.properties에서 설정 가능)
+		return new LettuceConnectionFactory();
+	}
+
+	@Bean
+	public StringRedisTemplate stringRedisTemplate(LettuceConnectionFactory redisConnectionFactory) {
+		return new StringRedisTemplate(redisConnectionFactory);
+	}
+}
+

--- a/boottalk/src/main/java/com/icandoit/boottalk/common/config/RedisConfig.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/common/config/RedisConfig.java
@@ -3,7 +3,6 @@ package com.icandoit.boottalk.common.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;

--- a/boottalk/src/main/resources/application.yml
+++ b/boottalk/src/main/resources/application.yml
@@ -35,4 +35,4 @@ spring:
   data:
     redis:
       host: 43.200.67.27
-      port: 6397
+      port: 6379

--- a/boottalk/src/main/resources/application.yml
+++ b/boottalk/src/main/resources/application.yml
@@ -31,3 +31,8 @@ spring:
 
   jwt:
     secret: "vmfhaltmskdlstkfkdgodyroqkfwkdbalroqkfwkdbalaaaaaaaaaaaaaaaabbbbb"
+
+  data:
+    redis:
+      host: 43.200.67.27
+      port: 6397


### PR DESCRIPTION
Closes #83 
## 🔍 주요 변경 사항
- Quartz 스케줄러를 통한 배치 작업 스케줄링 기능 추가
- 6개의 Fetch 작업을 각기 다른 Cron Trigger로 5분 간격 실행하도록 구성
- 12시 정각에 NotificationQuartzJob 트리거를 통한 알림 전송 작업 (추후 알림 구현 예정)
- 신규 부트캠프 정보를 Redis에 저장하는 기능 추가 (RedisService 업데이트) - 알림 전송을 위한 부트캠프 Id와 CategoryType을 저장
- CronTriggerFactoryBean의 afterPropertiesSet() 예외 처리 코드 추가

---

## 💡 변경 이유
- 기존 단일 스케줄링 방식에서 Quartz를 활용하여 유연하고 세밀한 배치 작업 스케줄링을 구현하기 위함
- 각 Fetch 작업을 개별적으로 스케줄링하여, 배치 작업이 11시 55분에 종료되도록 설정하고, 이후 알림 전송 작업을 12시에 실행함으로써,
  신규 부트캠프 데이터 기반 사용자 알림 기능을 점진적으로 도입할 수 있도록 설계함

---

## 🚀 개선 결과
- 배치 작업이 매일 정해진 시간에 6개의 Fetch 작업을 순차적으로(5분 간격) 실행하고, 이후 12시에 Notification 작업이 실행됨
- Redis에 신규 부트캠프 데이터 저장을 통해 빠른 조회 및 알림 대상 선별 가능
- Quartz를 통한 스케줄링으로 안정적이고 유연한 배치 운영 환경 구축


---

## 📂 관련 클래스 및 변경 파일
- **배치 Quartz Job 클래스:**  
  - `com.icandoit.boottalk.batch.scheduler.FetchBootcampQuartzJob`
  - `com.icandoit.boottalk.batch.scheduler.NotificationQuartzJob`
- **Quartz 설정 파일:**  
  - `com.icandoit.boottalk.batch.config.QuartzFetchConfig`
  - `com.icandoit.boottalk.batch.config.QuartzFetchTriggersConfig`
  - `com.icandoit.boottalk.batch.config.QuartzNotificationConfig`
- **기존 배치 Job 설정 파일:**  
  - `com.icandoit.boottalk.batch.config.BootcampBatchJobConfig`
- **Redis 관련:**  
  - `com.icandoit.boottalk.common.config.RedisConfig`
  - `com.icandoit.boottalk.bootcamp.service.RedisService`


