### PR TITLE
feat: 커피챗 신청 가능 시간 목록 조회

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatApplicationController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatApplicationController.java
@@ -84,6 +84,5 @@ public class CoffeeChatApplicationController {
         return ResponseEntity.ok().build();
     }
 
-    // TODO: 커피챗 신청 예약 일정 조회
 
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatTimeController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatTimeController.java
@@ -1,5 +1,6 @@
 package com.icandoit.boottalk.coffeeChat.controller;
 
+import com.icandoit.boottalk.coffeeChat.dto.AvailableChatTimeDto;
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatTimeMapDto;
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatTimeResponseDto;
 import com.icandoit.boottalk.coffeeChat.service.CoffeeChatTimeService;
@@ -31,11 +32,9 @@ public class CoffeeChatTimeController {
     }
 
     //mentorId를 받아 커피챗 가능 시간 조회
-    @GetMapping("/{mentorId}")
-    public ResponseEntity<List<CoffeeChatTimeResponseDto>> getMentorAvailableChatTimes(
-        @PathVariable Long mentorId) {
-
-        return ResponseEntity.ok(coffeeChatTimeService.getMentorAvailableChatTimes(mentorId));
+    @GetMapping("/{coffeeChatInfoId}")
+    public ResponseEntity<AvailableChatTimeDto> getAvailableChatTimes(@PathVariable Long coffeeChatInfoId) {
+        return ResponseEntity.ok(coffeeChatTimeService.getAvailableChatTimes(coffeeChatInfoId));
     }
 
     @PutMapping

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/dto/AvailableChatTimeDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/dto/AvailableChatTimeDto.java
@@ -1,0 +1,11 @@
+package com.icandoit.boottalk.coffeeChat.dto;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+
+public record AvailableChatTimeDto (
+    Map<LocalDate, List<LocalTime>> availableChatTimes
+){
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/repository/CoffeeChatApplicationRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/repository/CoffeeChatApplicationRepository.java
@@ -3,6 +3,7 @@ package com.icandoit.boottalk.coffeeChat.repository;
 import com.icandoit.boottalk.coffeeChat.entity.CoffeeChatApplication;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -56,5 +57,22 @@ public interface CoffeeChatApplicationRepository extends JpaRepository<CoffeeCha
 		@Param("coffeeChatStartTime") LocalDateTime coffeeChatStartTime);
 
 	boolean existsByMentee_UserIdAndCoffeeChatInfo_CoffeeChatInfoId(Long userId, Long coffeeChatInfoId);
+
+	// 커피챗 정보 ID에 해당하는 startTime ~ endTime 기간의 커피챗 시작 시간들 조회
+	//
+	@Query("""
+		SELECT ca.coffeeChatStartTime
+		FROM CoffeeChatApplication ca
+		WHERE ca.coffeeChatInfo.coffeeChatInfoId = :coffeeChatInfoId
+		AND ca.coffeeChatStartTime BETWEEN
+		:startTime AND :endTime
+		AND ca.status != "CANCELED"
+	""")
+	List<LocalDateTime> findStartTimesByCoffeeChatInfoIdAndPeriod(
+		@Param("coffeeChatInfoId") Long coffeeChatInfoId,
+		@Param("startTime") LocalDateTime startTime,
+		@Param("endTime") LocalDateTime endTime
+	);
+
 
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/repository/CoffeeChatTimeRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/repository/CoffeeChatTimeRepository.java
@@ -12,5 +12,9 @@ public interface CoffeeChatTimeRepository extends JpaRepository<CoffeeChatTime, 
     @Query("SELECT ct FROM CoffeeChatTime ct JOIN FETCH ct.coffeeChatInfo WHERE ct.coffeeChatInfo.mentor.userId = :mentorId")
     List<CoffeeChatTime> findAllWithCoffeeChatInfoByUserId(@Param("mentorId") Long mentorId);
 
+    @Query("SELECT ct FROM CoffeeChatTime ct JOIN FETCH ct.coffeeChatInfo WHERE ct.coffeeChatInfo.coffeeChatInfoId = :coffeeChatInfoId")
+    List<CoffeeChatTime> findAllWithCoffeeChatInfoByCoffeeChatInfoId(@Param("coffeeChatInfoId") Long coffeeChatInfoId);
+
     boolean existsByCoffeeChatInfo(CoffeeChatInfo coffeeChatInfo);
+
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatTimeService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatTimeService.java
@@ -1,32 +1,44 @@
 package com.icandoit.boottalk.coffeeChat.service;
 
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.icandoit.boottalk.coffeeChat.dto.AvailableChatTimeDto;
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatTimeDto;
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatTimeMapDto;
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatTimeResponseDto;
 import com.icandoit.boottalk.coffeeChat.entity.CoffeeChatInfo;
 import com.icandoit.boottalk.coffeeChat.entity.CoffeeChatTime;
+import com.icandoit.boottalk.coffeeChat.repository.CoffeeChatApplicationRepository;
 import com.icandoit.boottalk.coffeeChat.repository.CoffeeChatInfoRepository;
 import com.icandoit.boottalk.coffeeChat.repository.CoffeeChatTimeRepository;
 import com.icandoit.boottalk.coffeeChat.service.converter.CoffeeChatTimeConverter;
 import com.icandoit.boottalk.libs.exception.CustomException;
 import com.icandoit.boottalk.libs.exception.ErrorCode;
-import java.time.DayOfWeek;
-import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class CoffeeChatTimeService {
+    private static final int COFFEE_CHAT_APPLICATION_PERIOD_DAYS = 30;
 
     private final CoffeeChatInfoRepository coffeeChatInfoRepository;
     private final CoffeeChatTimeRepository coffeeChatTimeRepository;
+    private final CoffeeChatApplicationRepository coffeeChatAppRepository;
 
     @Transactional
     public List<CoffeeChatTimeResponseDto> createCoffeeChatTimes(Long userId,
@@ -62,11 +74,31 @@ public class CoffeeChatTimeService {
     // 자신의 멘토 가능 시간 조회
     @Transactional(readOnly = true)
     public List<CoffeeChatTimeResponseDto> getMentorAvailableChatTimes(Long userId) {
-        List<CoffeeChatTime> coffeeChatTimes = getmentorCoffeeChatTimesOrThrow(userId);
+        List<CoffeeChatTime> coffeeChatTimes = getMentorCoffeeChatTimesOrThrow(userId);
 
         return coffeeChatTimes.stream()
             .map(CoffeeChatTimeResponseDto::from)
             .toList();
+    }
+
+    public AvailableChatTimeDto getAvailableChatTimes(Long coffeeChatInfoId) {
+
+        // 현재 시간과 신청 기간 설정
+        LocalDateTime now = LocalDateTime.now();
+        LocalDate startDate = now.toLocalDate();
+        LocalDate endDate = startDate.plusDays(COFFEE_CHAT_APPLICATION_PERIOD_DAYS);
+        
+        // 멘토가 설정한 요일별 멘토링(커피챗) 시간 목록
+        List<CoffeeChatTime> mentoringTimeList = coffeeChatTimeRepository.findAllWithCoffeeChatInfoByCoffeeChatInfoId(coffeeChatInfoId);
+
+        // 이미 신청된 커피챗 시간 목록
+        List<LocalDateTime> appliedDateTimes = coffeeChatAppRepository.findStartTimesByCoffeeChatInfoIdAndPeriod(
+                coffeeChatInfoId, now, now.plusDays(COFFEE_CHAT_APPLICATION_PERIOD_DAYS));
+
+        // 신청된 시간 제외한 신청 가능한 시간 필터링
+        Map<LocalDate, List<LocalTime>> availableChatTimesByDate  = getAvailableChatTimesByDate(mentoringTimeList, appliedDateTimes, startDate, endDate);
+
+        return new AvailableChatTimeDto(availableChatTimesByDate);
     }
 
     @Transactional
@@ -125,11 +157,42 @@ public class CoffeeChatTimeService {
         return dayOfWeek.toString() + "-" + startTime.format(DateTimeFormatter.ofPattern("HH:mm"));
     }
 
-    private List<CoffeeChatTime> getmentorCoffeeChatTimesOrThrow(Long userId) {
+    private List<CoffeeChatTime> getMentorCoffeeChatTimesOrThrow(Long userId) {
 
         return Optional.ofNullable(
                 coffeeChatTimeRepository.findAllWithCoffeeChatInfoByUserId(userId))
             .filter(list -> !list.isEmpty())
             .orElseThrow(() -> new CustomException(ErrorCode.USER_COFFEE_CHAT_NOT_FOUND));
     }
+
+    // 멘토링 가능한 시간과 신청된 시간을 필터링하여 신청 가능한 시간을 구함
+    private Map<LocalDate, List<LocalTime>> getAvailableChatTimesByDate(
+        List<CoffeeChatTime> mentoringTimeList,
+        List<LocalDateTime> appliedDateTimes,
+        LocalDate startDate, LocalDate endDate
+    ) {
+        // 신청일 기준 30일 내 멘토링 가능한 요일의 날짜를 key로, 해당 날짜의 신청 가능 시간을 리스트로 매핑
+        Map<LocalDate, List<LocalTime>> availableChatTimesByDate = new HashMap<>();
+
+        for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
+            List<LocalTime> availableTimes = new ArrayList<>();
+            for (CoffeeChatTime chatTime : mentoringTimeList) {
+                if (date.getDayOfWeek() == chatTime.getDayOfWeek()) { // 멘토링 시간의 요일과 일치하는 날짜라면
+                    LocalTime startTime = chatTime.getStartTime();
+                    LocalDateTime fullDateTime = LocalDateTime.of(date, startTime); // appliedDateTimes의 LocalDateTime 과 비교하기 위해 포맷팅
+                    if (!appliedDateTimes.contains(fullDateTime)) { // 이미 신청된 시간이 아니라면 추가
+                        availableTimes.add(startTime);
+                    }
+                }
+            }
+
+            // 신청 가능한 시간이 있다면 맵에 추가
+            if (!availableTimes.isEmpty()) {
+                availableChatTimesByDate.put(date, availableTimes);
+            }
+        }
+
+        return availableChatTimesByDate;
+    }
+
 }


### PR DESCRIPTION
## 🔍 주요 변경 사항
- 멘토가 설정한 **요일별 멘토링 시간을 기준**으로, **오늘부터 30일간의 신청 가능한 시간 목록 조회** 기능 추가
- 기존에 신청된 시간은 제외하고, 신청 가능한 시간만 필터링하여 `AvailableChatTimeDto`로 반환
- **신청된 커피챗 중 상태가 'CANCELED' 인 것은 제외**하고 조회
- 기존 **멘토의 커피챗 시간 목록을 조회** 하는 **GET /api/coffee-cats/times/{mentorId} API 삭제**
   - **커피챗 신청 가능 시간 목록 조**회 **GET /api/coffee-cats/times/{coffeeChatId} API 가 추가**되면서 위 API가 필요 없어짐


---

## 💡 변경 이유
- 날짜별로 신청 가능한 커피챗 시간을 클리이언트에 명확하게 제공하기 위함
- 멘토가 설정한 요일별 멘토링 시간과 이미 신청된 시간을 비교하여, 사용자가 실제로 선택 가능한 시간만 전달하도록 하기 위함

--- 

## 🖼️ 스크린샷
ID가 16인 커피챗 정보에 설정한 시간이

> 월요일 - 9:00, 14:00
> 화요일 - 9:30, 10:00, 14:30
> 일요일 - 14:00, 15:00

일 때, 아래와 같이 조회됨
![신청가능커피챗시간목록](https://github.com/user-attachments/assets/c53873eb-4f8b-4959-84a4-e6f7868d65d3)


