### PR TITLE
refactor : Bootcamp 관련 collect() 함수를 .toList()로 refactor

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/controller/CategoryController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/controller/CategoryController.java
@@ -2,7 +2,6 @@ package com.icandoit.boottalk.bootcamp.controller;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,7 +18,7 @@ public class CategoryController {
 	public ResponseEntity<List<String>> getAllCategories() {
 		List<String> categories = Arrays.stream(BootcampCategoryType.values())
 			.map(BootcampCategoryType::getKoreanName)
-			.collect(Collectors.toList());
+			.toList();
 
 		return ResponseEntity.ok(categories);
 	}

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/dto/BootcampResponseDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/dto/BootcampResponseDto.java
@@ -2,7 +2,6 @@ package com.icandoit.boottalk.bootcamp.dto;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import com.icandoit.boottalk.bootcamp.entity.Bootcamp;
 
@@ -42,6 +41,6 @@ public record BootcampResponseDto(
 	public static List<BootcampResponseDto> from(List<Bootcamp> bootcamps) {
 		return bootcamps.stream()
 			.map(BootcampResponseDto::from)
-			.collect(Collectors.toList());
+			.toList();
 	}
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/BootcampCertificationService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/BootcampCertificationService.java
@@ -1,7 +1,6 @@
 package com.icandoit.boottalk.bootcamp.service;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -60,7 +59,7 @@ public class BootcampCertificationService {
 
 		return certifications.stream()
 			.map(GetCertificationResponseDto::from)
-			.collect(Collectors.toList());
+			.toList();
 	}
 
 	// 승인 대기중인 요청 모두 조회
@@ -68,7 +67,7 @@ public class BootcampCertificationService {
 		List<BootcampCertification> certifications = bootcampCertificationRepository.findAllByStatus(CertificationStatus.PENDING);
 		return certifications.stream()
 			.map(GetPendingCertificationResponseDto::from)
-		.collect(Collectors.toList());
+			.toList();
 	}
 
 	// 수료증 정보 조회


### PR DESCRIPTION
## 🔍 주요 변경 사항
- CategoryController
    - Arrays.stream(BootcampCategoryType.values()).map(...).collect(Collectors.toList()) 를Arrays.stream(BootcampCategoryType.values()).map(...).toList() 로 변경
- BootcampResponseDto
    - bootcamps.stream().map(...).collect(Collectors.toList()) 를 bootcamps.stream().map(...).toList() 로 변경
- BootcampCertificationService
    - certifications.stream().map(...).collect(Collectors.toList()) 를 certifications.stream().map(...).toList() 로 변경
    - 승인 대기중인 요청 조회 메소드 또한 collect(Collectors.toList()) 대신 toList() 사용

---

## 💡 변경 이유
- 간결성과 가독성 향상
    - toList() 메소드는 코드가 훨씬 간결하며 읽기 쉬움

- 불변 리스트 반환
    - toList() 메소드는 불변(immutable) 리스트를 반환함 
    - 이를 통해 의도치 않은 데이터 변경을 방지하고, 코드 안정성이 증가함

- 내장 최적화 활용
    - Java 최신 버전에서 toList() 메소드는 내부적으로 최적화되어 있어 성능 및 메모리 측면에서도 이점이 있음

- 의도 명확화
    - 결과 리스트가 수정되지 않을 예정이라면, 불변 리스트를 반환하는 toList()가 더 적합함

---

## 🚀 개선 결과
- 코드의 간결성과 가독성이 향상됨
- 불변 리스트를 활용하여 데이터의 안정성과 예측 가능한 동작을 보장함
- 불필요한 컬렉터 사용을 줄여 코드 라인이 단축되고, 최신 API 활용으로 최적화된 구현을 적용했음

---

## 📂 관련 클래스 및 변경 파일
- CategoryController.java
    - 변경된 부분: toList() 사용
- BootcampResponseDto.java
    - 변경된 부분: 리스트 변환 부분에 collect(Collectors.toList()) → .toList() 로 변경
- BootcampCertificationService.java
    - 변경된 부분: 승인 관련 목록 조회 로직에서 toList() 사용

---

## 💡 참고 블로그

[toList()](https://binux.tistory.com/146)




