### PR TITLE
feat : 부트캠프 검색 자동완성 기능 추가

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/controller/BootcampController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/controller/BootcampController.java
@@ -1,5 +1,7 @@
 package com.icandoit.boottalk.bootcamp.controller;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -11,8 +13,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.icandoit.boottalk.bootcamp.dto.BootcampAutocompleteDto;
 import com.icandoit.boottalk.bootcamp.dto.BootcampResponseDto;
+import com.icandoit.boottalk.bootcamp.entity.Bootcamp;
 import com.icandoit.boottalk.bootcamp.entity.enums.BootcampCategoryType;
+import com.icandoit.boottalk.bootcamp.repository.BootcampRepository;
 import com.icandoit.boottalk.bootcamp.service.BootcampService;
 import com.icandoit.boottalk.common.dto.PagedResponseDto;
 import com.icandoit.boottalk.review.dto.ReviewResponseDto;
@@ -27,6 +32,7 @@ public class BootcampController {
 
 	private final BootcampService bootcampService;
 	private final ReviewService reviewService;
+	private final BootcampRepository bootcampRepository;
 
 	// 지역별(시), 카테고리별(BootcampCategory), 평균 평점 별(없음, 1, 2, 3, 4 이상), 기간별 (4주 미만, 4 ~ 12주, 12 주 이상)
 	// 전체 조회 or 필터 기반 조회 (키워드 없음)
@@ -90,5 +96,17 @@ public class BootcampController {
 		Page<ReviewResponseDto> result = reviewService.getReviewsBootcampId(bootcampId, pageable);
 
 		return ResponseEntity.ok(PagedResponseDto.from(result));
+	}
+
+	@GetMapping("/autocomplete")
+	public ResponseEntity<List<BootcampAutocompleteDto>> autocomplete(
+		@RequestParam("query") String query
+	) {
+		Pageable pageable = PageRequest.of(0, 6);
+		List<Bootcamp> bootcamps = bootcampRepository.findByBootcampNameContainingIgnoreCase(query, pageable);
+		List<BootcampAutocompleteDto> result = bootcamps.stream()
+			.map(bootcamp -> new BootcampAutocompleteDto(bootcamp.getBootcampId(), bootcamp.getBootcampName()))
+			.toList();
+		return ResponseEntity.ok(result);
 	}
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/controller/CourseController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/controller/CourseController.java
@@ -32,7 +32,7 @@ public class CourseController {
 		List<Course> courses = courseRepository.findByCourseNameContainingIgnoreCase(query, pageable);
 		List<CourseAutocompleteDto> result = courses.stream()
 			.map(course -> new CourseAutocompleteDto(course.getCourseId(), course.getCourseName()))
-			.collect(Collectors.toList());
+			.toList();
 		return ResponseEntity.ok(result);
 	}
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/dto/BootcampAutocompleteDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/dto/BootcampAutocompleteDto.java
@@ -1,0 +1,4 @@
+package com.icandoit.boottalk.bootcamp.dto;
+
+public record BootcampAutocompleteDto(Long bootcampId, String bootcampName) {
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/repository/BootcampRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/repository/BootcampRepository.java
@@ -1,5 +1,8 @@
 package com.icandoit.boottalk.bootcamp.repository;
 
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.icandoit.boottalk.bootcamp.entity.Bootcamp;
@@ -7,4 +10,6 @@ import com.icandoit.boottalk.bootcamp.entity.Bootcamp;
 public interface BootcampRepository extends JpaRepository <Bootcamp, Long> {
 	// trainingProgramId와 bootcampDegree(기수)를 기준으로 부트캠프 존재 여부 확인.
 	boolean existsByCourse_TrainingProgramIdAndBootcampDegree(String trainingProgramId, int bootcampDegree);
+
+	List<Bootcamp> findByBootcampNameContainingIgnoreCase(String query, Pageable pageable);
 }


### PR DESCRIPTION
## 🔍 주요 변경 사항
- Autocomplete API 추가:
    - /api/bootcamps/autocomplete 엔드포인트를 추가하여, 부트캠프 이름에 대한 검색어(query)를 받아 검색 결과(최대 6건)를 반환하도록 구현
    - BootcampRepository에 findByBootcampNameContainingIgnoreCase(String query, Pageable pageable) 메소드 추가하여 페이징 처리된 검색 결과를 제공
- DTO 생성:
    - BootcampAutocompleteDto를 새로 생성하여, 부트캠프 ID와 이름만 반환하도록 구성

---

## 💡 변경 이유
- 사용자 인터페이스에서 부트캠프 이름 검색 시 자동완성 기능을 제공하여, 사용자가 보다 빠르게 원하는 부트캠프를 선택할 수 있도록 개선하기 위함

---

## 🚀 개선 결과
- 사용자가 부트캠프 이름 입력 시, /api/bootcamps/autocomplete API를 호출하여 최대 6개의 관련 부트캠프 결과를 실시간으로 조회할 수 있게 됨
- 결과는 부트캠프 ID와 이름만을 포함한 경량 DTO로 반환되어, 프론트엔드 처리 속도 및 효율성이 향상됨

---

## 📂 관련 클래스 및 변경 파일
- `BootcampController.java`
- `BootcampRepository.java`
- `BootcampAutocompleteDto.java`

## 스크린샷
![스크린샷 2025-04-12 오전 1 29 29](https://github.com/user-attachments/assets/015edb2f-5640-4178-b25a-1dd069dd748f)


