### PR TITLE
Feat/review certification

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/repository/BootcampCertificationRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/repository/BootcampCertificationRepository.java
@@ -17,4 +17,7 @@ public interface BootcampCertificationRepository extends JpaRepository<BootcampC
 	List<BootcampCertification> findAllByUserAndStatus(User user, CertificationStatus certificationStatus);
 
 	List<BootcampCertification> findAllByStatus(CertificationStatus certificationStatus);
+
+	// 유저가 해당 코스에 대해 APPROVED 인증을 가지고 있는지 여부
+	boolean existsByUserAndCourseAndStatus(User user, Course course, CertificationStatus certificationStatus);
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/libs/exception/ErrorCode.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/libs/exception/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
     NOT_COFFEE_CHAT_APPLICATION_OWNER(403, "사용자가 작성한 커피챗 신청 내역이 아닙니다."),
     NOT_COFFEE_CHAT_INFO_OWNER(403, "사용자가 작성한 커피챗 정보가 아닙니다."),
     CHAT_ROOM_FORBIDDEN(403, "해당 채팅방에 접근할 수 있는 권한이 없습니다."),
+    WRITE_REVIEW_FORBIDDEN(403, "리뷰 작성할 권한이 없습니다."),
 
     /* 404 NOT_FOUND */
     NOT_FOUND(404, "요청한 리소스를 찾을 수 없습니다."),

--- a/boottalk/src/main/java/com/icandoit/boottalk/review/service/ReviewService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/review/service/ReviewService.java
@@ -10,6 +10,8 @@ import org.springframework.transaction.annotation.Transactional;
 import com.icandoit.boottalk.bootcamp.entity.Bootcamp;
 import com.icandoit.boottalk.bootcamp.entity.Course;
 import com.icandoit.boottalk.bootcamp.entity.enums.BootcampCategoryType;
+import com.icandoit.boottalk.bootcamp.entity.enums.CertificationStatus;
+import com.icandoit.boottalk.bootcamp.repository.BootcampCertificationRepository;
 import com.icandoit.boottalk.bootcamp.repository.BootcampRepository;
 import com.icandoit.boottalk.bootcamp.repository.CourseRepository;
 import com.icandoit.boottalk.libs.exception.CustomException;
