### PR TITLE
refactor : 내 정보 조회시 currentPoint 도 응답 가능하도록 dto 및 로직 수정

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/user/controller/ManageController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/controller/ManageController.java
@@ -39,8 +39,9 @@ public class ManageController {
 		UserDto userDto = manageService.getUser(userId);
 		List<GetCertificationResponseDto> myCertifications
 			= bootcampCertificationService.getMyCertifications(userId);
+		int currentPoint = createPointHistoryService.getCurrentPointToNavi(user.getServiceUserId());
 
-		return ResponseEntity.ok(UserInfoDto.from(userDto, myCertifications));
+		return ResponseEntity.ok(UserInfoDto.from(userDto, myCertifications, currentPoint));
 	}
 
 	@GetMapping("/navi")

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/dto/UserInfoDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/dto/UserInfoDto.java
@@ -3,12 +3,24 @@ package com.icandoit.boottalk.user.domain.dto;
 import java.util.List;
 
 import com.icandoit.boottalk.bootcamp.dto.GetCertificationResponseDto;
+import com.icandoit.boottalk.bootcamp.entity.enums.BootcampCategoryType;
 
 public record UserInfoDto(
-	UserDto userInfo,
+	String name,
+	String email,
+	String profileImage,
+	BootcampCategoryType desiredCareer,
+	int currentPoint,
 	List<GetCertificationResponseDto> certifications
 ) {
-	public static UserInfoDto from(UserDto userInfo, List<GetCertificationResponseDto> certifications) {
-		return new UserInfoDto(userInfo, certifications);
+	public static UserInfoDto from(UserDto userInfo, List<GetCertificationResponseDto> certifications, int curPoint) {
+		return new UserInfoDto(
+			userInfo.name(),
+			userInfo.email(),
+			userInfo.profileImage(),
+			userInfo.desiredCareer(),
+			curPoint,
+			certifications
+		);
 	}
 }


### PR DESCRIPTION
## 🔍 주요 변경 사항
- userInfo 조회 dto 수정 및 변경
- ManageController 에 유저의 현재 point 가져오는 로직 추가


---

## 💡 변경 이유
- UserInfo Dto에서 현재 포인트를 포함하지 않아 마이페이지에서 현재 포인트 정보를 가져올 수 없음


---

## 🚀 개선 결과
- myPage에서 원하는 형태의 유저 정보를 받아와서 게시 가능


---

## 📂 관련 클래스 및 변경 파일
- `boottalk/src/main/java/com/icandoit/boottalk/user/controller/ManageController.java`
- `boottalk/src/main/java/com/icandoit/boottalk/user/domain/dto/UserInfoDto.java`

--- 

## 🖼️ 스크린샷
![스크린샷 2025-04-15 오후 11 54 58](https://github.com/user-attachments/assets/dff5242b-de07-4fce-91cf-13c3e78f0155)



