### PR TITLE
feat: 커피챗 관련 알림 전송 기능 추가

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/BootcampCertificationService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/BootcampCertificationService.java
@@ -104,7 +104,6 @@ public class BootcampCertificationService {
 
 	// 수료증 인증 승인 거절 알림 발송
 	public void sendCertificationNotification(Long userId, NotificationType type) {
-		NotificationRequestDto requestDto = new NotificationRequestDto(type, null);
-		sseEmitterService.sendToClient(userId, requestDto);
+		sseEmitterService.sendToClient(userId, NotificationRequestDto.ofType(type));
 	}
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/entity/enums/StatusType.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/entity/enums/StatusType.java
@@ -1,10 +1,39 @@
 package com.icandoit.boottalk.coffeeChat.entity.enums;
 
+import com.icandoit.boottalk.notification.type.NotificationType;
+
 public enum StatusType {
     PENDING,    // 대기 - 멘토가 아직 수락/거절하지 않은 상태
     CANCELED,   // 취소 - 멘티가 신청을 취소한 상태
     AUTO_CANCELED,   // 자동 취소 - 멘토의 무응답으로 자동 취소된 상태
     REJECTED,   // 거절 - 멘토가 신청을 거절한 상태
     APPROVED,   // 수락 - 멘토가 신청을 수락한 상태
-    COMPLETED,  // 완료 - 커피챗 일정이 종료된 상태
+    COMPLETED  // 완료 - 커피챗 일정이 종료된 상태
+    ;
+
+    public boolean isPending() {
+        return this == PENDING;
+    }
+
+    public boolean isCanceled() {
+        return this == CANCELED;
+    }
+
+    public boolean isRejected() {
+        return this == REJECTED;
+    }
+
+    public boolean isApproved() {
+        return this == APPROVED;
+    }
+
+    public NotificationType toNotificationType() {
+        return switch (this) {
+            case APPROVED -> NotificationType.COFFEE_CHAT_REQUEST_APPROVED;
+            case REJECTED -> NotificationType.COFFEE_CHAT_REQUEST_REJECTED;
+            case CANCELED -> NotificationType.COFFEE_CHAT_REQUEST_CANCELLED_FROM_MENTOR;
+            default -> throw new IllegalStateException("Unexpected StatusType: " + this);
+        };
+    }
+
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatApplicationService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatApplicationService.java
@@ -18,6 +18,9 @@ import com.icandoit.boottalk.coffeeChat.repository.CoffeeChatInfoRepository;
 import com.icandoit.boottalk.common.dto.PagedResponseDto;
 import com.icandoit.boottalk.libs.exception.CustomException;
 import com.icandoit.boottalk.libs.exception.ErrorCode;
+import com.icandoit.boottalk.notification.dto.NotificationRequestDto;
+import com.icandoit.boottalk.notification.service.SseEmitterService;
+import com.icandoit.boottalk.notification.type.NotificationType;
 import com.icandoit.boottalk.point_history.domain.type.EventType;
 import com.icandoit.boottalk.point_history.service.CreatePointHistoryService;
 import com.icandoit.boottalk.user.domain.entity.User;
@@ -36,6 +39,7 @@ public class CoffeeChatApplicationService {
     private final UserRepository userRepository;
 
     private final CreatePointHistoryService createPointHistoryService;
+    private final SseEmitterService sseEmitterService;
 
     // 멘토 타입에 따른 포인트 차감액
     private final int GENERAL_COFFEE_CHAT_POINT = 1;
@@ -71,6 +75,12 @@ public class CoffeeChatApplicationService {
 
         CoffeeChatApplication coffeeChatApp = CoffeeChatApplication.of(user, coffeeChatInfo, deductionPoint, request);
         coffeeChatAppRepository.save(coffeeChatApp);
+
+        // 멘토에게 커피챗 신청 알림 전송
+        sseEmitterService.sendToClient(
+            coffeeChatInfo.getMentor().getUserId(),
+            NotificationRequestDto.ofType(NotificationType.COFFEE_CHAT_REQUEST_RECEIVED)
+        );
 
         return CoffeeChatApplicationResponseDto.from(coffeeChatApp);
 
@@ -132,19 +142,25 @@ public class CoffeeChatApplicationService {
         StatusType currentStatus = coffeeChatApp.getStatus();
 
         // 커피챗 취소는 상태가 대기 또는 수락 중일 때만 가능
-        if (!(currentStatus == StatusType.PENDING || currentStatus == StatusType.APPROVED)) {
+        if (!(currentStatus.isPending() || currentStatus.isApproved())) {
             throw new CustomException(ErrorCode.COFFEE_CHAT_CANNOT_CANCEL);
         }
 
         // 커피챗 취소시 환불 처리
         // 상태가 대기이거나, 상태가 승인이고 커피챗 시작 시간 2일 전까지는 환불 처리
-        if (currentStatus == StatusType.PENDING ||
-            currentStatus == StatusType.APPROVED && coffeeChatApp.isNDaysOrMoreUntilStart(2)
+        if (currentStatus.isPending() ||
+            currentStatus.isApproved() && coffeeChatApp.isNDaysOrMoreUntilStart(2)
         ) {
             createPointHistoryService.createPointHistory(EventType.COFFEE_CHAT_CANCEL_REFUND, userId, coffeeChatApp.getUsedPoint());
         }
 
         coffeeChatApp.setStatus(StatusType.CANCELED);
+
+        // 멘토에게 커피챗 취소 알린 전송
+        sseEmitterService.sendToClient(
+            userId,
+            NotificationRequestDto.ofType(NotificationType.COFFEE_CHAT_REQUEST_CANCELLED_FROM_MENTEE)
+        );
 
     }
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatReceivedService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatReceivedService.java
@@ -15,6 +15,8 @@ import com.icandoit.boottalk.coffeeChat.repository.CoffeeChatApplicationReposito
 import com.icandoit.boottalk.common.dto.PagedResponseDto;
 import com.icandoit.boottalk.libs.exception.CustomException;
 import com.icandoit.boottalk.libs.exception.ErrorCode;
+import com.icandoit.boottalk.notification.dto.NotificationRequestDto;
+import com.icandoit.boottalk.notification.service.SseEmitterService;
 import com.icandoit.boottalk.point_history.domain.type.EventType;
 import com.icandoit.boottalk.point_history.service.CreatePointHistoryService;
 
@@ -29,6 +31,7 @@ public class CoffeeChatReceivedService {
     private final CoffeeChatInfoService coffeeChatInfoService;
     private final CoffeeChatApplicationService coffeeChatAppService;
     private final CreatePointHistoryService createPointHistoryService;
+    private final SseEmitterService sseEmitterService;
 
     private static final int MENTORING_BAN_DAYS = 30;
 
@@ -53,34 +56,39 @@ public class CoffeeChatReceivedService {
         CoffeeChatApplication coffeeChatApp = coffeeChatAppService.getCoffeeChatApplication(coffeeChatAppId);
 
         Long mentorId = coffeeChatApp.getCoffeeChatInfo().getMentor().getUserId();
+        Long menteeId = coffeeChatApp.getMentee().getUserId();
 
         validateCoffeeChatOwner(mentorId, userId);
 
         StatusType changeStatus = request.changeStatus();
         StatusType currentStatus = coffeeChatApp.getStatus();
 
-        if (changeStatus == StatusType.CANCELED) {
-            // 승인된 커피챗을 1일 전 멘토가 취소할 경우, 멘토 활동 30일 금지 패널티 부여
-            if (currentStatus == StatusType.APPROVED && !coffeeChatApp.isNDaysOrMoreUntilStart(1)) {
-                coffeeChatApp.getCoffeeChatInfo().applyMentoringBan(MENTORING_BAN_DAYS);
-            }
-
-            // 거절 또는 취소된 경우 -> 포인트 환불
-            if (currentStatus == StatusType.REJECTED || currentStatus == StatusType.APPROVED) {
-                createPointHistoryService.createPointHistory(
-                    EventType.COFFEE_CHAT_CANCEL_REFUND,
-                    coffeeChatApp.getMentee().getUserId(),
-                    coffeeChatApp.getUsedPoint()
-                );
-            }
-
+        // 승인된 커피챗을 1일 전 멘토가 취소할 경우, 멘토 활동 30일 금지 패널티 부여
+        if (changeStatus.isCanceled() && currentStatus.isApproved() &&
+            !coffeeChatApp.isNDaysOrMoreUntilStart(1)) {
+            coffeeChatApp.getCoffeeChatInfo().applyMentoringBan(MENTORING_BAN_DAYS);
         }
 
-        if (changeStatus == StatusType.APPROVED) {
+        // 멘토가 커피챗 거절/취소 시, 멘티에게 포인트 환불
+        if (changeStatus.isRejected() || changeStatus.isCanceled()) {
+            createPointHistoryService.createPointHistory(
+                EventType.COFFEE_CHAT_CANCEL_REFUND,
+                menteeId,
+                coffeeChatApp.getUsedPoint()
+            );
+        }
+
+        if (changeStatus.isApproved()) {
             // TODO: 채팅룸 생성 (커피챗 시작 시간이 되면 채팅방 활성화)
         }
 
         coffeeChatApp.setStatus(changeStatus); // 상태 변경
+
+        // 멘토에게 커피챗 수락/거절/취소 알림 전송
+        sseEmitterService.sendToClient(
+            menteeId,
+            NotificationRequestDto.ofType(changeStatus.toNotificationType())
+        );
 
         return CoffeeChatAppStatusResponseDto.from(coffeeChatApp);
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatRefundService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatRefundService.java
@@ -1,6 +1,5 @@
 package com.icandoit.boottalk.coffeeChat.service;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -9,6 +8,9 @@ import org.springframework.transaction.annotation.Transactional;
 import com.icandoit.boottalk.coffeeChat.entity.CoffeeChatApplication;
 import com.icandoit.boottalk.coffeeChat.entity.enums.StatusType;
 import com.icandoit.boottalk.coffeeChat.repository.CoffeeChatApplicationRepository;
+import com.icandoit.boottalk.notification.dto.NotificationRequestDto;
+import com.icandoit.boottalk.notification.service.SseEmitterService;
+import com.icandoit.boottalk.notification.type.NotificationType;
 import com.icandoit.boottalk.point_history.domain.type.EventType;
 import com.icandoit.boottalk.point_history.service.CreatePointHistoryService;
 
@@ -22,6 +24,7 @@ public class CoffeeChatRefundService {
 
     private final CoffeeChatApplicationRepository coffeeChatAppRepository;
     private final CreatePointHistoryService createPointHistoryService;
+    private final SseEmitterService sseEmitterService;
 
     // 멘토의 무응답으로 커피챗 시작 시간이 지난 신청 내역에 대한 환불 처리
     @Transactional
@@ -46,7 +49,10 @@ public class CoffeeChatRefundService {
                 coffeeChatApp.setStatus(StatusType.AUTO_CANCELED);
                 coffeeChatAppRepository.save(coffeeChatApp);
 
-                // TODO: 멘티에게 알림 전송
+                sseEmitterService.sendToClient(
+                    menteeId,
+                    NotificationRequestDto.ofType(NotificationType.COFFEE_CHAT_AUTO_REFUND)
+                );
 
                 log.info("커피챗 자동 환불. menteeId: {}, coffeeChatAppId: {}, refundPoint: {}",
                     menteeId, coffeeChatApp.getCoffeeChatInfo().getCoffeeChatInfoId(), refundPoint);

--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/dto/NotificationRequestDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/dto/NotificationRequestDto.java
@@ -9,4 +9,7 @@ public record NotificationRequestDto(
 	NotificationType type,
 	Long targetId // 부트캠프 알림 전송인 경우 targetId에 부트캠프 Id 삽입.
 ) {
+	public static NotificationRequestDto ofType(NotificationType type) {
+		return new NotificationRequestDto(type, null);
+	}
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/dto/NotificationResponseDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/dto/NotificationResponseDto.java
@@ -24,13 +24,13 @@ public record NotificationResponseDto(
 			url += "/" + notification.getTargetId();
 		}
 
-		return NotificationResponseDto.builder()
-			.notificationId(notification.getNotificationId())
-			.type(notification.getType())
-			.message(notification.getType().getMessage())
-			.url(baseUrl + url)
-			.checked(notification.isChecked())
-			.createdAt(notification.getCreatedAt())
-			.build();
+		return new NotificationResponseDto(
+			notification.getNotificationId(),
+			notification.getType(),
+			notification.getType().getMessage(),
+			baseUrl + url,
+			notification.isChecked(),
+			notification.getCreatedAt()
+		);
 	}
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/type/NotificationType.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/type/NotificationType.java
@@ -7,10 +7,12 @@ import lombok.Getter;
 @Getter
 public enum NotificationType {
 	COFFEE_CHAT_REQUEST_RECEIVED( "/coffee-chats/applications/received", "커피챗 신청이 들어왔습니다."),    // 멘티로부터 커피챗 신청 도착 알림
-	COFFEE_CHAT_REQUEST_CANCELLED("/coffee-chats/applications/received","취소된 커피챗 신청이 있습니다."),    // 커피챗 신청 취소 알림
-	COFFEE_CHAT_REQUEST_ACCEPTED("/coffee-chats", "신청한 커피챗이 수락되었습니다."),    // 멘토로부터 커피챗 신청 수락 알림
+	COFFEE_CHAT_REQUEST_CANCELLED_FROM_MENTEE("/coffee-chats/applications/received","취소된 커피챗 신청이 있습니다."),    // 커피챗 신청 취소 알림
+	COFFEE_CHAT_REQUEST_APPROVED("/coffee-chats", "신청한 커피챗이 수락되었습니다."),    // 멘토로부터 커피챗 신청 수락 알림
 	COFFEE_CHAT_REQUEST_REJECTED("/coffee-chats", "신청한 커피챗이 거절되었습니다."),           // 커피챗 거절 알림
-	CHAT_SUSPENDED("/coffee-chats/info", "커피챗 활동이 정지되었습니다."),		//등록된 커피챗 정지 알림
+	COFFEE_CHAT_REQUEST_CANCELLED_FROM_MENTOR("/coffee-chats/applications/received","신청한 커피챗이 취소되었습니다."),    // 커피챗 취소 알림
+	CHAT_SUSPENDED("/coffee-chats", "커피챗 활동이 정지되었습니다."),		//등록된 커피챗 정지 알림
+	COFFEE_CHAT_AUTO_REFUND("/coffee-chats/applications", "신청한 커피챗이 만료되어 자동 환불되었습니다."),	// 커피챗 자동 환불 알림
 	CERTIFICATE_VERIFIED("/users/my", "수료증 인증이 완료되었습니다."),       // 수료증 인증 완료 알림
 	CERTIFICATE_REJECTED("/users/my", "수료증 인증이 거절되었습니다."),// 수료증 인증 반려 알림
 	NEW_BOOT_CAMP("/bootcamps", "관심있는 직군의 새로운 부트캠프가 등록되었습니다.");// 새로운 부트캠프 등록


### PR DESCRIPTION
## 🔍 주요 변경 사항
- 커피챗 관련 이벤트 발생 시 알림 전송 추가
- StatusType에 isApproved, isCanceled 등 상태 비교 메서드 추가 → 반복적인 enum 비교 로직 제거 및 가독성 향상
- 알림 타입 COFFEE_CHAT_REQUEST_ACCEPTED → COFFEE_CHAT_REQUEST_APPROVED로 변경 (기존 커피챗 신청 상태값 APPROVED와의 용어 통일을 위함)
- NotificationRequestDto에 ofType 정적 메서드 추가 (targetId 없이 생성 가능하도록)
- NotificationResponseDto 수정 - record 형식에 맞게 생성자 방식으로 반환하도록 수정


---

## 💡 변경 이유
- 커피챗 관련 이벤트 발생 시 알림 전송 기능이 없어, 사용자 변동 사항을 실시간으로 인지하기 어려웠음


---

## 🚀 개선 결과
- 사용자가 서비스에 직접 접속하지 않아도, 알림을 통해 커피챗 관련 이벤트 변동을 실시간으로 확일할 수 있게 됨


---

## ✅ 테스트 시나리오
- 아래 이벤트 발생 시, 해당 알림 데이터가 정상적으로 저장되는지 확인
   - 멘티가 커피챗을 신청하면 멘토에게 전송되는 커피챗 신청 알림 데이터 저장 (COFFEE_CHAT_REQUEST_RECEIVED)
   - 멘티가 신청한 커피챗을 취소하면 멘토에게 전송되는 커피챗 취소 알림 데이터 저장 (COFFEE_CHAT_REQUEST_CANCELLED_FROM_MENTEE)
   - 멘토가 커피챗을 수락하면 멘티에게 전송되는 커피챗 수락 알림 데이터 저장 (COFFEE_CHAT_REQUEST_APPROVED)
   - 멘토가 커피챗을 거절하면 멘티에게 전송되는 커피챗 거절 알림 데이터 저장 (COFFEE_CHAT_REQUEST_REJECTED)
   - 멘토가 커피챗을 취소하면 멘티에게 전송되는 커피챗 취소 알림 데이터 저장 (COFFEE_CHAT_REQUEST_CANCELLED_FROM_MENTOR)
   - 무응답 커피챗 자동 환불 시, 멘티에게 전송되는 커피챗 자동 환불 알림 데이터 저장 (COFFEE_CHAT_AUTO_REFUND)

## ✅ TODO
- 커피챗 채팅 관련 알림 전송 기능 추가


