### PR TITLE
refactor: 커피챗 공통 메소드 분리 및 수신 목록 조회 시 커피챗 정보 없을 경우 200 응답으로 처리

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatApplicationService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatApplicationService.java
@@ -14,7 +14,6 @@ import com.icandoit.boottalk.coffeeChat.entity.CoffeeChatInfo;
 import com.icandoit.boottalk.coffeeChat.entity.enums.MentorType;
 import com.icandoit.boottalk.coffeeChat.entity.enums.StatusType;
 import com.icandoit.boottalk.coffeeChat.repository.CoffeeChatApplicationRepository;
-import com.icandoit.boottalk.coffeeChat.repository.CoffeeChatInfoRepository;
 import com.icandoit.boottalk.common.dto.PagedResponseDto;
 import com.icandoit.boottalk.libs.exception.CustomException;
 import com.icandoit.boottalk.libs.exception.ErrorCode;
@@ -24,7 +23,6 @@ import com.icandoit.boottalk.notification.type.NotificationType;
 import com.icandoit.boottalk.point_history.domain.type.EventType;
 import com.icandoit.boottalk.point_history.service.CreatePointHistoryService;
 import com.icandoit.boottalk.user.domain.entity.User;
-import com.icandoit.boottalk.user.domain.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,10 +32,9 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class CoffeeChatApplicationService {
 
-    private final CoffeeChatInfoRepository coffeeChatInfoRepository;
     private final CoffeeChatApplicationRepository coffeeChatAppRepository;
-    private final UserRepository userRepository;
 
+    private final CoffeeChatCommonService coffeeChatCommonService;
     private final CreatePointHistoryService createPointHistoryService;
     private final SseEmitterService sseEmitterService;
 
@@ -65,8 +62,8 @@ public class CoffeeChatApplicationService {
 
         log.debug("커피챗 신청 Lock 해제: userId: {}", userId);
 
-        User user = getUser(userId);
-        CoffeeChatInfo coffeeChatInfo = getCoffeeChatInfo(coffeChatInfoId);
+        User user = coffeeChatCommonService.getUser(userId);
+        CoffeeChatInfo coffeeChatInfo = coffeeChatCommonService.getCoffeeChatInfo(coffeChatInfoId);
 
         MentorType mentorType = coffeeChatInfo.getMentorType();
         int deductionPoint = getPointCostByMentorType (mentorType); // 멘토 타입에 따른 커피챗 포인트
@@ -111,16 +108,17 @@ public class CoffeeChatApplicationService {
     }
 
     public CoffeeChatApplicationResponseDto getCoffeeChatAppInfo(Long coffeeChatAppId) {
-        return CoffeeChatApplicationResponseDto.from(getCoffeeChatApplication(coffeeChatAppId));
+        return CoffeeChatApplicationResponseDto.from(
+            coffeeChatCommonService.getCoffeeChatApplication(coffeeChatAppId));
     }
 
     @Transactional
     public CoffeeChatApplicationResponseDto updateCoffeeChatApp(
         Long userId, Long coffeeChatAppId, CoffeeChatApplicationUpdateDto request) {
-        CoffeeChatApplication coffeeChatApp = getCoffeeChatApplication(coffeeChatAppId);
+        CoffeeChatApplication coffeeChatApp = coffeeChatCommonService.getCoffeeChatApplication(coffeeChatAppId);
 
-        validateCoffeeChatApplicant(userId, coffeeChatApp.getMentee().getUserId());
-        validateCoffeeChatInfo(coffeeChatApp.getCoffeeChatInfo().getCoffeeChatInfoId());
+        coffeeChatCommonService.validateCoffeeChatApplicant(userId, coffeeChatApp.getMentee().getUserId());
+        coffeeChatCommonService.validateCoffeeChatInfo(coffeeChatApp.getCoffeeChatInfo().getCoffeeChatInfoId());
 
         // 상태가 대기 중일 때만 content 수정 가능
         if (coffeeChatApp.getStatus() != StatusType.PENDING) {
@@ -134,10 +132,10 @@ public class CoffeeChatApplicationService {
 
     @Transactional
     public void cancelCoffeeChatApp(Long userId, Long coffeeChatAppId) {
-        CoffeeChatApplication coffeeChatApp = getCoffeeChatApplication(coffeeChatAppId);
+        CoffeeChatApplication coffeeChatApp = coffeeChatCommonService.getCoffeeChatApplication(coffeeChatAppId);
 
-        validateCoffeeChatApplicant(userId, coffeeChatApp.getMentee().getUserId());
-        validateCoffeeChatInfo(coffeeChatApp.getCoffeeChatInfo().getCoffeeChatInfoId());
+        coffeeChatCommonService.validateCoffeeChatApplicant(userId, coffeeChatApp.getMentee().getUserId());
+        coffeeChatCommonService.validateCoffeeChatInfo(coffeeChatApp.getCoffeeChatInfo().getCoffeeChatInfoId());
 
         StatusType currentStatus = coffeeChatApp.getStatus();
 
@@ -162,36 +160,6 @@ public class CoffeeChatApplicationService {
             NotificationRequestDto.ofType(NotificationType.COFFEE_CHAT_REQUEST_CANCELLED_FROM_MENTEE)
         );
 
-    }
-
-
-    private User getUser(Long userId) { // TODO: 추후 공통 코드 관리하는 곳으로 분리하여 호출하도록 리팩토링 필요해보임
-        return userRepository.findById(userId)
-            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-    }
-
-    private CoffeeChatInfo getCoffeeChatInfo(Long coffeeChatInfoId) {
-        return coffeeChatInfoRepository.findById(coffeeChatInfoId)
-            .orElseThrow(() -> new CustomException(ErrorCode.COFFEE_CHAT_NOT_FOUND));
-    }
-
-    protected CoffeeChatApplication getCoffeeChatApplication(Long coffeeChatAppId) {
-        return coffeeChatAppRepository.findById(coffeeChatAppId)
-            .orElseThrow(() -> new CustomException(ErrorCode.COFFEE_CHAT_APPLICATION_NOT_FOUND));
-    }
-
-    // 해당 사용자가 작성한 커피챗 신청자인지 확인
-    private void validateCoffeeChatApplicant(Long userId, Long menteeId) {
-        if (!userId.equals(menteeId)) {
-            throw new CustomException(ErrorCode.NOT_COFFEE_CHAT_APPLICATION_OWNER);
-        }
-    }
-
-    // 존재하는 커피챗 정보인지 확인
-    protected void validateCoffeeChatInfo(Long coffeeChatInfoId) {
-        if(!coffeeChatInfoRepository.existsById(coffeeChatInfoId)) {
-            throw new CustomException(ErrorCode.COFFEE_CHAT_NOT_FOUND);
-        }
     }
 
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatCommonService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatCommonService.java
@@ -1,5 +1,7 @@
 package com.icandoit.boottalk.coffeeChat.service;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
 
 import com.icandoit.boottalk.coffeeChat.entity.CoffeeChatApplication;
@@ -32,9 +34,14 @@ public class CoffeeChatCommonService {
         return coffeeChatInfoRepository.findById(coffeeChatInfoId)
             .orElseThrow(() -> new CustomException(ErrorCode.COFFEE_CHAT_NOT_FOUND));
     }
+
     protected CoffeeChatInfo getCoffeeChatInfoByUserId(Long userId) {
         return coffeeChatInfoRepository.findByMentor_UserId(userId)
             .orElseThrow(() -> new CustomException(ErrorCode.USER_COFFEE_CHAT_NOT_FOUND));
+    }
+
+    protected Optional<CoffeeChatInfo> getOptionalCoffeeChatInfoByUserId(Long userId) {
+        return coffeeChatInfoRepository.findByMentor_UserId(userId);
     }
 
     protected CoffeeChatApplication getCoffeeChatApplication(Long coffeeChatAppId) {

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatCommonService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatCommonService.java
@@ -1,0 +1,66 @@
+package com.icandoit.boottalk.coffeeChat.service;
+
+import org.springframework.stereotype.Service;
+
+import com.icandoit.boottalk.coffeeChat.entity.CoffeeChatApplication;
+import com.icandoit.boottalk.coffeeChat.entity.CoffeeChatInfo;
+import com.icandoit.boottalk.coffeeChat.repository.CoffeeChatApplicationRepository;
+import com.icandoit.boottalk.coffeeChat.repository.CoffeeChatInfoRepository;
+import com.icandoit.boottalk.libs.exception.CustomException;
+import com.icandoit.boottalk.libs.exception.ErrorCode;
+import com.icandoit.boottalk.user.domain.entity.User;
+import com.icandoit.boottalk.user.domain.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CoffeeChatCommonService {
+
+    private final CoffeeChatInfoRepository coffeeChatInfoRepository;
+    private final CoffeeChatApplicationRepository coffeeChatAppRepository;
+    private final UserRepository userRepository;
+
+    protected User getUser(Long userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    protected CoffeeChatInfo getCoffeeChatInfo(Long coffeeChatInfoId) {
+        return coffeeChatInfoRepository.findById(coffeeChatInfoId)
+            .orElseThrow(() -> new CustomException(ErrorCode.COFFEE_CHAT_NOT_FOUND));
+    }
+    protected CoffeeChatInfo getCoffeeChatInfoByUserId(Long userId) {
+        return coffeeChatInfoRepository.findByMentor_UserId(userId)
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_COFFEE_CHAT_NOT_FOUND));
+    }
+
+    protected CoffeeChatApplication getCoffeeChatApplication(Long coffeeChatAppId) {
+        return coffeeChatAppRepository.findById(coffeeChatAppId)
+            .orElseThrow(() -> new CustomException(ErrorCode.COFFEE_CHAT_APPLICATION_NOT_FOUND));
+    }
+
+    // 해당 사용자가 작성한 커피챗 신청자인지 확인
+    protected void validateCoffeeChatApplicant(Long userId, Long menteeId) {
+        if (!userId.equals(menteeId)) {
+            throw new CustomException(ErrorCode.NOT_COFFEE_CHAT_APPLICATION_OWNER);
+        }
+    }
+
+    // 존재하는 커피챗 정보인지 확인
+    protected void validateCoffeeChatInfo(Long coffeeChatInfoId) {
+        if(!coffeeChatInfoRepository.existsById(coffeeChatInfoId)) {
+            throw new CustomException(ErrorCode.COFFEE_CHAT_NOT_FOUND);
+        }
+    }
+
+    // 커피챗 정보의 작성자가 요청한 사용자와 일치하는지 확인
+    protected void validateCoffeeChatOwner(Long creatorId, Long requestUserId) {
+        if (!creatorId.equals(requestUserId)) {
+            throw new CustomException(ErrorCode.NOT_COFFEE_CHAT_INFO_OWNER);
+        }
+    }
+
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatInfoService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatInfoService.java
@@ -1,5 +1,7 @@
 package com.icandoit.boottalk.coffeeChat.service;
 
+import org.springframework.stereotype.Service;
+
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatInfoRequestDto;
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatInfoResponseDto;
 import com.icandoit.boottalk.coffeeChat.entity.CoffeeChatInfo;
@@ -7,23 +9,21 @@ import com.icandoit.boottalk.coffeeChat.repository.CoffeeChatInfoRepository;
 import com.icandoit.boottalk.libs.exception.CustomException;
 import com.icandoit.boottalk.libs.exception.ErrorCode;
 import com.icandoit.boottalk.user.domain.entity.User;
-import com.icandoit.boottalk.user.domain.repository.UserRepository;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class CoffeeChatInfoService {
 
-    private final UserRepository userRepository;
     private final CoffeeChatInfoRepository coffeeChatInfoRepository;
+
+    private final CoffeeChatCommonService coffeeChatCommonService;
 
     public CoffeeChatInfoResponseDto createCoffeeChatInfo(Long userId,
         CoffeeChatInfoRequestDto requestDto) {
 
-        User user = userRepository.findById(userId)
-            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user = coffeeChatCommonService.getUser(userId);
 
         if (coffeeChatInfoRepository.existsByMentor_UserId(userId)) {
             throw new CustomException(ErrorCode.COFFEE_CHAT_ALREADY_EXISTS);
@@ -42,7 +42,7 @@ public class CoffeeChatInfoService {
 
     public CoffeeChatInfoResponseDto getMyCoffeeChatInfo(Long userId) {
 
-        CoffeeChatInfo coffeeChatInfo = getCoffeeChatInfoByUserId(userId);
+        CoffeeChatInfo coffeeChatInfo = coffeeChatCommonService.getCoffeeChatInfoByUserId(userId);
         return CoffeeChatInfoResponseDto.from(coffeeChatInfo);
     }
 
@@ -56,14 +56,14 @@ public class CoffeeChatInfoService {
     public CoffeeChatInfoResponseDto updateMyCoffeeChatInfo(
         Long userId, CoffeeChatInfoRequestDto requestDto) {
 
-        CoffeeChatInfo coffeeChatInfo = getCoffeeChatInfoByUserId(userId);
+        CoffeeChatInfo coffeeChatInfo = coffeeChatCommonService.getCoffeeChatInfoByUserId(userId);
 
         coffeeChatInfo.update(requestDto);
         return CoffeeChatInfoResponseDto.from(coffeeChatInfo);
     }
 
     public void deleteMyCoffeeChatInfo(Long userId) {
-        CoffeeChatInfo coffeeChatInfo = getCoffeeChatInfoByUserId(userId);
+        CoffeeChatInfo coffeeChatInfo = coffeeChatCommonService.getCoffeeChatInfoByUserId(userId);
 
         // 멘토링 활동 금지 당한 커피챗 정보는 삭제 불가
         if (coffeeChatInfo.isMentoringBanned()) {
@@ -73,8 +73,4 @@ public class CoffeeChatInfoService {
         coffeeChatInfoRepository.delete(coffeeChatInfo);
     }
 
-    protected CoffeeChatInfo getCoffeeChatInfoByUserId(Long userId) {
-        return coffeeChatInfoRepository.findByMentor_UserId(userId)
-            .orElseThrow(() -> new CustomException(ErrorCode.USER_COFFEE_CHAT_NOT_FOUND));
-    }
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatReceivedService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatReceivedService.java
@@ -37,7 +37,12 @@ public class CoffeeChatReceivedService {
         Long userId, Pageable pageable) {
 
         // 커피챗 정보 조회
-        CoffeeChatInfo coffeeChatInfo = coffeeChatCommonService.getCoffeeChatInfoByUserId(userId);
+        CoffeeChatInfo coffeeChatInfo = coffeeChatCommonService.getOptionalCoffeeChatInfoByUserId(userId).orElse(null);
+
+        if (coffeeChatInfo == null) {
+            Page<CoffeeChatApplicationResponseDto> emptyPage = Page.empty(pageable);
+            return PagedResponseDto.from(emptyPage);
+        }
 
         Page<CoffeeChatApplicationResponseDto> page =
             coffeeChatAppRepository.findByCoffeeChatInfo_CoffeeChatInfoId(coffeeChatInfo.getCoffeeChatInfoId(), pageable)

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatReceivedService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatReceivedService.java
@@ -13,8 +13,6 @@ import com.icandoit.boottalk.coffeeChat.entity.CoffeeChatInfo;
 import com.icandoit.boottalk.coffeeChat.entity.enums.StatusType;
 import com.icandoit.boottalk.coffeeChat.repository.CoffeeChatApplicationRepository;
 import com.icandoit.boottalk.common.dto.PagedResponseDto;
-import com.icandoit.boottalk.libs.exception.CustomException;
-import com.icandoit.boottalk.libs.exception.ErrorCode;
 import com.icandoit.boottalk.notification.dto.NotificationRequestDto;
 import com.icandoit.boottalk.notification.service.SseEmitterService;
 import com.icandoit.boottalk.point_history.domain.type.EventType;
@@ -28,8 +26,7 @@ public class CoffeeChatReceivedService {
 
     private final CoffeeChatApplicationRepository coffeeChatAppRepository;
 
-    private final CoffeeChatInfoService coffeeChatInfoService;
-    private final CoffeeChatApplicationService coffeeChatAppService;
+    private final CoffeeChatCommonService coffeeChatCommonService;
     private final CreatePointHistoryService createPointHistoryService;
     private final SseEmitterService sseEmitterService;
 
@@ -40,7 +37,7 @@ public class CoffeeChatReceivedService {
         Long userId, Pageable pageable) {
 
         // 커피챗 정보 조회
-        CoffeeChatInfo coffeeChatInfo = coffeeChatInfoService.getCoffeeChatInfoByUserId(userId);
+        CoffeeChatInfo coffeeChatInfo = coffeeChatCommonService.getCoffeeChatInfoByUserId(userId);
 
         Page<CoffeeChatApplicationResponseDto> page =
             coffeeChatAppRepository.findByCoffeeChatInfo_CoffeeChatInfoId(coffeeChatInfo.getCoffeeChatInfoId(), pageable)
@@ -53,12 +50,12 @@ public class CoffeeChatReceivedService {
     public CoffeeChatAppStatusResponseDto changeCoffeeChatAppStatus(
         Long userId, Long coffeeChatAppId, CoffeeChatAppChangeStatusDto request) {
 
-        CoffeeChatApplication coffeeChatApp = coffeeChatAppService.getCoffeeChatApplication(coffeeChatAppId);
+        CoffeeChatApplication coffeeChatApp = coffeeChatCommonService.getCoffeeChatApplication(coffeeChatAppId);
 
         Long mentorId = coffeeChatApp.getCoffeeChatInfo().getMentor().getUserId();
         Long menteeId = coffeeChatApp.getMentee().getUserId();
 
-        validateCoffeeChatOwner(mentorId, userId);
+        coffeeChatCommonService.validateCoffeeChatOwner(mentorId, userId);
 
         StatusType changeStatus = request.changeStatus();
         StatusType currentStatus = coffeeChatApp.getStatus();
@@ -94,12 +91,6 @@ public class CoffeeChatReceivedService {
 
     }
 
-    // 커피챗 정보의 작성자가 요청한 사용자와 일치하는지 확인
-    private void validateCoffeeChatOwner(Long creatorId, Long requestUserId) {
-        if (!creatorId.equals(requestUserId)) {
-            throw new CustomException(ErrorCode.NOT_COFFEE_CHAT_INFO_OWNER);
-        }
-    }
 
 
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatTimeService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatTimeService.java
@@ -14,12 +14,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.icandoit.boottalk.coffeeChat.dto.AvailableChatTimeDto;
 import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatTimeDto;
-import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatTimeMapDto;
-import com.icandoit.boottalk.coffeeChat.dto.CoffeeChatTimeResponseDto;
 import com.icandoit.boottalk.coffeeChat.entity.CoffeeChatInfo;
 import com.icandoit.boottalk.coffeeChat.entity.CoffeeChatTime;
 import com.icandoit.boottalk.coffeeChat.repository.CoffeeChatApplicationRepository;


### PR DESCRIPTION
## 🔍 주요 변경 사항

- 커피챗 서비스 공통 메서드를 `CoffeeChatCommonService` 클래스로 분리  
  - `CoffeeChatApplicationService`, `CoffeeChatInfoService`, `CoffeeChatReceivedService` 등에서  
    중복으로 사용되던 로직을 공통 클래스로 추출하여 **재사용성과 유지보수성 향상**

- 커피챗 수신 목록 조회 시, 커피챗 정보가 없는 경우 404 대신 200 응답으로 빈 목록 반환  
  - 기존에는 커피챗 정보가 없을 경우 404 에러를 발생시켰으며,  
    프론트단에서는 이 에러 응답을 확인해 빈 목록을 출력해야 했음  
  - 해당 로직을 수정하여 **커피챗 정보가 없을 경우에도 200 응답과 함께 빈 목록을 반환**하도록 개선

## 🖼️ 스크린샷
- 기존 커피챗 수신 목록 조회 (커피챗 정보가 없을 경우)
![수신커피챗1](https://github.com/user-attachments/assets/e4594ae2-a4c7-40fe-835e-c0e0d22164b4)

- 변경된 커피챗 수신 목록 조회 (커피챗 정보가 없을 경우)
![수신커피챗2](https://github.com/user-attachments/assets/98bddbe3-dfd3-45ac-9f63-065601c224c0)



