### PR TITLE
feat: 커피챗 정보/커피챗 신청 상세 조회 추가

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatApplicationController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatApplicationController.java
@@ -63,6 +63,12 @@ public class CoffeeChatApplicationController {
             user.getServiceUserId(), pageable));
     }
 
+    // 커피챗 신청 상세 조회
+    @GetMapping("/{coffeeChatAppId}")
+    public ResponseEntity<CoffeeChatApplicationResponseDto> getCoffeeChatAppInfo(@PathVariable Long coffeeChatAppId) {
+        return ResponseEntity.ok(coffeeChatAppService.getCoffeeChatAppInfo(coffeeChatAppId));
+    }
+
     // 커피챗 신청 수정
     @PutMapping("/{coffeeChatAppId}")
     public ResponseEntity<CoffeeChatApplicationResponseDto> updateCoffeeChatApp(

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatInfoController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatInfoController.java
@@ -4,6 +4,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,6 +28,11 @@ public class CoffeeChatInfoController {
     public ResponseEntity<CoffeeChatInfoResponseDto> getMyCoffeeChatInfo(@AuthenticationPrincipal CustomOAuth2User user) {
 
         return ResponseEntity.ok(coffeeChatInfoService.getMyCoffeeChatInfo(user.getServiceUserId()));
+    }
+
+    @GetMapping("/{coffeeChatInfoId}")
+    public ResponseEntity<CoffeeChatInfoResponseDto> getCoffeeChatInfo(@PathVariable Long coffeeChatInfoId) {
+        return ResponseEntity.ok(coffeeChatInfoService.getCoffeeChatInfo(coffeeChatInfoId));
     }
 
     @PutMapping

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/repository/CoffeeChatInfoRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/repository/CoffeeChatInfoRepository.java
@@ -8,7 +8,5 @@ public interface CoffeeChatInfoRepository extends JpaRepository<CoffeeChatInfo, 
 
     Optional<CoffeeChatInfo> findByMentor_UserId(Long userId);
 
-    Optional<CoffeeChatInfo> findByCoffeeChatInfoId(Long coffeeChatInfoId);
-
     boolean existsByMentor_UserId(Long userId);
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/repository/CoffeeChatInfoRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/repository/CoffeeChatInfoRepository.java
@@ -6,7 +6,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CoffeeChatInfoRepository extends JpaRepository<CoffeeChatInfo, Long> {
 
-    Optional<CoffeeChatInfo> findBymentor_UserId(Long userId);
+    Optional<CoffeeChatInfo> findByMentor_UserId(Long userId);
 
-    boolean existsBymentor_UserId(Long userId);
+    Optional<CoffeeChatInfo> findByCoffeeChatInfoId(Long coffeeChatInfoId);
+
+    boolean existsByMentor_UserId(Long userId);
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatApplicationService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatApplicationService.java
@@ -100,6 +100,9 @@ public class CoffeeChatApplicationService {
         return PagedResponseDto.from(page);
     }
 
+    public CoffeeChatApplicationResponseDto getCoffeeChatAppInfo(Long coffeeChatAppId) {
+        return CoffeeChatApplicationResponseDto.from(getCoffeeChatApplication(coffeeChatAppId));
+    }
 
     @Transactional
     public CoffeeChatApplicationResponseDto updateCoffeeChatApp(

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatInfoService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatInfoService.java
@@ -50,7 +50,7 @@ public class CoffeeChatInfoService {
 
     public CoffeeChatInfoResponseDto getCoffeeChatInfo(Long coffeeChatInfoId) {
         return CoffeeChatInfoResponseDto.from(
-            coffeeChatInfoRepository.findByCoffeeChatInfoId(coffeeChatInfoId)
+            coffeeChatInfoRepository.findById(coffeeChatInfoId)
                 .orElseThrow(() -> new CustomException(ErrorCode.COFFEE_CHAT_NOT_FOUND))
         );
     }

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatInfoService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatInfoService.java
@@ -26,7 +26,7 @@ public class CoffeeChatInfoService {
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        if (coffeeChatInfoRepository.existsBymentor_UserId(userId)) {
+        if (coffeeChatInfoRepository.existsByMentor_UserId(userId)) {
             throw new CustomException(ErrorCode.COFFEE_CHAT_ALREADY_EXISTS);
         }
 
@@ -46,6 +46,13 @@ public class CoffeeChatInfoService {
 
         CoffeeChatInfo coffeeChatInfo = getCoffeeChatInfoByUserId(userId);
         return CoffeeChatInfoResponseDto.from(coffeeChatInfo);
+    }
+
+    public CoffeeChatInfoResponseDto getCoffeeChatInfo(Long coffeeChatInfoId) {
+        return CoffeeChatInfoResponseDto.from(
+            coffeeChatInfoRepository.findByCoffeeChatInfoId(coffeeChatInfoId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COFFEE_CHAT_NOT_FOUND))
+        );
     }
 
     @Transactional
@@ -71,7 +78,7 @@ public class CoffeeChatInfoService {
     }
 
     protected CoffeeChatInfo getCoffeeChatInfoByUserId(Long userId) {
-        return coffeeChatInfoRepository.findBymentor_UserId(userId)
+        return coffeeChatInfoRepository.findByMentor_UserId(userId)
             .orElseThrow(() -> new CustomException(ErrorCode.USER_COFFEE_CHAT_NOT_FOUND));
     }
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatTimeService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatTimeService.java
@@ -32,7 +32,7 @@ public class CoffeeChatTimeService {
     public List<CoffeeChatTimeResponseDto> createCoffeeChatTimes(Long userId,
         CoffeeChatTimeMapDto requestDto) {
 
-        CoffeeChatInfo coffeeChatInfo = coffeeChatInfoRepository.findBymentor_UserId(userId)
+        CoffeeChatInfo coffeeChatInfo = coffeeChatInfoRepository.findByMentor_UserId(userId)
             .orElseThrow(() -> new CustomException(ErrorCode.USER_COFFEE_CHAT_NOT_FOUND));
 
         // 이미 시간이 존재한다면 예외처리
@@ -73,7 +73,7 @@ public class CoffeeChatTimeService {
     public List<CoffeeChatTimeResponseDto> updateCoffeeChatTimes(Long userId,
         CoffeeChatTimeMapDto requestDto) {
 
-        CoffeeChatInfo coffeeChatInfo = coffeeChatInfoRepository.findBymentor_UserId(userId)
+        CoffeeChatInfo coffeeChatInfo = coffeeChatInfoRepository.findByMentor_UserId(userId)
             .orElseThrow(() -> new CustomException(ErrorCode.USER_COFFEE_CHAT_NOT_FOUND));
 
         List<CoffeeChatTime> existingTimes = coffeeChatTimeRepository.findAllWithCoffeeChatInfoByUserId(


### PR DESCRIPTION
## 🔍 주요 변경 사항
- 커피챗 정보 ID로 커피챗 정보 상세 조회 추가
- 커피챗 신청 ID로 커피챗 신청 상세 조회 추가
---

## 💡 변경 이유
- 기존에는 나의 커피챗 정보 조회만 있으므로, 다른 멘토의 커피챗 정보를 볼 수 있는 API가 필요했음
- 기존에는 나의 커피챗 목록 조회만 있으므로, 커피챗 신청 내역을 클릭하였을 때 해당 상세 내용을 보기 위한 커피챗 신청 상세 조회 API가 필요했음
--- 

## 🖼️ 스크린샷
- coffeeChatInfoId가 16인 커피챗 정보 상세 조회
![커피챗상세](https://github.com/user-attachments/assets/36ce2810-9c70-41e3-b50f-b805c824e98f)

- coffeeChatAppId가 37인 커피챗 신청 상세 조회
![커피챗신청상세](https://github.com/user-attachments/assets/e2e53d97-1252-41f6-82a5-fd8d8dae079f)


