### PR TITLE
fix: 커피챗 신청 관련 테스트 수정 (CoffeeChatApplicationServiceTest, CoffeeChatApplicationServiceIntegrationTest)

### DIFF
--- a/boottalk/src/test/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatApplicationServiceIntegrationTest.java
+++ b/boottalk/src/test/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatApplicationServiceIntegrationTest.java
@@ -9,6 +9,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.icandoit.boottalk.bootcamp.entity.enums.BootcampCategoryType;
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatApplicationCreateDto;
@@ -17,17 +21,35 @@ import com.icandoit.boottalk.coffeeChat.entity.enums.JobType;
 import com.icandoit.boottalk.coffeeChat.entity.enums.MentorType;
 import com.icandoit.boottalk.coffeeChat.repository.CoffeeChatApplicationRepository;
 import com.icandoit.boottalk.coffeeChat.repository.CoffeeChatInfoRepository;
+import com.icandoit.boottalk.point_history.domain.entity.PointHistory;
+import com.icandoit.boottalk.point_history.domain.repository.PointHistoryRepository;
 import com.icandoit.boottalk.point_history.domain.type.EventType;
 import com.icandoit.boottalk.point_history.service.CreatePointHistoryService;
 import com.icandoit.boottalk.user.domain.entity.User;
 import com.icandoit.boottalk.user.domain.repository.UserRepository;
 
-import jakarta.transaction.Transactional;
 
 @SpringBootTest
