### PR TITLE
Fix/bootcamp detail response : BootcampResponseDto 추가 및 JobType 추가

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/controller/BootcampController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/controller/BootcampController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.icandoit.boottalk.bootcamp.dto.BootcampAutocompleteDto;
+import com.icandoit.boottalk.bootcamp.dto.BootcampDetailResponseDto;
 import com.icandoit.boottalk.bootcamp.dto.BootcampResponseDto;
 import com.icandoit.boottalk.bootcamp.entity.Bootcamp;
 import com.icandoit.boottalk.bootcamp.entity.enums.BootcampCategoryType;
@@ -81,7 +82,7 @@ public class BootcampController {
 
 	// 단일 부트캠프 조회
 	@GetMapping("/{bootcampId}")
-	public ResponseEntity<BootcampResponseDto> getBootcamp(@PathVariable Long bootcampId) {
+	public ResponseEntity<BootcampDetailResponseDto> getBootcamp(@PathVariable Long bootcampId) {
 		return ResponseEntity.ok(bootcampService.findById(bootcampId));
 	}
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/dto/BootcampDetailResponseDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/dto/BootcampDetailResponseDto.java
@@ -1,0 +1,51 @@
+package com.icandoit.boottalk.bootcamp.dto;
+
+import java.time.LocalDate;
+
+import com.icandoit.boottalk.bootcamp.entity.Bootcamp;
+
+public record BootcampDetailResponseDto(
+	Long bootcampId,
+	String bootcampName,
+	String bootcampRegion,
+	boolean bootcampCost,
+	String bootcampLink,
+	String bootcampCategory,
+	int bootcampDegree,
+	int bootcampCapacity,
+	LocalDate bootcampStartDate,
+	LocalDate bootcampEndDate,
+	Double courseAverageRating,
+	Integer courseReviewCount,
+	Long trainingCenterId,
+	String trainingCenterName,
+	String trainingCenterPhoneNumber,
+	String trainingCenterEmail,
+	String trainingCenterAddress,
+	String trainingCenterUrl
+) {
+	public static BootcampDetailResponseDto from(
+		Bootcamp bootcamp
+	) {
+		return new BootcampDetailResponseDto(
+			bootcamp.getBootcampId(),
+			bootcamp.getBootcampName(),
+			bootcamp.getBootcampRegion(),
+			bootcamp.isBootcampCost(),
+			bootcamp.getBootcampLink(),
+			bootcamp.getBootcampCategoryType().getKoreanName(),
+			bootcamp.getBootcampDegree(),
+			bootcamp.getBootcampCapacity(),
+			bootcamp.getBootcampStartDate(),
+			bootcamp.getBootcampEndDate(),
+			bootcamp.getCourse().getAverageRating(),
+			bootcamp.getCourse().getReviewCount(),
+			bootcamp.getTrainingCenter().getTrainingCenterId(),
+			bootcamp.getTrainingCenter().getTrainingCenterName(),
+			bootcamp.getTrainingCenter().getTrainingCenterPhoneNumber(),
+			bootcamp.getTrainingCenter().getTrainingCenterEmail(),
+			bootcamp.getTrainingCenter().getTrainingCenterAddress(),
+			bootcamp.getTrainingCenter().getTrainingCenterUrl()
+		);
+	}
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/BootcampService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/BootcampService.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.icandoit.boottalk.bootcamp.dto.BootcampDetailResponseDto;
 import com.icandoit.boottalk.bootcamp.dto.BootcampResponseDto;
 import com.icandoit.boottalk.bootcamp.entity.Bootcamp;
 import com.icandoit.boottalk.bootcamp.entity.enums.BootcampCategoryType;
@@ -34,14 +35,14 @@ public class BootcampService {
 
 	// 부트캠프 단일 조회
 	@Transactional(readOnly = true)
-	public BootcampResponseDto findById(Long id) {
+	public BootcampDetailResponseDto findById(Long id) {
 		Optional<Bootcamp> bootcamp = bootcampRepository.findById(id);
 
 		if (bootcamp.isEmpty()) {
 			throw new CustomException(BOOTCAMP_NOT_FOUND);
 		}
 
-		return BootcampResponseDto.from(bootcamp.get());
+		return BootcampDetailResponseDto.from(bootcamp.get());
 	}
 
 	// 부트캠프 필터링, 검색 조회

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/entity/enums/JobType.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/entity/enums/JobType.java
@@ -1,5 +1,5 @@
 package com.icandoit.boottalk.coffeeChat.entity.enums;
 
 public enum JobType {
-    BACKEND, FRONTEND
+    BACKEND, FRONTEND, PM, UIUX, DATA_ANALYSIS ,ETC
 }


### PR DESCRIPTION
## 🔍 주요 변경 사항
- `BootcampDetailResponseDto` 추가
- `JobType` 몇가지 항목 추가


---

## 💡 변경 이유
- 상세 부트캠프 조회시 해당하는 TrainingCenter에 대한 내용이 담겨 있지 않음
- 프론트엔드에서 몇가지 항목 요청

---

## 🚀 개선 결과
- 부트캠프 상세 조회시에 더 다양한 결과를 return 가능
- `JobType` 에 BACKEND, FRONTEND, PM, UIUX, DATA_ANALYSIS ,ETC 추가



---

## 📂 관련 클래스 및 변경 파일
`BootcampController`
`BootcampService`
`BootcampDetailResponseDto`
`JobType`



---

## 🖼️ 스크린샷
![Uploading 2025-04-14_6.29.26.png…]()




