### PR TITLE
fix : @PreAuthorize 에서 발생한 AccessDeniedException 커스텀 응답 처리 추가

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/libs/exception/GlobalExceptionHandler.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/libs/exception/GlobalExceptionHandler.java
@@ -1,14 +1,27 @@
 package com.icandoit.boottalk.libs.exception;
 
+
 import com.icandoit.boottalk.libs.dto.ExceptionResponseDto;
 import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
 @Slf4j
 @ControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(AuthorizationDeniedException.class)
+    public ResponseEntity<ExceptionResponseDto<Void>> handleAccessDeniedException(AuthorizationDeniedException e) {
+        log.error("AuthorizationDeniedException 발생: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+            .body(ExceptionResponseDto.of(ErrorCode.FORBIDDEN.getHttpStatus(),
+                ErrorCode.FORBIDDEN.getMessage()));
+
+    }
 
     /**
      * CustomException 처리 - ErrorCode에 정의된 예외 반환
@@ -30,4 +43,6 @@ public class GlobalExceptionHandler {
             .body(ExceptionResponseDto.of(ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus(),
                 ErrorCode.INTERNAL_SERVER_ERROR.getMessage()));
     }
+
+
 }


### PR DESCRIPTION
## 🔍 주요 변경 사항

- 컨트롤러 메서드에 접근 시 사용자 권한이 없는 경우 `AccessDenied` 예외가 발생, 이에 대해 응답값으로 `ExceptionResponseDto` 값을 반환할 수 있도록 변경
- `GlobalExceptionHandler` 에 `AuthorizationDeniedException`를 처리할 수 있는 `handleAccessDeniedException` 을 추가해 AccessDenied 예외 발생 시 지정해둔 `ExceptionResponseDto` 를 반환할 수 있도록 함. 
- 참고 사항
  - SecurityFilterChain에서 커스텀 예외핸들러를 설정해서 @PreAuthorize 으로 인해 발생한 예외를 처리할 수 없음. 
  -  @PreAuthorize 은 SecurityFilterChain후에 메서드 호출 시점에서 처리됨. 
  - SecurityFilterChain에서 설정한 커스텀 예외핸들러는 SecurityFilterChain에서 발생하는 예외만 처리 가능

---

## 💡 변경 이유
- 기존에는  AccessDenied 예외 발생 시 따로 해당 예외를 지정하지 않아 500 에러 발생

---

## 🚀 개선 결과
- 프론트 엔드 쪽에서 권한 문제로 에러 발생 시 이유를 알 수 있음. 

---

## 📂 관련 클래스 및 변경 파일
- GlobalExceptionHandler
---

## ✅ 테스트 시나리오(예정) 



---

## 💡 참고 블로그



--- 

## 🖼️ 스크린샷
- @PreAuthorize 적용한 컨트롤러 메서드에 권한을 가지지 못한 사용자가 해당 메서드를 호출할 시
![image](https://github.com/user-attachments/assets/9d2be5d0-ac2c-4efd-b3a5-d6f9e8d8c808)