+@ActiveProfiles("test")
 @Transactional // 테스트 끝나면 자동 롤백
 @DisplayName("커피챗 신청 서비스 통합 테스트")
 public class CoffeeChatApplicationServiceIntegrationTest {
+    @TestConfiguration
+    static class TestHelper {
+
+        @Autowired
+        PointHistoryRepository pointHistoryRepository;
+
+        @Transactional(propagation = Propagation.NOT_SUPPORTED)
+        public int getCurrentPointToTest(Long userId) {
+            return pointHistoryRepository.findFirstByUserIdOrderByPointHistoryIdDesc(userId)
+                .map(PointHistory::getCurrentPoint)
+                .orElse(0);
+        }
+    }
+
+    @Autowired
+    TestHelper testHelper;
 
     @Autowired
     private CoffeeChatApplicationService coffeeChatApplicationService;
@@ -80,7 +102,7 @@ public class CoffeeChatApplicationServiceIntegrationTest {
     @DisplayName("커피챗 신청 실패 시 포인트 차감 롤백됨")
     void shouldRollbackPointDeduction_WhenApplicationFails() {
         // Given
-        int beforePoint = createPointHistoryService.getCurrentPoint(mentee.getUserId());
+        int beforePoint = testHelper.getCurrentPointToTest(mentee.getUserId());
 
         CoffeeChatApplicationCreateDto request = new CoffeeChatApplicationCreateDto(
             chatInfo.getCoffeeChatInfoId(),
@@ -89,15 +111,14 @@ public class CoffeeChatApplicationServiceIntegrationTest {
             LocalDateTime.of(2025, 4, 5, 11, 0)
         );
 
-        // Save 실패 유도: 예를 들면 필수 필드 누락 or 유니크 위반
-
         // When
         assertThrows(Exception.class, () -> {
             coffeeChatApplicationService.createCoffeeChatApp(mentee.getUserId(), request);
         });
 
         // Then: 포인트 차감이 롤백되어 이전과 동일한 값 유지
-        int afterPoint = createPointHistoryService.getCurrentPoint(mentee.getUserId());
+        int afterPoint = testHelper.getCurrentPointToTest(mentee.getUserId());
         assertEquals(beforePoint, afterPoint, "커피챗 저장 실패 시 포인트 차감이 롤백되어야 합니다.");
     }
+
 }

--- a/boottalk/src/test/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatApplicationServiceTest.java
+++ b/boottalk/src/test/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatApplicationServiceTest.java
@@ -83,23 +83,23 @@ class CoffeeChatApplicationServiceTest {
             LocalDateTime.of(2025, 4, 5, 11, 0)
         );
 
-        int currentPoint = 5;
         int deductionPoint  = 3;
 
-        CoffeeChatApplication mockApplication = CoffeeChatApplication.of(mockUser, mockChatInfo, request);
+        CoffeeChatApplication mockApplication = CoffeeChatApplication.of(mockUser, mockChatInfo, deductionPoint, request);
 
         // Mock 설정
         // 중복 신청이 아닌 경우 설정
-        when(coffeeChatAppRepository.existsByMentee_UserIdAndCoffeeChatInfo_CoffeeChatInfoId(userId,
-            coffeeChatInfoId)).thenReturn(false);
+        when(coffeeChatAppRepository.existsLatestPendingOrApprovedApplication(userId, coffeeChatInfoId)).thenReturn(false);
+        when(coffeeChatAppRepository.isTimeSlotAlreadyTaken(userId, request.coffeeChatStartTime())).thenReturn(false);
+
         // 유저와 커피챗 정보가 정상 조회 된다는 설정
         when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
         when(coffeeChatInfoRepository.findById(coffeeChatInfoId)).thenReturn(Optional.of(mockChatInfo));
-        // 현재 포인트 조회 결과 지정
-        when(createPointHistoryService.getCurrentPoint(userId)).thenReturn(currentPoint);
+
         // 포인트 차감
         when(createPointHistoryService.createPointHistory(
             EventType.COFFEE_CHAT_APPLY, userId, deductionPoint)).thenReturn(mock(PointHistoryDto.class));
+
         // 저장 후 반환될 커피챗 신청 객체 설정
         when(coffeeChatAppRepository.save(any(CoffeeChatApplication.class))).thenReturn(mockApplication);
 
@@ -112,38 +112,13 @@ class CoffeeChatApplicationServiceTest {
         assertEquals(userId, response.menteeUserId()); // 신청자 유저 ID 확인
         assertEquals(StatusType.PENDING, response.status()); // 신청 상태 확인
 
-    }
-
-    @Test
-    @DisplayName("커피챗 신청 실패 - 포인트 부족")
-    void createCoffeeChatApplication_LackOfPoint() {
-        // Given
-        Long userId = mockUser.getUserId();
-        Long coffeeChatInfoId = mockChatInfo.getCoffeeChatInfoId();
-
-        CoffeeChatApplicationCreateDto request = new CoffeeChatApplicationCreateDto(
-            coffeeChatInfoId,
-            "안녕하세요 백엔드 커피챗 신청합니다.",
-            LocalDateTime.of(2025, 4, 5, 10, 30),
-            LocalDateTime.of(2025, 4, 5, 11, 0)
+        // 현재 포인트 차감 확인
+        verify(createPointHistoryService).createPointHistory(
+            eq(EventType.COFFEE_CHAT_APPLY),
+            eq(userId),
+            eq(deductionPoint)  // deductionPoint가 정확하게 차감되었는지 확인
         );
 
-        int currentPoint = 1; // 차감 포인트보다 부족
-
-        // Mock 설정
-        // 중복 신청이 아닌 경우 설정
-        when(coffeeChatAppRepository.existsByMentee_UserIdAndCoffeeChatInfo_CoffeeChatInfoId(userId,
-            coffeeChatInfoId)).thenReturn(false);
-        // 유저와 커피챗 정보가 정상 조회 된다는 설정
-        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
-        when(coffeeChatInfoRepository.findById(coffeeChatInfoId)).thenReturn(Optional.of(mockChatInfo));
-        // 현재 포인트 조회 결과 지정
-        when(createPointHistoryService.getCurrentPoint(userId)).thenReturn(currentPoint);
-
-        // When & Then
-        assertThrows(CustomException.class, () -> {
-            coffeeChatApplicationService.createCoffeeChatApp(userId, request);
-        } );
     }
 
     @Test
@@ -159,10 +134,9 @@ class CoffeeChatApplicationServiceTest {
             LocalDateTime.of(2025, 4, 5, 10, 30),
             LocalDateTime.of(2025, 4, 5, 11, 0)
         );
-
-
-        when(coffeeChatAppRepository.existsByMentee_UserIdAndCoffeeChatInfo_CoffeeChatInfoId(userId,
-            coffeeChatInfoId)).thenReturn(true); // 이미 신청된 상태
+        
+        // 해당 커피챗에 대해 대기 상태의 신청이 이미 존재
+        when(coffeeChatAppRepository.existsLatestPendingOrApprovedApplication(userId, coffeeChatInfoId)).thenReturn(true);
 
         // When & Then
         assertThrows(CustomException.class, () -> {
@@ -171,49 +145,5 @@ class CoffeeChatApplicationServiceTest {
 
     }
 
-
-    @Test
-    @DisplayName("포인트 차감 후 커피챗 신청 실패 시 롤백되어야 함")
-    void createCoffeeChatApplication_SaveFails_ShouldRollback() {
-        // Given
-        Long userId = mockUser.getUserId();
-        Long coffeeChatInfoId = mockChatInfo.getCoffeeChatInfoId();
-
-        CoffeeChatApplicationCreateDto request = new CoffeeChatApplicationCreateDto(
-            coffeeChatInfoId,
-            "안녕하세요 백엔드 커피챗 신청합니다.",
-            LocalDateTime.of(2025, 4, 5, 10, 30),
-            LocalDateTime.of(2025, 4, 5, 11, 0)
-        );
-
-        int currentPoint = 5;
-        int deductionPoint  = 3;
-
-        // Mock 설정
-        // 중복 신청이 아닌 경우 설정
-        when(coffeeChatAppRepository.existsByMentee_UserIdAndCoffeeChatInfo_CoffeeChatInfoId(userId,
-            coffeeChatInfoId)).thenReturn(false);
-        // 유저와 커피챗 정보가 정상 조회 된다는 설정
-        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
-        when(coffeeChatInfoRepository.findById(coffeeChatInfoId)).thenReturn(Optional.of(mockChatInfo));
-        // 현재 포인트 조회 결과 지정
-        when(createPointHistoryService.getCurrentPoint(userId)).thenReturn(currentPoint);
-
-        // 포인트 차감 성공한 뒤
-        when(createPointHistoryService.createPointHistory(
-            EventType.COFFEE_CHAT_APPLY, userId, deductionPoint)).thenReturn(mock(PointHistoryDto.class));
-
-        // 커피챗 저장 시 예외 발생
-        when(coffeeChatAppRepository.save(any(CoffeeChatApplication.class))).thenThrow(new RuntimeException("저장 실패"));
-
-        // When: 저장 과정에서 예외 발생 유도
-        assertThrows(RuntimeException.class, () ->
-            coffeeChatApplicationService.createCoffeeChatApp(userId, request));
-
-        // Then: 포인트 히스토리가 저장되지 않았는지 확인
-        verify(createPointHistoryService, times(1)).
-            createPointHistory(EventType.COFFEE_CHAT_APPLY, userId, deductionPoint);
-
-    }
 
 }


### PR DESCRIPTION

## 🔍 주요 변경 사항

### CoffeeChatApplicationServiceTest 수정 
- 커피챗 신청 관련 코드 변경에 따라 테스트 코드도 수정됨 (중복신청 관련)
- `createCoffeeChatApplication_LackOfPoint` 삭제
   - 포인트 부족에 대한 예외는 `CreatePointHistoryService`에서 처리하므로, 이곳에서 검증할 필요 없음
- `createCoffeeChatApplication_SaveFails_ShouldRollback` 삭제
    - 포인트 차감 이후 커피챗 신청 실패 시 롤백 여부는 단위 테스트로 확인하기 어려움
    - 기존에 작성된 통합 테스트에서 검증하고 있으므로 중복적이고 불필요

### CoffeeChatApplicationServiceIntegrationTest 수정
- 예외 발생 후 포인트 롤백을 검증하기 위해  이전과 동일한 값을 유지하는지 확인하기 위해 DB 에 접근해야 하나, **예외가 발생하면 해당 트랜잭션 세션이 종료되므로 DB 조회가 불가능**함
- 기존 트랜잭션과 분리된 조회를 위해 `@Transactional(propagation = Propagation.NOT_SUPPORTED)` 사용이 필요하지만, 실제 비즈니스 로직 서비스에 적용하기 어려움
- 테스트 전용 설정을 위해 `@TestConfiguration`을 사용해 별도의 테스트 Bean 구성함
    

---

## 💡 변경 이유

- 기존 테스트에서 `createPointHistoryService.getCurrentPoint()`를 직접 호출해 포인트 검증을 시도했으나, 이 메서드는 실제로 `coffeeChatApplicationService.createCoffeeChatApp()` 의 내부에서 호출되는 `createPointHistory()` 내부 로직에 해당.
  - 테스트 후 현재 포인트 값을 비교하여 검증하려고 했는데, 해당 포인트 조회 로직은 테스트 대상 서비스에서 직접 호출하는 메서드가 아니라, 내부 의존 객체인 `createPointHistoryService` 내부에서 사용되는 로직이라 **단위 테스트 관점에서는 직접 검증 대상이 아닌 부분**이이 됐고, 그로 인해 `UnnecessaryStubbingException` 같은 예외가 발생함
- 예외 상황에서도 포인트 차감이 제대로 롤백되는지 확인하기 위해 **트랜잭션 외부에서 현재 포인트 값을 조회**할 필요가 있었음
   - 테스트 코드 내에서 예외가 발생하면 동일 세션에서 DB 조회가 어려운 문제가 있었고, 이를 해결하기 위해 `@TestConfiguration`을 사용하여 테스트 전용 Bean을 만들고, 그 안에서  `@Transactional(propagation = Propagation.NOT_SUPPORTED)`  을 적용해 **기존 트랜잭션과 무관하게 포인를 조회**할 수 있도록 처리함











