### PR TITLE
refactor : SseEmitterService 로 변경된 부분 수정

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/batch/scheduler/NotificationQuartzJob.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/batch/scheduler/NotificationQuartzJob.java
@@ -28,7 +28,6 @@ public class NotificationQuartzJob extends QuartzJobBean {
 	private final SseEmitterService sseEmitterService;
 	private final RedisService redisService;
 	private final UserRepository userRepository;
-	private static final String BOOTCAMP_DETAIL_URL = "https://your-domain.com/api/bootcamps/";
 
 	@Override
 	protected void executeInternal(JobExecutionContext context) throws JobExecutionException {

--- a/boottalk/src/main/java/com/icandoit/boottalk/batch/scheduler/NotificationQuartzJob.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/batch/scheduler/NotificationQuartzJob.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
 import com.icandoit.boottalk.bootcamp.entity.enums.BootcampCategoryType;
 import com.icandoit.boottalk.bootcamp.service.RedisService;
 import com.icandoit.boottalk.notification.dto.NotificationRequestDto;
-import com.icandoit.boottalk.notification.service.NotificationService;
+import com.icandoit.boottalk.notification.service.SseEmitterService;
 import com.icandoit.boottalk.notification.type.NotificationType;
 import com.icandoit.boottalk.user.domain.repository.UserRepository;
 
@@ -25,7 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class NotificationQuartzJob extends QuartzJobBean {
 
-	private final NotificationService notificationService;
+	private final SseEmitterService sseEmitterService;
 	private final RedisService redisService;
 	private final UserRepository userRepository;
 	private static final String BOOTCAMP_DETAIL_URL = "https://your-domain.com/api/bootcamps/";
@@ -62,16 +62,13 @@ public class NotificationQuartzJob extends QuartzJobBean {
 					// 해당 직군 관련 데이터들 notification Service 로 전달
 					for(Long userId : targetUserIds) {
 						for(String bootcampId : bootcampIds) {
-							String bootcampDetailUrl = BOOTCAMP_DETAIL_URL + bootcampId;
-							String message = "관심 직군의 부트캠프가 오픈 되었습니다: " + bootcampDetailUrl;
 
 							NotificationRequestDto requestDto = new NotificationRequestDto(
-								NotificationType.BOOTCAMP_OPEN,
-								message,
-								bootcampDetailUrl
+								NotificationType.NEW_BOOT_CAMP,
+								Long.valueOf(bootcampId)
 							);
 
-							notificationService.sendLiveNotification(userId, requestDto);
+							sseEmitterService.sendToClient(userId, requestDto);
 						}
 					}
 

--- a/boottalk/src/test/java/com/icandoit/boottalk/batch/scheduler/FetchBootcampQuartzJobTest.java
+++ b/boottalk/src/test/java/com/icandoit/boottalk/batch/scheduler/FetchBootcampQuartzJobTest.java
@@ -16,12 +16,12 @@ import org.quartz.JobExecutionException;
 import com.icandoit.boottalk.bootcamp.entity.enums.BootcampCategoryType;
 import com.icandoit.boottalk.bootcamp.service.RedisService;
 import com.icandoit.boottalk.notification.dto.NotificationRequestDto;
-import com.icandoit.boottalk.notification.service.NotificationService;
+import com.icandoit.boottalk.notification.service.SseEmitterService;
 import com.icandoit.boottalk.user.domain.repository.UserRepository;
 
 class FetchBootcampQuartzJobTest {
 	private NotificationQuartzJob notificationQuartzJob;
-	private NotificationService notificationService;
+	private SseEmitterService sseEmitterService;
 	private RedisService redisService;
 	private UserRepository userRepository;
 	private JobExecutionContext context;
@@ -30,10 +30,10 @@ class FetchBootcampQuartzJobTest {
 
 	@BeforeEach
 	void setUp() {
-		notificationService = mock(NotificationService.class);
+		sseEmitterService = mock(SseEmitterService.class);
 		redisService = mock(RedisService.class);
 		userRepository = mock(UserRepository.class);
-		notificationQuartzJob = new NotificationQuartzJob(notificationService, redisService, userRepository);
+		notificationQuartzJob = new NotificationQuartzJob(sseEmitterService, redisService, userRepository);
 
 		// JobExecutionContext 도 목 객체로 설정
 		context = mock(JobExecutionContext.class);
@@ -63,7 +63,7 @@ class FetchBootcampQuartzJobTest {
 		notificationQuartzJob.executeInternal(context);
 
 		// 각 사용자와 각 부트캠프 ID 조합에 대해 알림 전송이 2 * 2 = 4번 호출되어야 함
-		verify(notificationService, times(4)).sendLiveNotification(anyLong(), any(NotificationRequestDto.class));
+		verify(sseEmitterService, times(4)).sendToClient(anyLong(), any(NotificationRequestDto.class));
 		// 전송 완료 후, 해당 Redis 키 삭제 호출 확인
 		verify(redisService, times(1)).deleteKey(redisKey);
 	}


### PR DESCRIPTION
## 🔍 주요 변경 사항
- 기존에 NotificationService를 사용하여 알림 전송을 수행하던 로직을 SseEmitterService를 사용하도록 변경

---

## 💡 변경 이유
- SSE 연결 관리를 위해 SseEmitterService를 사용함으로써 실시간 알림 전송 로직을 개선하고 책임을 분리하기 위함


---

## 🚀 개선 결과
- 대상 사용자에게 SSE 기반으로 안정적인 실시간 알림 전송이 가능



---

## 📂 관련 클래스 및 변경 파일
- `com.icandoit.boottalk.batch.scheduler.NotificationQuartzJob`
- `com.icandoit.boottalk.bootcamp.service.RedisService`


---

## ✅ 테스트
- 단위 테스트를 통해 Redis에서 데이터를 읽어 알림 전송이 올바르게 수행되는지와, 전송 후 Redis 키가 삭제되는지 검증


---

## 🖼️ 스크린샷

![스크린샷 2025-04-15 오전 2 44 15](https://github.com/user-attachments/assets/e25e1056-2b14-4236-ae29-e03a86d397fb)

