### PR TITLE
Fix/Security Config CORS 추가

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/common/config/CorsConfig.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/common/config/CorsConfig.java
@@ -17,6 +17,7 @@ public class CorsConfig {
 					.allowedOrigins("http://localhost:3000") // 정확한 Origin 명시
 					.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
 					.allowedHeaders("Content-Type", "Authorization")
+					.exposedHeaders("Set-Cookie")
 					.allowCredentials(true);
 			}
 		};

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/SecurityConfiguration.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/SecurityConfiguration.java
@@ -39,6 +39,7 @@ public class SecurityConfiguration {
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		log.info("SecurityFilterChain 설정");
 
 		http
 			.cors(cors ->  cors.configurationSource(corsConfigurationSource()))
@@ -60,17 +61,20 @@ public class SecurityConfiguration {
 			.authorizeHttpRequests(auth -> auth
 				// 경로에 대한 접근 권한 설정
 				// TODO  : 추후에 접근 가능한 페이지 설정
-				.requestMatchers("/", "/swagger-ui/**", "/v3/api-docs/**", "/api/oauth2/authorization/**", "/login/**", "/api/bootcamps/**", "/api/reviews/**").permitAll()
+				.requestMatchers("/", "/swagger-ui/**", "/v3/api-docs/**", "/api/oauth2/authorization/**", "/login/**", "/api/bootcamps/**", "/api/reviews/**", "/api/test/**").permitAll()
 				.anyRequest().authenticated())
 			.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
 			//oauth2 로그인 설정
-			.oauth2Login(oauth2 -> oauth2
-				.authorizationEndpoint(endpoint -> endpoint. // 프론트엔드쪽에서 로그인 버튼을 눌렀을 때
-					baseUri("/api/oauth2/authorization")) // 해당 엔드포인트로 요청을 보내면 네이버 로그인 페이지로 리디렉션
-				.userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig
-					.userService(customUserService)) // 네이버로부터 사용자 정보()를 받아올 클래스
-				.successHandler(customSuccessHandler) // 로그인 성공 시 토큰을 발급하는 클래스
-				.clientRegistrationRepository(customClientRegistrationRepository.clientRegistrationRepository())) // 부트톡 서버와 네이버 서버간 인증코드와 엑세스 토큰을 주고 받기 위한 설정이 저장된 클래스
+			.oauth2Login(oauth2 -> {
+				log.info("OAuth2 로그인 설정");
+				oauth2
+					.authorizationEndpoint(endpoint -> endpoint. // 프론트엔드쪽에서 로그인 버튼을 눌렀을 때
+						baseUri("/api/oauth2/authorization")) // 해당 엔드포인트로 요청을 보내면 네이버 로그인 페이지로 리디렉션
+					.userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig
+						.userService(customUserService)) // 네이버로부터 사용자 정보()를 받아올 클래스
+					.successHandler(customSuccessHandler) // 로그인 성공 시 토큰을 발급하는 클래스
+					.clientRegistrationRepository(customClientRegistrationRepository.clientRegistrationRepository());
+			}) // 부트톡 서버와 네이버 서버간 인증코드와 엑세스 토큰을 주고 받기 위한 설정이 저장된 클래스
 			.logout(logout -> logout.logoutUrl("/logout")
 				.logoutSuccessHandler((request, response, auth) -> {
 					response.sendRedirect("http://localhost:3000/"); // 로그아웃 성공 시 메인페이지로 이동
@@ -92,4 +96,5 @@ public class SecurityConfiguration {
 		source.registerCorsConfiguration("/**", configuration);
 		return source;
 	}
+
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/SecurityConfiguration.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/SecurityConfiguration.java
@@ -60,7 +60,7 @@ public class SecurityConfiguration {
 			.authorizeHttpRequests(auth -> auth
 				// 경로에 대한 접근 권한 설정
 				// TODO  : 추후에 접근 가능한 페이지 설정
-				.requestMatchers("/", "/swagger-ui/**", "/v3/api-docs/**", "/api/oauth2/authorization/**", "/login/**").permitAll()
+				.requestMatchers("/", "/swagger-ui/**", "/v3/api-docs/**", "/api/oauth2/authorization/**", "/login/**", "/api/bootcamps/**", "/api/reviews/**").permitAll()
 				.anyRequest().authenticated())
 			.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
 			//oauth2 로그인 설정

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/SecurityConfiguration.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/SecurityConfiguration.java
@@ -86,6 +86,8 @@ public class SecurityConfiguration {
 		configuration.setAllowedOrigins(List.of("http://localhost:3000"));
 		configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
 		configuration.setAllowCredentials(true);
+		configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "X-Requested-With", "Accept"));
+		configuration.setExposedHeaders(Arrays.asList("Authorization", "Set-Cookie"));
 		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
 		source.registerCorsConfiguration("/**", configuration);
 		return source;

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/SecurityConfiguration.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/SecurityConfiguration.java
@@ -22,11 +22,13 @@ import com.icandoit.boottalk.social_login.oauth2.CustomSuccessHandler;
 import com.icandoit.boottalk.social_login.service.CustomUserService;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 @EnableMethodSecurity
+@Slf4j
 public class SecurityConfiguration {
 
 	private final CustomClientRegistrationRepository customClientRegistrationRepository;
@@ -43,26 +45,35 @@ public class SecurityConfiguration {
 			.csrf(AbstractHttpConfigurer::disable)
 			.httpBasic(AbstractHttpConfigurer::disable)
 			.formLogin(AbstractHttpConfigurer::disable)
-			// 세션 사용하지 않기 때문에
+			// .exceptionHandling(exception -> {
+			// 	log.info("Exception Handling triggered");
+			// 	exception.authenticationEntryPoint((request, response, authException) -> {
+			// 		log.info("Unauthorized access attempt: {}", request.getRequestURI());
+			// 		response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+			// 	});
+			// })
+
+
+		// 세션 사용하지 않기 때문에
 			.sessionManagement(session -> session
 				.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.authorizeHttpRequests(auth -> auth
 				// 경로에 대한 접근 권한 설정
 				// TODO  : 추후에 접근 가능한 페이지 설정
-				.requestMatchers("/", "/swagger-ui/**", "/v3/api-docs/**", "/api/oauth2/authorization/**").permitAll()
+				.requestMatchers("/", "/swagger-ui/**", "/v3/api-docs/**", "/api/oauth2/authorization/**", "/login/**").permitAll()
 				.anyRequest().authenticated())
 			.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
 			//oauth2 로그인 설정
 			.oauth2Login(oauth2 -> oauth2
 				.authorizationEndpoint(endpoint -> endpoint. // 프론트엔드쪽에서 로그인 버튼을 눌렀을 때
-					baseUri("/api/oauth2/authorization/naver")) // 해당 엔드포인트로 요청을 보내면 네이버 로그인 페이지로 리디렉션
+					baseUri("/api/oauth2/authorization")) // 해당 엔드포인트로 요청을 보내면 네이버 로그인 페이지로 리디렉션
 				.userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig
 					.userService(customUserService)) // 네이버로부터 사용자 정보()를 받아올 클래스
 				.successHandler(customSuccessHandler) // 로그인 성공 시 토큰을 발급하는 클래스
 				.clientRegistrationRepository(customClientRegistrationRepository.clientRegistrationRepository())) // 부트톡 서버와 네이버 서버간 인증코드와 엑세스 토큰을 주고 받기 위한 설정이 저장된 클래스
 			.logout(logout -> logout.logoutUrl("/logout")
 				.logoutSuccessHandler((request, response, auth) -> {
-					response.sendRedirect("http://localhost:3000"); // 로그아웃 성공 시 메인페이지로 이동
+					response.sendRedirect("http://localhost:3000/"); // 로그아웃 성공 시 메인페이지로 이동
 				})
 				.clearAuthentication(true));
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/SecurityConfiguration.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/SecurityConfiguration.java
@@ -87,7 +87,7 @@ public class SecurityConfiguration {
 	@Bean
 	public CorsConfigurationSource corsConfigurationSource() {
 		CorsConfiguration configuration = new CorsConfiguration();
-		configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+		configuration.setAllowedOrigins(List.of("http://localhost:3000", "http://127.0.0.1:3000"));
 		configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
 		configuration.setAllowCredentials(true);
 		configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "X-Requested-With", "Accept"));

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/SecurityConfiguration.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/SecurityConfiguration.java
@@ -1,5 +1,8 @@
 package com.icandoit.boottalk.social_login.config;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -9,6 +12,9 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import com.icandoit.boottalk.social_login.jwt.JwtFilter;
 import com.icandoit.boottalk.social_login.oauth2.CustomClientRegistrationRepository;
@@ -33,6 +39,7 @@ public class SecurityConfiguration {
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 
 		http
+			.cors(cors ->  cors.configurationSource(corsConfigurationSource()))
 			.csrf(AbstractHttpConfigurer::disable)
 			.httpBasic(AbstractHttpConfigurer::disable)
 			.formLogin(AbstractHttpConfigurer::disable)
@@ -42,12 +49,11 @@ public class SecurityConfiguration {
 			.authorizeHttpRequests(auth -> auth
 				// 경로에 대한 접근 권한 설정
 				// TODO  : 추후에 접근 가능한 페이지 설정
-				.requestMatchers("/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+				.requestMatchers("/", "/swagger-ui/**", "/v3/api-docs/**", "/api/oauth2/authorization/**").permitAll()
 				.anyRequest().authenticated())
 			.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
 			//oauth2 로그인 설정
 			.oauth2Login(oauth2 -> oauth2
-				.loginPage("http://localhost:3000/login") // 사용자 인증이 필요한 경우 해당 페이지로 이동함.
 				.authorizationEndpoint(endpoint -> endpoint. // 프론트엔드쪽에서 로그인 버튼을 눌렀을 때
 					baseUri("/api/oauth2/authorization/naver")) // 해당 엔드포인트로 요청을 보내면 네이버 로그인 페이지로 리디렉션
 				.userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig
@@ -60,7 +66,17 @@ public class SecurityConfiguration {
 				})
 				.clearAuthentication(true));
 
-
 		return http.build();
+	}
+
+	@Bean
+	public CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration configuration = new CorsConfiguration();
+		configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+		configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
+		configuration.setAllowCredentials(true);
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", configuration);
+		return source;
 	}
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/dto/NaverResponse.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/dto/NaverResponse.java
@@ -10,16 +10,14 @@ public record NaverResponse(
 	String provider,
 	String providerId,
 	String email,
-	String name,
-	String profileImage
+	String name
 ) {
 	public static NaverResponse from(Map<String,Object> attributes) {
 		return new NaverResponse(
 			"naver",
 			attributes.get("id").toString(),
 			attributes.get("email").toString(),
-			attributes.get("name").toString(),
-			attributes.get("profile_image").toString()
+			attributes.get("name").toString()
 		);
 	}
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/dto/NaverResponse.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/dto/NaverResponse.java
@@ -3,7 +3,6 @@ package com.icandoit.boottalk.social_login.dto;
 import java.util.Map;
 
 import lombok.Builder;
-import lombok.Getter;
 
 @Builder
 public record NaverResponse(

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/jwt/JwtFilter.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/jwt/JwtFilter.java
@@ -45,6 +45,7 @@ public class JwtFilter extends OncePerRequestFilter {
 			|| requestURI.startsWith("/v3/api-docs")
 			|| requestURI.startsWith("/login/")
 			|| requestURI.startsWith("/api/oauth2/")
+			|| requestURI.startsWith("/api/bootcamps")
 			) {
 			filterChain.doFilter(request, response);
 			return;

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/jwt/JwtFilter.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/jwt/JwtFilter.java
@@ -39,13 +39,16 @@ public class JwtFilter extends OncePerRequestFilter {
 		// swagger 접근 시 필터 적용 X
 		String requestURI = request.getRequestURI();
 
+		log.info("requestURI: {}", requestURI);
+
 		if (requestURI.startsWith("/swagger-ui/")
-			|| requestURI.startsWith("/v3/api-docs"))
-		{
+			|| requestURI.startsWith("/v3/api-docs")
+			|| requestURI.startsWith("/login/")
+			|| requestURI.startsWith("/api/oauth2/")
+			) {
 			filterChain.doFilter(request, response);
 			return;
 		}
-
 
 		// 처음 로그인하고 나서 리다이렉트 된 url에서는 토큰이 헤더에 담겨져 있지 않고 쿠키에 담겨 있음.
 
@@ -62,16 +65,17 @@ public class JwtFilter extends OncePerRequestFilter {
 				for (Cookie cookie : cookies) {
 					if (cookie.getName().equals(TOKEN_HEADER)) {
 						token = cookie.getValue();
+						log.info("토큰 쿠키 확인");
 
 						// 쿠키에서 찾은 토큰을 다음 요청부터는 헤더에서 사용할 수 있도록
 						// 응답 헤더에 토큰 추가
 						response.setHeader(TOKEN_HEADER, TOKEN_PREFIX + token);
 
 						// 헤더에 토큰을 옮긴 후에 쿠키에서는 삭제
-						Cookie deleteCookie = new Cookie(TOKEN_HEADER, null);
-						deleteCookie.setMaxAge(0); // 쿠키 만료
-						deleteCookie.setPath("/"); // 쿠키의 경로를 원래 쿠키와 동일하게 설정
-						response.addCookie(deleteCookie);
+						// Cookie deleteCookie = new Cookie(TOKEN_HEADER, null);
+						// deleteCookie.setMaxAge(0); // 쿠키 만료
+						// deleteCookie.setPath("/"); // 쿠키의 경로를 원래 쿠키와 동일하게 설정
+						// response.addCookie(deleteCookie);
 
 						break;
 					}
@@ -90,7 +94,9 @@ public class JwtFilter extends OncePerRequestFilter {
 		SecurityContextHolder.getContext().setAuthentication(jwtProvider.getAuthentication(token));
 
 		//TODO 어떤 사용자 정보를 가지고 있는지 로그를 통해 확인. 추후 사용자 ID 정도만 확인할 수 있도록 변경
-		CustomOAuth2User userDetails =  (CustomOAuth2User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+		CustomOAuth2User userDetails = (CustomOAuth2User)SecurityContextHolder.getContext()
+			.getAuthentication()
+			.getPrincipal();
 		log.info("token info : {}, {}, {}", userDetails.getName(), userDetails.getAuthorities().stream().map(
 			GrantedAuthority::getAuthority).collect(Collectors.toList()), userDetails.getServiceUserId());
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/oauth2/CustomSuccessHandler.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/oauth2/CustomSuccessHandler.java
@@ -4,8 +4,6 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
 
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
@@ -45,8 +43,10 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
 
 		//토큰 생성 후 쿠키에 담아 전달
-		createCookie(response ,"Authorization"
-			, jwtProvider.createToken(userDetails.getServiceUserId(), userDetails.getName(), role));
+		response.addCookie(createCookie("Authorization", jwtProvider.createToken(userDetails.getServiceUserId(), userDetails.getName(), role)));
+
+		// createCookie(response ,"Authorization"
+		// 	, jwtProvider.createToken(userDetails.getServiceUserId(), userDetails.getName(), role));
 
 		// 신규회원인 경우,추가정보 입력 url로 리다이렉션
 		if (UserRole.valueOf(role).equals(UserRole.NEW_USER)) {
@@ -58,22 +58,32 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 	}
 
 	// 쿠키 생성
-	private void createCookie(HttpServletResponse response, String key, String value) {
+	private Cookie createCookie(String key, String value) {
 
-		ResponseCookie responseCookie = ResponseCookie.from(key, value)
-			.maxAge(60 * 60 * 60)
-			.path("/")
-			.httpOnly(true)
-			.secure(true)
-			.sameSite("None")
-			.build();
+		Cookie cookie = new Cookie(key, value);
+		cookie.setMaxAge(60*60*60);
+		//cookie.setSecure(true);
+		cookie.setPath("/");
+		cookie.setHttpOnly(true);
 
-		// Cookie cookie = new Cookie(key, value);
-		// cookie.setMaxAge(60*60*60);
-		// // cookie.setSecure(true); 실제 서비스 배포시에 활성화 (https 에서만 해당 쿠키가 전달되게 함)
-		// cookie.setPath("/");
-		// cookie.setHttpOnly(true);
-
-		response.addHeader(HttpHeaders.SET_COOKIE, responseCookie.toString());
+		return cookie;
 	}
+	// private void createCookie(HttpServletResponse response, String key, String value) {
+	//
+	// 	ResponseCookie responseCookie = ResponseCookie.from(key, value)
+	// 		.maxAge(60 * 60 * 60)
+	// 		.path("/")
+	// 		.httpOnly(true)
+	// 		.domain("http://localhost:8080")
+	// 		.sameSite("None")
+	// 		.build();
+	//
+	// 	// Cookie cookie = new Cookie(key, value);
+	// 	// cookie.setMaxAge(60*60*60);
+	// 	// // cookie.setSecure(true); 실제 서비스 배포시에 활성화 (https 에서만 해당 쿠키가 전달되게 함)
+	// 	// cookie.setPath("/");
+	// 	// cookie.setHttpOnly(true);
+	//
+	// 	response.addHeader(HttpHeaders.SET_COOKIE, responseCookie.toString());
+	// }
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/oauth2/CustomSuccessHandler.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/oauth2/CustomSuccessHandler.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
 
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
@@ -43,8 +45,8 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
 
 		//토큰 생성 후 쿠키에 담아 전달
-		response.addCookie(createCookie("Authorization"
-			, jwtProvider.createToken(userDetails.getServiceUserId(), userDetails.getName(), role)));
+		createCookie(response ,"Authorization"
+			, jwtProvider.createToken(userDetails.getServiceUserId(), userDetails.getName(), role));
 
 		// 신규회원인 경우,추가정보 입력 url로 리다이렉션
 		if (UserRole.valueOf(role).equals(UserRole.NEW_USER)) {
@@ -56,14 +58,21 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 	}
 
 	// 쿠키 생성
-	private Cookie createCookie(String key, String value) {
+	private void createCookie(HttpServletResponse response, String key, String value) {
 
-		Cookie cookie = new Cookie(key, value);
-		cookie.setMaxAge(60*60*60);
-		// cookie.setSecure(true); 실제 서비스 배포시에 활성화 (https 에서만 해당 쿠키가 전달되게 함)
-		cookie.setPath("/");
-		cookie.setHttpOnly(true);
+		ResponseCookie responseCookie = ResponseCookie.from(key, value)
+			.maxAge(60 * 60 * 60)
+			.path("/")
+			.httpOnly(true)
+			.sameSite("None")
+			.build();
 
-		return cookie;
+		// Cookie cookie = new Cookie(key, value);
+		// cookie.setMaxAge(60*60*60);
+		// // cookie.setSecure(true); 실제 서비스 배포시에 활성화 (https 에서만 해당 쿠키가 전달되게 함)
+		// cookie.setPath("/");
+		// cookie.setHttpOnly(true);
+
+		response.addHeader(HttpHeaders.SET_COOKIE, responseCookie.toString());
 	}
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/oauth2/CustomSuccessHandler.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/oauth2/CustomSuccessHandler.java
@@ -32,7 +32,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
 		//CustomOAuth2UserService.loadUser 에서 반환된 사용자 정보 가져오기
 		CustomOAuth2User userDetails = (CustomOAuth2User) authentication.getPrincipal();
-		log.error("userDetails info : {}, {}, {}", userDetails.getServiceUserId(), userDetails.getName(), userDetails.getAuthorities());
+		log.error("소셜 로그인 성공 userDetails info : {}, {}, {}", userDetails.getServiceUserId(), userDetails.getName(), userDetails.getAuthorities());
 
 		//사용자 권한 가져오기
 		Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
@@ -51,7 +51,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 			response.sendRedirect("http://localhost:3000/social-register");
 		} else {
 			// 기존 회원의 경우, 메인페이지로 리다이렉션
-			response.sendRedirect("http://localhost:3000/");
+			response.sendRedirect("http://localhost:3000");
 		}
 	}
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/oauth2/CustomSuccessHandler.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/oauth2/CustomSuccessHandler.java
@@ -64,6 +64,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 			.maxAge(60 * 60 * 60)
 			.path("/")
 			.httpOnly(true)
+			.secure(true)
 			.sameSite("None")
 			.build();
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/oauth2/CustomSuccessHandler.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/oauth2/CustomSuccessHandler.java
@@ -13,7 +13,6 @@ import com.icandoit.boottalk.social_login.dto.CustomOAuth2User;
 import com.icandoit.boottalk.social_login.dto.UserRole;
 import com.icandoit.boottalk.social_login.jwt.JwtProvider;
 
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/oauth2/CustomSuccessHandler.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/oauth2/CustomSuccessHandler.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
 
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
@@ -13,7 +15,7 @@ import com.icandoit.boottalk.social_login.dto.CustomOAuth2User;
 import com.icandoit.boottalk.social_login.dto.UserRole;
 import com.icandoit.boottalk.social_login.jwt.JwtProvider;
 
-import jakarta.servlet.http.Cookie;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -43,10 +45,10 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
 
 		//토큰 생성 후 쿠키에 담아 전달
-		response.addCookie(createCookie("Authorization", jwtProvider.createToken(userDetails.getServiceUserId(), userDetails.getName(), role)));
+		// response.addCookie(createCookie("Authorization", jwtProvider.createToken(userDetails.getServiceUserId(), userDetails.getName(), role)));
 
-		// createCookie(response ,"Authorization"
-		// 	, jwtProvider.createToken(userDetails.getServiceUserId(), userDetails.getName(), role));
+		createCookie(response ,"Authorization"
+			, jwtProvider.createToken(userDetails.getServiceUserId(), userDetails.getName(), role));
 
 		// 신규회원인 경우,추가정보 입력 url로 리다이렉션
 		if (UserRole.valueOf(role).equals(UserRole.NEW_USER)) {
@@ -58,32 +60,32 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 	}
 
 	// 쿠키 생성
-	private Cookie createCookie(String key, String value) {
-
-		Cookie cookie = new Cookie(key, value);
-		cookie.setMaxAge(60*60*60);
-		//cookie.setSecure(true);
-		cookie.setPath("/");
-		cookie.setHttpOnly(true);
-
-		return cookie;
-	}
-	// private void createCookie(HttpServletResponse response, String key, String value) {
+	// private Cookie createCookie(String key, String value) {
 	//
-	// 	ResponseCookie responseCookie = ResponseCookie.from(key, value)
-	// 		.maxAge(60 * 60 * 60)
-	// 		.path("/")
-	// 		.httpOnly(true)
-	// 		.domain("http://localhost:8080")
-	// 		.sameSite("None")
-	// 		.build();
+	// 	Cookie cookie = new Cookie(key, value);
+	// 	cookie.setMaxAge(60*60*60);
+	// 	//cookie.setSecure(true);
+	// 	cookie.setPath("/");
+	// 	cookie.setHttpOnly(true);
 	//
-	// 	// Cookie cookie = new Cookie(key, value);
-	// 	// cookie.setMaxAge(60*60*60);
-	// 	// // cookie.setSecure(true); 실제 서비스 배포시에 활성화 (https 에서만 해당 쿠키가 전달되게 함)
-	// 	// cookie.setPath("/");
-	// 	// cookie.setHttpOnly(true);
-	//
-	// 	response.addHeader(HttpHeaders.SET_COOKIE, responseCookie.toString());
+	// 	return cookie;
 	// }
+	private void createCookie(HttpServletResponse response, String key, String value) {
+
+		ResponseCookie responseCookie = ResponseCookie.from(key, value)
+			.maxAge(60 * 60 * 60)
+			.path("/")
+			.httpOnly(true)
+			.secure(false)
+			.sameSite("Lax")
+			.build();
+
+		// Cookie cookie = new Cookie(key, value);
+		// cookie.setMaxAge(60*60*60);
+		// // cookie.setSecure(true); 실제 서비스 배포시에 활성화 (https 에서만 해당 쿠키가 전달되게 함)
+		// cookie.setPath("/");
+		// cookie.setHttpOnly(true);
+
+		response.addHeader(HttpHeaders.SET_COOKIE, responseCookie.toString());
+	}
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/oauth2/SocialClientRegistration.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/oauth2/SocialClientRegistration.java
@@ -28,7 +28,7 @@ public class SocialClientRegistration {
 		return ClientRegistration.withRegistrationId("naver")
 			.clientId(clientId)
 			.clientSecret(clientSecret)
-			.redirectUri("http://localhost:8080/login/oauth2/code/naver")
+			.redirectUri("http://43.200.67.27:8080/login/oauth2/code/naver")
 			.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
 			.scope("name", "email")
 			.authorizationUri("https://nid.naver.com/oauth2.0/authorize")

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/entity/User.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/entity/User.java
@@ -43,7 +43,7 @@ public class User extends BaseEntity {
 	private String resourceUserId;
 
 	@Enumerated(EnumType.STRING)
-	@Column(columnDefinition = "VARCHAR(50)", nullable = false)
+	@Column(columnDefinition = "VARCHAR(50)")
 	private BootcampCategoryType desiredCareer;
 
 	@Setter


### PR DESCRIPTION
## 🔍 주요 변경 사항
- SecurityConfiguration 내부에 corsConfigurationSource 빈등록하여 securityFilter에서 설정한 CORS가 적용될 수 있도록 함.
  - configuration.setAllowedOrigins(List.of("http://localhost:3000")); 
    => 요청을 허용할 출처 지정
  - configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")); 
    => 허용할 메서드 지정
  - configuration.setAllowCredentials(true); 
    => 인증 정보(쿠키, Authorization 헤더 등)를 포함한 요청을 허용
  -  UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
    => URL 패턴별로 CORS 설정을 적용할 수 있는 소스 객체를 생성
  -  source.registerCorsConfiguration("/**", configuration);
    => 모든 경로("/**")에 위에서 정의한 CORS 설정을 적용 

- OAuth2.loginPage() 메서드 삭제
  - 사용자 인증 없이 api 요청 시 강제로 로그인 페이지로 이동하는 설정을 제거해 만약 사용자 인증 없이 권한이 필요한 api 요청 시 그냥 에러를 반환하게 하기 위함.



---

## 💡 변경 이유
- 프론트 엔드와 연동을 위해 추가
- loginPage() 설정으로 인해 
  - 부트캠프 상세 페이지에서 상세 내용을 불러오는 api 와 리뷰 목록을 불러오는 api를 요청할 시에 리뷰 목록을 불러오는 api 의 경우 사용자 인증이 필요함. 이때 기존 security 설정("api 요청 시 사용자 인증이 되어있지 않으면 로그인 페이지로 이동되게 설정")에 따라 로그인 페이지로 이동하게 됨. 즉 상세 내용은 사용자 인증 없이도 볼 수 있음에도 불구하고 리뷰목록을 불러오는 api 때문에 상세내용 확인도 못하고 로그인 페이지로 강제 이동하게 됨.

---

## 🚀 개선 결과
- 프론트엔드와 연동


---

## 📂 관련 클래스 및 변경 파일



---

## ✅ 테스트 시나리오(예정) 



---

## 💡 참고 블로그



--- 

## 🖼️ 스크린샷



