### PR TITLE
refactor: 커피챗 필터링 조회 시 페이징 응답을 Page -> PagedResponseDto 로 통일

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatQueryController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatQueryController.java
@@ -1,11 +1,5 @@
 package com.icandoit.boottalk.coffeeChat.controller;
 
-import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatListDto;
-import com.icandoit.boottalk.coffeeChat.entity.enums.JobType;
-import com.icandoit.boottalk.coffeeChat.entity.enums.MentorType;
-import com.icandoit.boottalk.coffeeChat.service.CoffeeChatQueryService;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -15,6 +9,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatListDto;
+import com.icandoit.boottalk.coffeeChat.entity.enums.JobType;
+import com.icandoit.boottalk.coffeeChat.entity.enums.MentorType;
+import com.icandoit.boottalk.coffeeChat.service.CoffeeChatQueryService;
+import com.icandoit.boottalk.common.dto.PagedResponseDto;
+
+import lombok.RequiredArgsConstructor;
+
 @RestController
 @RequestMapping("/api/coffee-chats/info")
 @RequiredArgsConstructor
@@ -22,7 +24,7 @@ public class CoffeeChatQueryController {
     private final CoffeeChatQueryService coffeeChatQueryService;
 
     @GetMapping("/search")
-    public ResponseEntity<Page<CoffeeChatListDto>> getCoffeeChats(
+    public ResponseEntity<PagedResponseDto<CoffeeChatListDto>> getCoffeeChats(
         @RequestParam(required = false) JobType jobType,
         @RequestParam(required = false) MentorType mentorType,
         @PageableDefault(

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/repository/CoffeeChatQueryRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/repository/CoffeeChatQueryRepository.java
@@ -1,22 +1,24 @@
 package com.icandoit.boottalk.coffeeChat.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatListDto;
 import com.icandoit.boottalk.coffeeChat.entity.QCoffeeChatInfo;
 import com.icandoit.boottalk.coffeeChat.entity.enums.JobType;
 import com.icandoit.boottalk.coffeeChat.entity.enums.MentorType;
+import com.icandoit.boottalk.common.dto.PagedResponseDto;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import jakarta.annotation.Nullable;
 
-import java.time.LocalDateTime;
-import java.util.List;
+import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.support.PageableExecutionUtils;
-import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
@@ -24,7 +26,7 @@ public class CoffeeChatQueryRepository {
 
     private final JPAQueryFactory queryFactory;
 
-    public Page<CoffeeChatListDto> getFilteredCoffeeChatResults(
+    public PagedResponseDto<CoffeeChatListDto> getFilteredCoffeeChatResults(
         @Nullable JobType jobType,
         @Nullable MentorType mentorType,
         Pageable pageable
@@ -61,7 +63,7 @@ public class CoffeeChatQueryRepository {
                 mentorTypeEq(mentorType)
             );
 
-        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+        return PagedResponseDto.from(PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne));
     }
 
     private BooleanExpression jobTypeEq(JobType jobType) {

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatQueryService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatQueryService.java
@@ -1,22 +1,24 @@
 package com.icandoit.boottalk.coffeeChat.service;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatListDto;
 import com.icandoit.boottalk.coffeeChat.entity.enums.JobType;
 import com.icandoit.boottalk.coffeeChat.entity.enums.MentorType;
 import com.icandoit.boottalk.coffeeChat.repository.CoffeeChatQueryRepository;
+import com.icandoit.boottalk.common.dto.PagedResponseDto;
+
 import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class CoffeeChatQueryService {
     private final CoffeeChatQueryRepository coffeeChatQueryRepository;
     @Transactional(readOnly = true)
-    public Page<CoffeeChatListDto> getFilteredCoffeeChatResults(
+    public PagedResponseDto<CoffeeChatListDto> getFilteredCoffeeChatResults(
         @Nullable JobType jobType,
         @Nullable MentorType userType,
         Pageable pageable

--- a/boottalk/src/test/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatInfoServiceTest.java
+++ b/boottalk/src/test/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatInfoServiceTest.java
@@ -1,18 +1,12 @@
 package com.icandoit.boottalk.coffeeChat.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
-import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatListDto;
-import com.icandoit.boottalk.coffeeChat.entity.enums.JobType;
-import com.icandoit.boottalk.coffeeChat.entity.enums.MentorType;
-import com.icandoit.boottalk.coffeeChat.repository.CoffeeChatQueryRepository;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,10 +14,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+
+import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatListDto;
+import com.icandoit.boottalk.coffeeChat.entity.enums.JobType;
+import com.icandoit.boottalk.coffeeChat.entity.enums.MentorType;
+import com.icandoit.boottalk.coffeeChat.repository.CoffeeChatQueryRepository;
+import com.icandoit.boottalk.common.dto.PagedResponseDto;
 
 @ExtendWith(MockitoExtension.class)
 class CoffeeChatInfoServiceTest {
@@ -35,7 +34,7 @@ class CoffeeChatInfoServiceTest {
     private CoffeeChatQueryService coffeeChatQueryService;
 
     private List<CoffeeChatListDto> coffeeChatList;
-    private Page<CoffeeChatListDto> coffeeChatPage;
+    private PagedResponseDto<CoffeeChatListDto> coffeeChatPage;
     private Pageable pageable;
 
     @BeforeEach
@@ -47,7 +46,7 @@ class CoffeeChatInfoServiceTest {
                 "프론트엔드 코스 수료자 test2 입니다.")
         );
         pageable = PageRequest.of(0, 10);
-        coffeeChatPage = new PageImpl<>(coffeeChatList, pageable, coffeeChatList.size());
+        coffeeChatPage = PagedResponseDto.from(new PageImpl<>(coffeeChatList, pageable, coffeeChatList.size()));
     }
 
     @Test
@@ -58,14 +57,16 @@ class CoffeeChatInfoServiceTest {
             pageable)).thenReturn(coffeeChatPage);
 
         // when
-        Page<CoffeeChatListDto> result = coffeeChatQueryService.getFilteredCoffeeChatResults(null,
+        PagedResponseDto<CoffeeChatListDto> result = coffeeChatQueryService.getFilteredCoffeeChatResults(null,
             null, pageable);
 
         // then
         assertNotNull(result);
-        assertEquals(2, result.getTotalElements());
+        assertEquals(2, result.pagination().totalItems());
         verify(coffeeChatQueryRepository, times(1)).getFilteredCoffeeChatResults(null, null,
             pageable);
+
+
     }
 
     @Test
@@ -77,18 +78,18 @@ class CoffeeChatInfoServiceTest {
             .filter(dto -> JobType.BACKEND.equals(dto.jobType()))
             .collect(Collectors.toList());
 
-        Page<CoffeeChatListDto> filteredPage = new PageImpl<>(filteredList, pageable,
-            filteredList.size());
+        PagedResponseDto<CoffeeChatListDto> filteredPage =
+            PagedResponseDto.from(new PageImpl<>(filteredList, pageable, filteredList.size()));
 
         when(coffeeChatQueryRepository.getFilteredCoffeeChatResults(jobType, null, pageable))
             .thenReturn(filteredPage);
 
-        Page<CoffeeChatListDto> result = coffeeChatQueryService.getFilteredCoffeeChatResults(
+        PagedResponseDto<CoffeeChatListDto> result = coffeeChatQueryService.getFilteredCoffeeChatResults(
             jobType,
             null, pageable);
 
         assertNotNull(result);
-        assertEquals(1, result.getTotalElements());
+        assertEquals(1, result.pagination().totalItems());
         verify(coffeeChatQueryRepository, times(1)).getFilteredCoffeeChatResults(jobType, null,
             pageable);
     }
@@ -102,19 +103,19 @@ class CoffeeChatInfoServiceTest {
             .filter(dto -> MentorType.PROFESSIONAL.equals(dto.mentorType()))
             .collect(Collectors.toList());
 
-        Page<CoffeeChatListDto> filteredPage = new PageImpl<>(filteredList, pageable,
-            filteredList.size());
+        PagedResponseDto<CoffeeChatListDto> filteredPage =
+            PagedResponseDto.from(new PageImpl<>(filteredList, pageable, filteredList.size()));
 
         when(coffeeChatQueryRepository.getFilteredCoffeeChatResults(null, userType, pageable))
             .thenReturn(filteredPage);
 
         // when
-        Page<CoffeeChatListDto> result = coffeeChatQueryService.getFilteredCoffeeChatResults(null,
+        PagedResponseDto<CoffeeChatListDto> result = coffeeChatQueryService.getFilteredCoffeeChatResults(null,
             userType, pageable);
 
         // then
         assertNotNull(result);
-        assertEquals(1, result.getTotalElements());
+        assertEquals(1, result.pagination().totalItems());
         verify(coffeeChatQueryRepository, times(1)).getFilteredCoffeeChatResults(null, userType,
             pageable);
     }


### PR DESCRIPTION


## 🔍 주요 변경 사항
- 기존 Page 객체 반환 방식에서 커스텀 DTO(**PagedResponseDto**)로 변경

---

## 💡 변경 이유
- 프로젝트 전반에서 페이징 응답을 PagedResponseDto로 통일하기로 함

---

## 🚀 개선 결과
- 클라이언트 측에서 일관된 페이징 응답 포맷으로 처리 가능
--- 

## 🖼️ 스크린샷

![필터링](https://github.com/user-attachments/assets/04469b79-a29e-4299-bfdb-ac8975703543)


