### PR TITLE
feat : 부트캠프 수료 승인/거절 시 알림 발송 로직 구현

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/BootcampCertificationService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/BootcampCertificationService.java
@@ -1,5 +1,7 @@
 package com.icandoit.boottalk.bootcamp.service;
 
+import static com.icandoit.boottalk.notification.type.NotificationType.*;
+
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -18,6 +20,9 @@ import com.icandoit.boottalk.bootcamp.repository.BootcampCertificationRepository
 import com.icandoit.boottalk.bootcamp.repository.CourseRepository;
 import com.icandoit.boottalk.libs.exception.CustomException;
 import com.icandoit.boottalk.libs.exception.ErrorCode;
+import com.icandoit.boottalk.notification.dto.NotificationRequestDto;
+import com.icandoit.boottalk.notification.service.SseEmitterService;
+import com.icandoit.boottalk.notification.type.NotificationType;
 import com.icandoit.boottalk.user.domain.entity.User;
 import com.icandoit.boottalk.user.domain.repository.UserRepository;
 
@@ -30,6 +35,7 @@ public class BootcampCertificationService {
 	private final UserRepository userRepository;
 	private final CourseRepository courseRepository;
 	private final BootcampCertificationRepository bootcampCertificationRepository;
+	private final SseEmitterService sseEmitterService;
 
 	// 수료증 등록
 	@Transactional
@@ -86,6 +92,19 @@ public class BootcampCertificationService {
 
 		BootcampCertification savedCertification = bootcampCertificationRepository.save(certification);
 
+		// 수료증 인증 알림 전송 부분
+		Long userId = savedCertification.getUser().getUserId();
+		NotificationType type = request.isTrue() ? CERTIFICATE_VERIFIED : CERTIFICATE_REJECTED;
+
+		sendCertificationNotification(userId, type);
+
+
 		return CertificationResponseDto.from(savedCertification);
+	}
+
+	// 수료증 인증 승인 거절 알림 발송
+	public void sendCertificationNotification(Long userId, NotificationType type) {
+		NotificationRequestDto requestDto = new NotificationRequestDto(type, null);
+		sseEmitterService.sendToClient(userId, requestDto);
 	}
 }


### PR DESCRIPTION
## 🔍 주요 변경 사항
- BootcampCertificationService에 수료증 승인/거절 시 알림 전송 로직을 추가
- sendCertificationNotification(Long userId, NotificationType type) 메서드를 도입하여, 승인 시 CERTIFICATE_VERIFIED, 거절 시 CERTIFICATE_REJECTED 알림을 SSE를 통해 전송하도록 구현
- 수료증 상태 업데이트 후 해당 알림 전송 로직을 호출하도록 수정


---

## 💡 변경 이유
- 수료증 승인 또는 거절 결과를 사용자에게 실시간으로 알려 사용자 경험을 개선하기 위해 알림 전송 로직을 추가
- SSE 기반의 알림 전송을 통해 이벤트가 발생하였음을 즉시 인지할 수 있도록 함으로써, 사용자와의 상호작용을 보다 원활하게 만들고자 함


---

## 🚀 개선 결과
- 수료증 승인/거절 처리 후, 알림이 즉각적으로 전송되어 사용자에게 수료 상태 변동 정보를 제공

---

## 📂 관련 클래스 및 변경 파일
- `com.icandoit.boottalk.bootcamp.service.BootcampCertificationService`


--- 

## 🖼️ 스크린샷
- 승인 요청
    ![스크린샷 2025-04-15 오후 6 41 11](https://github.com/user-attachments/assets/9e060ef2-ac6e-4ebf-b6cd-ce928545df07)

    ![스크린샷 2025-04-15 오후 6 44 59](https://github.com/user-attachments/assets/23fd1ad6-67d7-43e8-9182-d00d872e3cb3)

- 거절 요청
    ![스크린샷 2025-04-15 오후 6 45 51](https://github.com/user-attachments/assets/1ec18bc7-ee9c-421b-9e7d-51d24deb903a)

    ![스크린샷 2025-04-15 오후 6 46 07](https://github.com/user-attachments/assets/1f75ff30-c4a4-4be6-8df5-7a8e0b7e2310)



