### PR TITLE
refactor : coffeeChat - request,response dto 변경에 따른 로직 수정

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/dto/AvailableChatTimeDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/dto/AvailableChatTimeDto.java
@@ -1,11 +1,10 @@
 package com.icandoit.boottalk.coffeeChat.dto;
 
 import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.List;
 import java.util.Map;
 
 public record AvailableChatTimeDto (
-    Map<LocalDate, List<LocalTime>> availableChatTimes
+    Map<LocalDate, List<String>> availableChatTimes
 ){
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/dto/CoffeeChatRequestDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/dto/CoffeeChatRequestDto.java
@@ -1,10 +1,18 @@
 package com.icandoit.boottalk.coffeeChat.dto;
 
+import java.util.List;
+import java.util.Map;
+
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record CoffeeChatRequestDto(
     @Valid CoffeeChatInfoRequestDto info,
-    @Valid CoffeeChatTimeMapDto time
+
+    @NotNull(message = "멘토링 가능 시간은 필수 항목입니다.")
+    @Size(min = 1, message = "멘토링 가능 시간을 1개 이상 선택해주세요.")
+    Map<String, List<String>> time
 ) {
 
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/dto/CoffeeChatResponseDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/dto/CoffeeChatResponseDto.java
@@ -1,13 +1,14 @@
 package com.icandoit.boottalk.coffeeChat.dto;
 
 import java.util.List;
+import java.util.Map;
 
 public record CoffeeChatResponseDto(
     CoffeeChatInfoResponseDto info,
-    List<CoffeeChatTimeResponseDto> times
+    Map<String, List<String>> time
 ) {
 
-    public static CoffeeChatResponseDto of(CoffeeChatInfoResponseDto info, List<CoffeeChatTimeResponseDto> times) {
-        return new CoffeeChatResponseDto(info, times);
+    public static CoffeeChatResponseDto of(CoffeeChatInfoResponseDto info, Map<String, List<String>> time) {
+        return new CoffeeChatResponseDto(info, time);
     }
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatTimeService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatTimeService.java
@@ -106,7 +106,15 @@ public class CoffeeChatTimeService {
         // 신청된 시간 제외한 신청 가능한 시간 필터링
         Map<LocalDate, List<LocalTime>> availableChatTimesByDate  = getAvailableChatTimesByDate(mentoringTimeList, appliedDateTimes, startDate, endDate);
 
-        return new AvailableChatTimeDto(availableChatTimesByDate);
+        Map<LocalDate, List<String>> formattedAvailableChatTimes = availableChatTimesByDate.entrySet().stream()
+            .collect(Collectors.toMap(
+                Map.Entry::getKey,
+                e -> e.getValue().stream()
+                    .map(time -> time.format(DateTimeFormatter.ofPattern("HH:mm")))
+                    .collect(Collectors.toList())
+            ));
+
+        return new AvailableChatTimeDto(formattedAvailableChatTimes);
     }
 
     public Map<String, List<String>> updateCoffeeChatTimes(Long userId,

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatTimeService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatTimeService.java
@@ -40,8 +40,8 @@ public class CoffeeChatTimeService {
     private final CoffeeChatTimeRepository coffeeChatTimeRepository;
     private final CoffeeChatApplicationRepository coffeeChatAppRepository;
 
-    public List<CoffeeChatTimeResponseDto> createCoffeeChatTimes(Long userId,
-        CoffeeChatTimeMapDto requestDto) {
+    public Map<String, List<String>> createCoffeeChatTimes(Long userId,
+        Map<String, List<String>> times) {
 
         CoffeeChatInfo coffeeChatInfo = coffeeChatInfoRepository.findByMentor_UserId(userId)
             .orElseThrow(() -> new CustomException(ErrorCode.USER_COFFEE_CHAT_NOT_FOUND));
@@ -52,7 +52,7 @@ public class CoffeeChatTimeService {
         }
 
         // 시 : 분 파싱
-        List<CoffeeChatTimeDto> timeDtos = CoffeeChatTimeConverter.toDtoList(requestDto);
+        List<CoffeeChatTimeDto> timeDtos = CoffeeChatTimeConverter.mapToDtoList(times);
 
         List<CoffeeChatTime> chatTimes = timeDtos.stream()
             .map(dto -> {
@@ -66,17 +66,27 @@ public class CoffeeChatTimeService {
         coffeeChatTimeRepository.saveAll(chatTimes);
 
         return chatTimes.stream()
-            .map(CoffeeChatTimeResponseDto::from)
-            .toList();
+            .collect(Collectors.groupingBy(
+                time -> time.getDayOfWeek().toString(),
+                Collectors.mapping(
+                    time -> time.getStartTime().format(DateTimeFormatter.ofPattern("HH:mm")),
+                    Collectors.toList()
+                )
+            ));
     }
 
     // 자신의 멘토 가능 시간 조회
-    public List<CoffeeChatTimeResponseDto> getMentorAvailableChatTimes(Long userId) {
+    public Map<String, List<String>> getMentorAvailableChatTimes(Long userId) {
         List<CoffeeChatTime> coffeeChatTimes = getMentorCoffeeChatTimesOrThrow(userId);
 
         return coffeeChatTimes.stream()
-            .map(CoffeeChatTimeResponseDto::from)
-            .toList();
+            .collect(Collectors.groupingBy(
+                time -> time.getDayOfWeek().toString(),
+                Collectors.mapping(
+                    time -> time.getStartTime().format(DateTimeFormatter.ofPattern("HH:mm")),
+                    Collectors.toList()
+                )
+            ));
     }
 
     public AvailableChatTimeDto getAvailableChatTimes(Long coffeeChatInfoId) {
@@ -99,17 +109,17 @@ public class CoffeeChatTimeService {
         return new AvailableChatTimeDto(availableChatTimesByDate);
     }
 
-    public List<CoffeeChatTimeResponseDto> updateCoffeeChatTimes(Long userId,
-        CoffeeChatTimeMapDto requestDto) {
+    public Map<String, List<String>> updateCoffeeChatTimes(Long userId,
+        Map<String, List<String>> times) {
 
         CoffeeChatInfo coffeeChatInfo = coffeeChatInfoRepository.findByMentor_UserId(userId)
             .orElseThrow(() -> new CustomException(ErrorCode.USER_COFFEE_CHAT_NOT_FOUND));
 
-        List<CoffeeChatTime> existingTimes = coffeeChatTimeRepository.findAllWithCoffeeChatInfoByUserId(
-            userId);
+        List<CoffeeChatTime> existingTimes =
+            coffeeChatTimeRepository.findAllWithCoffeeChatInfoByUserId(userId);
 
         // 변환된 새 요청 리스트
-        List<CoffeeChatTimeDto> newDtos = CoffeeChatTimeConverter.toDtoList(requestDto);
+        List<CoffeeChatTimeDto> newDtos = CoffeeChatTimeConverter.mapToDtoList(times);
 
         // Set으로 중복 제거 및 비교를 쉽게
         Set<String> existingKeys = existingTimes.stream()
@@ -147,7 +157,14 @@ public class CoffeeChatTimeService {
         // 최종 조회된 전체 시간 목록 반환
         List<CoffeeChatTime> finalList = coffeeChatTimeRepository.findAllWithCoffeeChatInfoByUserId(
             userId);
-        return finalList.stream().map(CoffeeChatTimeResponseDto::from).toList();
+        return finalList.stream()
+            .collect(Collectors.groupingBy(
+                time -> time.getDayOfWeek().toString(),
+                Collectors.mapping(
+                    time -> time.getStartTime().format(DateTimeFormatter.ofPattern("HH:mm")),
+                    Collectors.toList()
+                )
+            ));
     }
 
     private String generateKey(DayOfWeek dayOfWeek, LocalTime startTime) {

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/converter/CoffeeChatTimeConverter.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/converter/CoffeeChatTimeConverter.java
@@ -37,4 +37,27 @@ public class CoffeeChatTimeConverter {
         }
         return result;
     }
+
+    public static List<CoffeeChatTimeDto> mapToDtoList(Map<String, List<String>> times) {
+        List<CoffeeChatTimeDto> result = new ArrayList<>();
+
+        for (Map.Entry<String, List<String>> entry : times.entrySet()) {
+            DayOfWeek day;
+            try {
+                // key를 DayOfWeek enum으로 변환 (예: "MONDAY")
+                day = DayOfWeek.valueOf(entry.getKey());
+            } catch (IllegalArgumentException e) {
+                throw new CustomException(ErrorCode.INVALID_DAY_FORMAT);
+            }
+            for (String timeStr : entry.getValue()) {
+                try {
+                    LocalTime time = LocalTime.parse(timeStr, TIME_FORMATTER);
+                    result.add(new CoffeeChatTimeDto(day, time));
+                } catch (DateTimeParseException e) {
+                    throw new CustomException(ErrorCode.INVALID_TIME_FORMAT);
+                }
+            }
+        }
+        return result;
+    }
 }


### PR DESCRIPTION
## 🔍 주요 변경 사항
- DTO 변경:
    - CoffeeChatRequestDto의 time 필드를 기존의 복합 DTO(CoffeeChatTimeMapDto) 대신 Map<String, List<String>>로 통일
    - CoffeeChatResponseDto도 time 필드를 Map<String, List<String>>로 변경하여 클라이언트와의 데이터 구조를 일치시킴
    
- Service 수정:
    - CoffeeChatTimeService 내의 메서드들(createCoffeeChatTimes, getMentorAvailableChatTimes, updateCoffeeChatTimes)에서 파라미터 및 반환 자료형을 수정
    - 기존 DTO 변환 로직을 CoffeeChatTimeConverter.mapToDtoList를 사용하도록 변경하여, 입력 데이터를 Map<String, List<String>>에서 DTO 리스트로 변환하고, 최종 반환 시 요일별("DAY")로 그룹핑된 "HH:mm" 형식의 문자열 리스트를 반환
   
- Converter에 메서드 추가:
    - CoffeeChatTimeConverter에 mapToDtoList 메서드를 추가해, Map<String, List<String>> 자료형의 요청 데이터를 DTO 리스트로 변환하도록 개선


---

## 💡 변경 이유
- 프론트엔드의 요청/응답 데이터와 백엔드 데이터 처리 간의 자료형 일관성을 유지하기 위해 time 필드를 단순화하였음
- 코드 가독성을 향상시키고, 불필요한 중첩 구조를 제거하기 위함
- Service 계층에서 반환 자료형을 클라이언트가 기대하는 Map<String, List<String>>로 맞추어 API 인터페이스를 개선


---

## 🚀 개선 결과
- 전체 시스템에서 데이터 흐름과 변환 과정이 명확하게 통일


---

## 📂 관련 클래스 및 변경 파일
- DTO 클래스:
    - `com.icandoit.boottalk.coffeeChat.dto.CoffeeChatRequestDto`
    - `com.icandoit.boottalk.coffeeChat.dto.CoffeeChatResponseDto`

- Service 클래스:
    - `com.icandoit.boottalk.coffeeChat.service.CoffeeChatTimeService`

- Converter 클래스:
    - `com.icandoit.boottalk.coffeeChat.service.converter.CoffeeChatTimeConverter`

--- 

## 🖼️ 스크린샷
- post 요청
![2025-04-15_8 27 27](https://github.com/user-attachments/assets/245e973d-27dc-429e-a167-c718a95e2b98)
- get 요청
![2025-04-15_8 29 11](https://github.com/user-attachments/assets/01432ffb-4b00-4a1d-b192-afc568fb87a5)
- put 요청
![2025-04-15_8 30 00](https://github.com/user-attachments/assets/c207d0ff-95c7-4c1f-8b43-c25c8768bf9b)
- times 시간 12:00:00 -> 12:00 으로 수정
![스크린샷 2025-04-15 오후 9 59 40](https://github.com/user-attachments/assets/15272a55-fcd2-4ee6-b617-3ed427e1b93e)