@@ -31,6 +33,7 @@ public class ReviewService {
 	private final UserRepository userRepository;
 	private final ReviewRepository reviewRepository;
 	private final CourseRepository courseRepository;
+	private final BootcampCertificationRepository certificationRepository;
 
 	@Transactional
 	public ReviewResponseDto createReview(ReviewCreateRequestDto request, Long userId) {
@@ -42,6 +45,10 @@ public class ReviewService {
 		Course course = getCourseWithLock(trainingProgramId);
 
 		User user = userRepository.getReferenceById(userId);
+
+		if (!certificationRepository.existsByUserAndCourseAndStatus(user, course, CertificationStatus.APPROVED)) {
+			throw new CustomException(WRITE_REVIEW_FORBIDDEN);
+		}
 
 		Review review = Review.of(request, course, user);
 

--- a/boottalk/src/test/java/com/icandoit/boottalk/review/service/ReviewServiceTest.java
+++ b/boottalk/src/test/java/com/icandoit/boottalk/review/service/ReviewServiceTest.java
@@ -23,9 +23,12 @@ import com.icandoit.boottalk.bootcamp.entity.Bootcamp;
 import com.icandoit.boottalk.bootcamp.entity.Course;
 import com.icandoit.boottalk.bootcamp.entity.TrainingCenter;
 import com.icandoit.boottalk.bootcamp.entity.enums.BootcampCategoryType;
+import com.icandoit.boottalk.bootcamp.entity.enums.CertificationStatus;
+import com.icandoit.boottalk.bootcamp.repository.BootcampCertificationRepository;
 import com.icandoit.boottalk.bootcamp.repository.BootcampRepository;
 import com.icandoit.boottalk.bootcamp.repository.CourseRepository;
 import com.icandoit.boottalk.libs.exception.CustomException;
+import com.icandoit.boottalk.libs.exception.ErrorCode;
 import com.icandoit.boottalk.review.dto.ReviewCreateRequestDto;
 import com.icandoit.boottalk.review.dto.ReviewResponseDto;
 import com.icandoit.boottalk.review.dto.ReviewUpdateRequestDto;
@@ -51,6 +54,9 @@ class ReviewServiceTest {
 	@Mock
 	private UserRepository userRepository;
 
+	@Mock
+	private BootcampCertificationRepository certificationRepository;
+
 	@BeforeEach
 	void setUp() {
 		MockitoAnnotations.openMocks(this);
@@ -65,6 +71,11 @@ class ReviewServiceTest {
 
 		Course course = Course.of(trainingProgramId, "TestCourse", BootcampCategoryType.AI_SERVICE_IMPLEMENTATION,null);
 		User user = User.builder().userId(userId).userName("testUser").build();
+
+		given(reviewRepository.existsByCourse_TrainingProgramIdAndUser_UserId(trainingProgramId, userId))
+			.willReturn(false);
+		given(!certificationRepository.existsByUserAndCourseAndStatus(user, course, CertificationStatus.APPROVED))
+			.willReturn(true);
 
 		ReviewCreateRequestDto request = new ReviewCreateRequestDto(trainingProgramId, "this is review", 3);
 
@@ -96,6 +107,39 @@ class ReviewServiceTest {
 			() -> reviewService.createReview(request, userId));
 
 		assertEquals(DUPLICATE_REVIEW, exception.getErrorCode());
+	}
+
+	@Test
+	@DisplayName("리뷰 생성 실패 - 부트캠프 수료인증이 안된 유저")
+	void createReviewFailsWriteReviewForbidden() {
+	    //given
+		String trainingProgramId = "TP123";
+		Long userId = 1L;
+
+		User user = User.builder().userId(userId).userName("testUser").build();
+
+		Course course = Course.builder()
+			.courseId(1L)
+			.trainingCenter(TrainingCenter.builder().trainingCenterId(1L).build())
+			.trainingProgramId(trainingProgramId)
+			.build();
+
+
+		given(reviewRepository.existsByCourse_TrainingProgramIdAndUser_UserId(trainingProgramId, userId))
+			.willReturn(false);
+		given(!certificationRepository.existsByUserAndCourseAndStatus(user, course, CertificationStatus.APPROVED))
+			.willReturn(false);
+
+		when(courseRepository.findWithLockByTrainingProgramId(trainingProgramId)).thenReturn(Optional.of(course));
+
+		ReviewCreateRequestDto request = new ReviewCreateRequestDto(trainingProgramId, "승인 안된 리뷰", 4);
+
+
+	    //when & then
+		CustomException exception = assertThrows(CustomException.class,
+			() -> reviewService.createReview(request, userId));
+
+		assertEquals(WRITE_REVIEW_FORBIDDEN, exception.getErrorCode());
 	}
 
 	@Test


### PR DESCRIPTION
Closes #85 
## 🔍 주요 변경 사항

- **서비스 계층 개선:**
  - 리뷰 작성 시, 사용자의 해당 코스에 승인된(Approved) 수료 인증 존재 여부를 검증하도록 로직 개선
- **리포지토리 수정:**
  - `BootcampCertificationRepository`에 `existsByUserAndCourseAndStatus(User, Course, CertificationStatus)` 및 

---

## 💡 변경 이유:
- 보안 및 데이터 일관성: 리뷰 작성 시, 반드시 승인된 수료 인증이 있어야 리뷰 작성이 가능하도록 제약을 강화하여 데이터 무결성을 확보합니다.

---

## 🚀 개선 결과:
- 리뷰 작성 전, 사용자는 해당 코스에 대해 승인된 수료 인증이 없으면 리뷰를 작성할 수 없도록 처리됩니다.

---

## 📂 관련 클래스 및 변경 파일:
- **서비스:**  
  - `com.icandoit.boottalk.review.service.ReviewService.java` – 승인된 인증 여부를 체크하는 로직 수정
- **리포지토리:**  
  - `com.icandoit.boottalk.bootcamp.repository.BootcampCertificationRepository.java`

---

## ✅ 테스트 시나리오:
- **케이스 1: 내 수료 인증 조회 성공**  
  - 사용자가 승인된 수료 인증 내역을 조회하면, 해당 코스명 및 카테고리명이 올바르게 반환되는지 확인
- **케이스 2: 리뷰 작성 성공 (승인된 인증 존재)**  
  - 사용자가 승인된 수료 인증을 보유한 경우 리뷰 작성이 성공하고, 코스의 총 점수와 리뷰 수가 업데이트되는지 확인
- **케이스 3: 리뷰 작성 실패 (승인된 인증이 없는 경우)**  
  - 승인된 수료 인증이 없는 경우 리뷰 작성 시 WRITE_REVIEW_FORBIDDEN 에러가 발생하는지 확인
- **케이스 4: 존재하지 않는 코스의 경우**  
  - 코스 정보가 없을 때 COURSE_NOT_FOUND 예외가 발생하는지 확인


