### PR TITLE
feat : certification 조회, 수정 관리자 권한 추가

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/controller/BootcampCertificationController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/controller/BootcampCertificationController.java
@@ -59,6 +59,7 @@ public class BootcampCertificationController {
 	}
 
 	@PutMapping
+	@PreAuthorize("hasAuthority('ADMIN')")
 	public ResponseEntity<CertificationResponseDto> updateCertification(@RequestBody CertificationUpdateRequestDto request){
 		return ResponseEntity.ok(certificationService.updateCertification(request));
 	}

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/controller/BootcampCertificationController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/controller/BootcampCertificationController.java
@@ -3,6 +3,7 @@ package com.icandoit.boottalk.bootcamp.controller;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -44,15 +45,16 @@ public class BootcampCertificationController {
 		return ResponseEntity.ok(response);
 	}
 
-	// TODO :관리자 권한 추가
 	@GetMapping
+	@PreAuthorize("hasAuthority('ADMIN')")
 	public ResponseEntity<List<GetPendingCertificationResponseDto>> getAllCertifications() {
 		return ResponseEntity.ok(certificationService.getPendingCertifications());
 	}
 
-	// 관리자 권한 추가
 	@GetMapping("/{certificationId}")
-	public ResponseEntity<GetCertificationInfoDto> getCertification(@PathVariable Long certificationId) {
+	@PreAuthorize("hasAuthority('ADMIN')")
+	public ResponseEntity<GetCertificationInfoDto> getCertification(
+		@PathVariable Long certificationId) {
 		return ResponseEntity.ok(certificationService.findById(certificationId));
 	}
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/BootcampCertificationService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/BootcampCertificationService.java
@@ -63,7 +63,6 @@ public class BootcampCertificationService {
 			.collect(Collectors.toList());
 	}
 
-	// TODO : 관리자 권한 추가
 	// 승인 대기중인 요청 모두 조회
 	public List<GetPendingCertificationResponseDto> getPendingCertifications() {
 		List<BootcampCertification> certifications = bootcampCertificationRepository.findAllByStatus(CertificationStatus.PENDING);
@@ -73,14 +72,13 @@ public class BootcampCertificationService {
 	}
 
 	// 수료증 정보 조회
-	// TODO : 관리자 권한 추가
 	public GetCertificationInfoDto findById(Long certificationId) {
 		BootcampCertification certification = bootcampCertificationRepository.getReferenceById(certificationId);
 
 		return GetCertificationInfoDto.from(certification);
 	}
 
-	// TODO : 관리자 권한 추가
+	// 수료증 승인 거절 로직
 	public CertificationResponseDto updateCertification(CertificationUpdateRequestDto request) {
 		BootcampCertification certification = bootcampCertificationRepository.getReferenceById(request.certificationId());
 


### PR DESCRIPTION
## 🔍 주요 변경 사항
- 관리자(Admin) 전용 API에 `@PreAuthorize("hasAuthority('ADMIN')")` 어노테이션 추가
  - `/api/users/certification` 경로의 전체 인증 요청 조회 API  
  - `/api/users/certification/{certificationId}` 경로의 개별 인증 정보 조회 API

---

## 💡 변경 이유
- 민감한 인증 정보 조회 API가 관리자의 전용 기능임을 명확히 하고, 일반 사용자가 접근하지 못하도록 하기 위함
- 보안 강화 및 권한 기반 접근 제어 정책을 적용하여, 오용 또는 비인가 접근을 차단하기 위함

---

## 🚀 개선 결과
- 해당 관리자 API는 이제 관리자 권한(ADMIN)이 있는 사용자만 호출할 수 있게 되어 보안이 강화됨
- 프론트엔드에서는 관리자 권한이 있는 사용자만 해당 인증 정보를 확인할 수 있으며, 권한이 없는 경우 접근이 거부됨

