### PR TITLE
Feat/notification new bootcamp 부트캠프 개설시 알림 전송 기능

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/batch/config/QuartzFetchTriggersConfig.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/batch/config/QuartzFetchTriggersConfig.java
@@ -23,7 +23,7 @@ public class QuartzFetchTriggersConfig {
 		CronTriggerFactoryBean triggerFactoryBean = new CronTriggerFactoryBean();
 		triggerFactoryBean.setJobDetail(fetchBootcampJobDetail);
 		// 매일 11시 25분에 실행
-		triggerFactoryBean.setCronExpression("0 25 11 * * ?");
+		triggerFactoryBean.setCronExpression("0 25 23 * * ?");
 		triggerFactoryBean.setName("fetchTrigger_C0061_19");
 
 		JobDataMap dataMap = new JobDataMap();
@@ -41,7 +41,7 @@ public class QuartzFetchTriggersConfig {
 		CronTriggerFactoryBean triggerFactoryBean = new CronTriggerFactoryBean();
 		triggerFactoryBean.setJobDetail(fetchBootcampJobDetail);
 		// 매일 11시 30분에 실행
-		triggerFactoryBean.setCronExpression("0 30 11 * * ?");
+		triggerFactoryBean.setCronExpression("0 30 23 * * ?");
 		triggerFactoryBean.setName("fetchTrigger_C0061_20");
 		JobDataMap dataMap = new JobDataMap();
 		dataMap.put("categoryCode", "C0061");
@@ -56,7 +56,7 @@ public class QuartzFetchTriggersConfig {
 		CronTriggerFactoryBean triggerFactoryBean = new CronTriggerFactoryBean();
 		triggerFactoryBean.setJobDetail(fetchBootcampJobDetail);
 		// 매일 11시 35분에 실행
-		triggerFactoryBean.setCronExpression("0 35 11 * * ?");
+		triggerFactoryBean.setCronExpression("0 35 23 * * ?");
 		triggerFactoryBean.setName("fetchTrigger_C0104_19");
 		JobDataMap dataMap = new JobDataMap();
 		dataMap.put("categoryCode", "C0104");
@@ -71,7 +71,7 @@ public class QuartzFetchTriggersConfig {
 		CronTriggerFactoryBean triggerFactoryBean = new CronTriggerFactoryBean();
 		triggerFactoryBean.setJobDetail(fetchBootcampJobDetail);
 		// 매일 11시 40분에 실행
-		triggerFactoryBean.setCronExpression("0 40 11 * * ?");
+		triggerFactoryBean.setCronExpression("0 40 23 * * ?");
 		triggerFactoryBean.setName("fetchTrigger_C0104_20");
 		JobDataMap dataMap = new JobDataMap();
 		dataMap.put("categoryCode", "C0104");
@@ -86,7 +86,7 @@ public class QuartzFetchTriggersConfig {
 		CronTriggerFactoryBean triggerFactoryBean = new CronTriggerFactoryBean();
 		triggerFactoryBean.setJobDetail(fetchBootcampJobDetail);
 		// 매일 11시 45분에 실행
-		triggerFactoryBean.setCronExpression("0 45 11 * * ?");
+		triggerFactoryBean.setCronExpression("0 45 23 * * ?");
 		triggerFactoryBean.setName("fetchTrigger_C0105_19");
 		JobDataMap dataMap = new JobDataMap();
 		dataMap.put("categoryCode", "C0105");
@@ -101,7 +101,7 @@ public class QuartzFetchTriggersConfig {
 		CronTriggerFactoryBean triggerFactoryBean = new CronTriggerFactoryBean();
 		triggerFactoryBean.setJobDetail(fetchBootcampJobDetail);
 		// 매일 11시 50분에 실행
-		triggerFactoryBean.setCronExpression("0 50 11 * * ?");
+		triggerFactoryBean.setCronExpression("0 50 23 * * ?");
 		triggerFactoryBean.setName("fetchTrigger_C0105_20");
 		JobDataMap dataMap = new JobDataMap();
 		dataMap.put("categoryCode", "C0105");

--- a/boottalk/src/main/java/com/icandoit/boottalk/batch/config/QuartzNotificationConfig.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/batch/config/QuartzNotificationConfig.java
@@ -28,7 +28,7 @@ public class QuartzNotificationConfig {
 		CronTriggerFactoryBean triggerFactoryBean = new CronTriggerFactoryBean();
 		triggerFactoryBean.setJobDetail(notificationJobDetail);
 		// 매일 12시에 실행
-		triggerFactoryBean.setCronExpression("0 0 12 * * ?");
+		triggerFactoryBean.setCronExpression("0 59 23 * * ?");
 		triggerFactoryBean.setName("notificationTrigger");
 		triggerFactoryBean.afterPropertiesSet();
 		return triggerFactoryBean.getObject();

--- a/boottalk/src/main/java/com/icandoit/boottalk/batch/scheduler/NotificationQuartzJob.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/batch/scheduler/NotificationQuartzJob.java
@@ -1,11 +1,21 @@
 package com.icandoit.boottalk.batch.scheduler;
 
+import static com.icandoit.boottalk.bootcamp.service.RedisService.*;
+
+import java.util.List;
+import java.util.Set;
+
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.springframework.scheduling.quartz.QuartzJobBean;
 import org.springframework.stereotype.Component;
 
+import com.icandoit.boottalk.bootcamp.entity.enums.BootcampCategoryType;
+import com.icandoit.boottalk.bootcamp.service.RedisService;
+import com.icandoit.boottalk.notification.dto.NotificationRequestDto;
 import com.icandoit.boottalk.notification.service.NotificationService;
+import com.icandoit.boottalk.notification.type.NotificationType;
+import com.icandoit.boottalk.user.domain.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,13 +26,62 @@ import lombok.extern.slf4j.Slf4j;
 public class NotificationQuartzJob extends QuartzJobBean {
 
 	private final NotificationService notificationService;
+	private final RedisService redisService;
+	private final UserRepository userRepository;
+	private static final String BOOTCAMP_DETAIL_URL = "https://your-domain.com/api/bootcamps/";
 
 	@Override
 	protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
 		try {
 			log.info("Notification Quartz Job 시작: 알림 전송 작업 실행...");
-			// TODO : 실제 알림 전송 기능을 호출 (추후 구현 예정)
-			// notificationService.sendNewBootcampNotifications();
+
+			// redis 키값 받아오고
+			Set<String> keys = redisService.getKeys(BOOTCAMP_KEY_PREFIX + "*");
+			// key 값이 존재한다면
+			if(keys != null && !keys.isEmpty()) {
+				for(String redisKey : keys) {
+					// key 값에서 데이터 parsing
+					String categoryString = redisKey.substring(BOOTCAMP_KEY_PREFIX.length());
+					BootcampCategoryType category;
+
+					// parsing 된 데이터 존재 값 확인
+					try {
+						category = BootcampCategoryType.valueOf(categoryString);
+					} catch (IllegalArgumentException e) {
+						log.warn("알 수 없는 부트캠프 카테고리: {}", categoryString);
+						continue;
+					}
+
+					// key 값에 해당하는 value 값 조회
+					List<String> bootcampIds = redisService.getList(redisKey);
+					log.info("Redis key [{}] 의 부트캠프 ID: {}", redisKey, bootcampIds);
+
+					// 해당 직군과 일치하는 userId 리스트 조회
+					List<Long> targetUserIds = userRepository.findByIdsByDesiredCareer(category);
+
+					// 해당 직군 관련 데이터들 notification Service 로 전달
+					for(Long userId : targetUserIds) {
+						for(String bootcampId : bootcampIds) {
+							String bootcampDetailUrl = BOOTCAMP_DETAIL_URL + bootcampId;
+							String message = "관심 직군의 부트캠프가 오픈 되었습니다: " + bootcampDetailUrl;
+
+							NotificationRequestDto requestDto = new NotificationRequestDto(
+								NotificationType.BOOTCAMP_OPEN,
+								message,
+								bootcampDetailUrl
+							);
+
+							notificationService.sendLiveNotification(userId, requestDto);
+						}
+					}
+
+					// 전송 완료된 key 값 삭제
+					redisService.deleteKey(redisKey);
+				}
+			} else {
+				log.info("Redis 에 부트캠프 알림 데이터가 없습니다.");
+			}
+
 			log.info("Notification Quartz Job 완료: 알림 전송 작업 종료");
 		} catch (Exception e) {
 			log.error("Notification Quartz Job 실행 실패", e);

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/config/RestTemplateConfig.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/config/RestTemplateConfig.java
@@ -14,7 +14,7 @@ public class RestTemplateConfig {
 
 		HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory();
 		factory.setConnectTimeout(5000);
-		factory.setReadTimeout(5000);
+		factory.setReadTimeout(12000);
 
 		restTemplate.setRequestFactory(factory);
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/RedisService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/RedisService.java
@@ -1,23 +1,59 @@
 package com.icandoit.boottalk.bootcamp.service;
 
 import java.time.Duration;
+import java.util.List;
+import java.util.Set;
 
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
 
 import com.icandoit.boottalk.bootcamp.entity.enums.BootcampCategoryType;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class RedisService {
 
 	private final RedisTemplate<String, String> redisTemplate;
 
+	public static final String BOOTCAMP_KEY_PREFIX = "new:bootcamp:";
+
+	// redis 에서 pattern 에 해당하는 key 값 조회
+	public Set<String> getKeys(String pattern) {
+		Set<String> keys = redisTemplate.keys(pattern);
+		if (CollectionUtils.isEmpty(keys)) {
+			log.info("패턴 [{}]에 해당하는 키가 없습니다.", pattern);
+		} else {
+			log.info("패턴 [{}]에 해당하는 키들: {}", pattern, keys);
+		}
+		return keys;
+	}
+
+	// redis 에서 키값에 해당하는 데이터 조회
+	public List<String> getList(String key) {
+		List<String> list = redisTemplate.opsForList().range(key, 0, -1);
+		log.info("키 [{}]에 저장된 리스트 값: {}", key, list);
+		return list;
+	}
+
+	// redis 에 key 와 value 값 저장
 	public void storeNewBootcampInfo(String bootcampId, BootcampCategoryType categoryType) {
-		String redisKey = "new:bootcamp:" + categoryType;
+		String redisKey = BOOTCAMP_KEY_PREFIX + categoryType.name();
 		redisTemplate.opsForList().rightPush(redisKey, bootcampId);
 		redisTemplate.expire(redisKey, Duration.ofHours(2));
+	}
+
+	// redis 에서 해당 키 값 삭제
+	public void deleteKey(String redisKey) {
+		Boolean deleted = redisTemplate.delete(redisKey);
+		if (Boolean.TRUE.equals(deleted)) {
+			log.info("키 [{}] 삭제 성공", redisKey);
+		} else {
+			log.warn("키 [{}] 삭제 실패 또는 존재하지 않음", redisKey);
+		}
 	}
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/dto/NotificationRequestDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/dto/NotificationRequestDto.java
@@ -1,8 +1,5 @@
 package com.icandoit.boottalk.notification.dto;
 
-import java.time.LocalDateTime;
-
-import com.icandoit.boottalk.notification.entity.Notification;
 import com.icandoit.boottalk.notification.type.NotificationType;
 
 import lombok.Builder;

--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/type/NotificationType.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/type/NotificationType.java
@@ -8,5 +8,6 @@ public enum NotificationType {
 	CHAT_SUSPENDED,		//등록된 커피챗 정지 알림
 	CERTIFICATE_VERIFIED,       // 수료증 인증 완료 알림
 	CERTIFICATE_REJECTED,// 수료증 인증 반려 알림
-	BOOT_TALK_EVENT
+	BOOT_TALK_EVENT,
+	BOOTCAMP_OPEN // 관심 직군의 bootcamp 오픈
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/repository/UserRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/repository/UserRepository.java
@@ -4,6 +4,7 @@ import java.sql.Timestamp;
 import java.util.List;
 import java.util.Optional;
 
+import com.icandoit.boottalk.bootcamp.entity.enums.BootcampCategoryType;
 import com.icandoit.boottalk.user.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -24,4 +25,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
 	//테스트용
 	Optional<User> findByUserName(String userName);
+
+	// 관심직군에 해당하는 유저들 아이디 List 조회
+	@Query("SELECT u.userId FROM User u WHERE u.desiredCareer = :desiredCareer")
+	List<Long> findByIdsByDesiredCareer(@Param("desiredCareer") BootcampCategoryType category);
 }

--- a/boottalk/src/test/java/com/icandoit/boottalk/batch/config/BootcampBatchJobConfigTest.java
+++ b/boottalk/src/test/java/com/icandoit/boottalk/batch/config/BootcampBatchJobConfigTest.java
@@ -1,0 +1,61 @@
+package com.icandoit.boottalk.batch.config;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import com.icandoit.boottalk.bootcamp.service.Employ24ApiService;
+
+class BootcampBatchJobConfigTest {
+	@Mock
+	private Employ24ApiService employ24ApiService;
+
+	@Mock
+	private JobRepository jobRepository;
+
+	@Mock
+	private PlatformTransactionManager transactionManager;
+
+	private BootcampBatchJobConfig config;
+
+	@BeforeEach
+	public void setUp() {
+		MockitoAnnotations.openMocks(this);
+		config = new BootcampBatchJobConfig(employ24ApiService, jobRepository, transactionManager);
+	}
+
+	@Test
+	public void testBootcampFetchJobIsNotNull() {
+		// when
+		Job job = config.bootcampFetchJob();
+
+		// then
+		assertNotNull(job);
+	}
+
+	@Test
+	public void testFetchStepsAreNotNull() {
+		// when
+		Step step_C0061_19 = config.fetchStep_C0061_19();
+		Step step_C0061_20 = config.fetchStep_C0061_20();
+		Step step_C0104_19 = config.fetchStep_C0104_19();
+		Step step_C0104_20 = config.fetchStep_C0104_20();
+		Step step_C0105_19 = config.fetchStep_C0105_19();
+		Step step_C0105_20 = config.fetchStep_C0105_20();
+
+		// then: 모든 Step이 null이 아니어야 함
+		assertNotNull(step_C0061_19);
+		assertNotNull(step_C0061_20);
+		assertNotNull(step_C0104_19);
+		assertNotNull(step_C0104_20);
+		assertNotNull(step_C0105_19);
+		assertNotNull(step_C0105_20);
+	}
+}

--- a/boottalk/src/test/java/com/icandoit/boottalk/batch/scheduler/FetchBootcampQuartzJobTest.java
+++ b/boottalk/src/test/java/com/icandoit/boottalk/batch/scheduler/FetchBootcampQuartzJobTest.java
@@ -1,0 +1,70 @@
+package com.icandoit.boottalk.batch.scheduler;
+
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.quartz.JobDataMap;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
+import com.icandoit.boottalk.bootcamp.entity.enums.BootcampCategoryType;
+import com.icandoit.boottalk.bootcamp.service.RedisService;
+import com.icandoit.boottalk.notification.dto.NotificationRequestDto;
+import com.icandoit.boottalk.notification.service.NotificationService;
+import com.icandoit.boottalk.user.domain.repository.UserRepository;
+
+class FetchBootcampQuartzJobTest {
+	private NotificationQuartzJob notificationQuartzJob;
+	private NotificationService notificationService;
+	private RedisService redisService;
+	private UserRepository userRepository;
+	private JobExecutionContext context;
+
+	private static final String BOOTCAMP_KEY_PREFIX = "new:bootcamp:";
+
+	@BeforeEach
+	void setUp() {
+		notificationService = mock(NotificationService.class);
+		redisService = mock(RedisService.class);
+		userRepository = mock(UserRepository.class);
+		notificationQuartzJob = new NotificationQuartzJob(notificationService, redisService, userRepository);
+
+		// JobExecutionContext 도 목 객체로 설정
+		context = mock(JobExecutionContext.class);
+		JobDataMap jobDataMap = new JobDataMap();
+		when(context.getMergedJobDataMap()).thenReturn(jobDataMap);
+	}
+
+	@Test
+	void testExecuteInternal() throws JobExecutionException {
+		// given
+
+		// Redis에 저장된 키
+		String redisKey = BOOTCAMP_KEY_PREFIX + "CLOUD_SOLUTION_ARCH";
+		Set<String> keys = new HashSet<>();
+		keys.add(redisKey);
+		when(redisService.getKeys(BOOTCAMP_KEY_PREFIX + "*")).thenReturn(keys);
+
+		// 해당 키에 저장된 부트캠프 ID 리스트 (예: "101", "102")
+		List<String> bootcampIds = Arrays.asList("101", "102");
+		when(redisService.getList(redisKey)).thenReturn(bootcampIds);
+
+		// BootcampCategoryType 값에 맞는 사용자 ID 리스트 반환
+		when(userRepository.findByIdsByDesiredCareer(BootcampCategoryType.CLOUD_SOLUTION_ARCH))
+			.thenReturn(Arrays.asList(1L, 2L));
+
+		// Quartz Job 실행
+		notificationQuartzJob.executeInternal(context);
+
+		// 각 사용자와 각 부트캠프 ID 조합에 대해 알림 전송이 2 * 2 = 4번 호출되어야 함
+		verify(notificationService, times(4)).sendLiveNotification(anyLong(), any(NotificationRequestDto.class));
+		// 전송 완료 후, 해당 Redis 키 삭제 호출 확인
+		verify(redisService, times(1)).deleteKey(redisKey);
+	}
+}


### PR DESCRIPTION
Closes #96 
## 🔍 주요 변경 사항
- **RedisService**:  
  - Redis key 조회(getKeys), 해당 key의 리스트 값 읽기(getList),  
    부트캠프 정보 저장(storeNewBootcampInfo) 및 key 삭제(deleteKey) 기능 추가.
- **NotificationQuartzJob**:  
  - Quartz Job을 통해 Redis의 "new:bootcamp:{카테고리}" 형태의 키를 조회하여,  
    해당 키에 저장된 부트캠프 ID 리스트를 기반으로 관심 직군 사용자(유저)의 ID를 조회하고,  
    각 사용자에게 알림 메시지(부트캠프 상세 URL 포함)를 전송하며,  
    전송 완료 후 해당 Redis 키를 삭제하는 로직 구현.
- **UserRepository**:  
  - `findByIdsByDesiredCareer(BootcampCategoryType category)` 메서드 추가하여,  
    관심 직군에 해당하는 사용자 ID 리스트를 반환하도록 수정.
- **RestTemplateConfig**:  
  - RestTemplate의 연결 타임아웃 및 읽기 타임아웃을 각각 5000ms와 12000ms로 설정.

---

## 💡 변경 이유
- Redis에 부트캠프 관련 정보를 저장하고, 이를 기반으로 관심 직군 사용자에게 실시간 알림을 제공하기 위해 기능을 구현
- 기존 RestTemplate의 기본 타임아웃이 외부 API 호출 시 Read timed out 문제가 발생하여, 타임아웃 값을 늘려 문제를 개선하기 위해 변경
- 사용자 경험 개선과 중복 알림 방지를 위해, 알림 전송 후 Redis에 저장된 관련 키를 삭제하는 기능을 추가

---

## 🚀 개선 결과
- 부트캠프 데이터 수집 후 Redis에 저장된 정보를 기반으로,  해당 직군의 사용자에게 실시간 SSE 알림 전송이 가능
- Redis key 삭제 로직 추가로 알림 중복 발생을 방지
- 외부 API 호출 시 타임아웃 문제를 해결하여 데이터 수집의 안정성을 높였음



---

## 📂 관련 클래스 및 변경 파일
- **Batch Scheduler 관련**  
  - `NotificationQuartzJob.java` (알림 전송 Quartz Job)
  - `BootcampBatchJobConfig.java` (배치 Job 및 Step 구성)
  - `QuartzFetchTriggersConfig.java`, `QuartzNotificationConfig.java`, `FetchBootcampQuartzJob.java`
- **Service**  
  - `RedisService.java` (Redis 데이터 처리)
  - `NotificationService.java`, `SseEmitterService.java` (알림 전송 처리)
- **Repository**  
  - `UserRepository.java` (findByIdsByDesiredCareer 메서드 추가)
- **설정 파일**  
  - `RestTemplateConfig.java` (RestTemplate 타임아웃 설정)



---

## ✅ 테스트 시나리오
- **BootcampBatchJobConfigTest**:  
  - 각 Step과 Job 구성 요소가 null이 아님을 확인하여 배치 구성 검증.
- **FetchBootcampQuartzJobTest (NotificationQuartzJobTest)**:  
  - Redis에 저장된 특정 키에 대해, 해당 키에서 부트캠프 ID 리스트를 조회하고,  
    관련 사용자에게 알림 전송 및 알림 전송 후 Redis 키 삭제가 올바르게 수행되는지 검증.



