### PR TITLE
refactor : Bootcamp, TrainingCenter, Certification 파일 refactor

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/batch/scheduler/NotificationQuartzJob.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/batch/scheduler/NotificationQuartzJob.java
@@ -1,7 +1,5 @@
 package com.icandoit.boottalk.batch.scheduler;
 
-import static com.icandoit.boottalk.bootcamp.service.RedisService.*;
-
 import java.util.List;
 import java.util.Set;
 
@@ -15,6 +13,7 @@ import com.icandoit.boottalk.bootcamp.service.RedisService;
 import com.icandoit.boottalk.notification.dto.NotificationRequestDto;
 import com.icandoit.boottalk.notification.service.SseEmitterService;
 import com.icandoit.boottalk.notification.type.NotificationType;
+import com.icandoit.boottalk.common.RedisKeyPrefix;
 import com.icandoit.boottalk.user.domain.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -35,12 +34,12 @@ public class NotificationQuartzJob extends QuartzJobBean {
 			log.info("Notification Quartz Job 시작: 알림 전송 작업 실행...");
 
 			// redis 키값 받아오고
-			Set<String> keys = redisService.getKeys(BOOTCAMP_KEY_PREFIX + "*");
+			Set<String> keys = redisService.getKeys(RedisKeyPrefix.bootcamp() + "*");
 			// key 값이 존재한다면
 			if(keys != null && !keys.isEmpty()) {
 				for(String redisKey : keys) {
 					// key 값에서 데이터 parsing
-					String categoryString = redisKey.substring(BOOTCAMP_KEY_PREFIX.length());
+					String categoryString = redisKey.substring(RedisKeyPrefix.bootcamp().length());
 					BootcampCategoryType category;
 
 					// parsing 된 데이터 존재 값 확인

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/controller/BootcampCertificationController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/controller/BootcampCertificationController.java
@@ -4,46 +4,27 @@ import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.icandoit.boottalk.bootcamp.dto.CertificationCreationRequestDto;
 import com.icandoit.boottalk.bootcamp.dto.CertificationResponseDto;
 import com.icandoit.boottalk.bootcamp.dto.CertificationUpdateRequestDto;
 import com.icandoit.boottalk.bootcamp.dto.GetCertificationInfoDto;
 import com.icandoit.boottalk.bootcamp.dto.GetPendingCertificationResponseDto;
 import com.icandoit.boottalk.bootcamp.service.BootcampCertificationService;
-import com.icandoit.boottalk.social_login.dto.CustomOAuth2User;
 
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/users/certification")
+@RequestMapping("/api/admin/certification")
 @RequiredArgsConstructor
 public class BootcampCertificationController {
 
 	private final BootcampCertificationService certificationService;
-
-	// 부트캠프 수료증 등록
-	@PostMapping
-	public ResponseEntity<CertificationResponseDto> createCertification(
-		@AuthenticationPrincipal CustomOAuth2User user,
-		@RequestBody CertificationCreationRequestDto request
-	) {
-		Long userId = user.getServiceUserId();
-
-		CertificationResponseDto response = certificationService.createCertification(
-			userId, request
-		);
-
-		return ResponseEntity.ok(response);
-	}
 
 	@GetMapping
 	@PreAuthorize("hasAuthority('ADMIN')")

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/controller/TrainingCenterController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/controller/TrainingCenterController.java
@@ -24,5 +24,4 @@ public class TrainingCenterController {
 	{
 		return ResponseEntity.ok(trainingCenterService.findById(trainingCenterId));
 	}
-
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/entity/enums/BootcampCategoryType.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/entity/enums/BootcampCategoryType.java
@@ -41,15 +41,10 @@ public enum BootcampCategoryType {
 	}
 
 	public static boolean isValidKoreanName(String koreanName) {
-		if(!koreanToEnumMap.containsKey(koreanName)) {
-			throw new CustomException(ErrorCode.INVALID_CATEGORY_NAME);
-		}
-
 		return koreanToEnumMap.containsKey(koreanName);
 	}
 
 	public static BootcampCategoryType fromKoreanName(String koreanName) {
-
 		return koreanToEnumMap.get(koreanName);
 	}
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/entity/enums/BootcampCategoryType.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/entity/enums/BootcampCategoryType.java
@@ -41,13 +41,15 @@ public enum BootcampCategoryType {
 	}
 
 	public static boolean isValidKoreanName(String koreanName) {
+		if(!koreanToEnumMap.containsKey(koreanName)) {
+			throw new CustomException(ErrorCode.INVALID_CATEGORY_NAME);
+		}
+
 		return koreanToEnumMap.containsKey(koreanName);
 	}
 
 	public static BootcampCategoryType fromKoreanName(String koreanName) {
-		if(!koreanToEnumMap.containsKey(koreanName)) {
-			throw new CustomException(ErrorCode.INVALID_CATEGORY_NAME);
-		}
+
 		return koreanToEnumMap.get(koreanName);
 	}
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/repository/CourseRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/repository/CourseRepository.java
@@ -21,8 +21,5 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
 	@Query("SELECT c From Course c WHERE c.trainingProgramId = :trainingProgramId")
 	Optional<Course> findWithLockByTrainingProgramId(String trainingProgramId);
 
-	// course name 으로 코드 조회
-	Optional<Course> findByCourseName(String courseName);
-
 	List<Course> findByCourseNameContainingIgnoreCase(String query, Pageable pageable);
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/BootcampCertificationService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/BootcampCertificationService.java
@@ -1,5 +1,7 @@
 package com.icandoit.boottalk.bootcamp.service;
 
+import static com.icandoit.boottalk.bootcamp.entity.enums.CertificationStatus.*;
+import static com.icandoit.boottalk.libs.exception.ErrorCode.*;
 import static com.icandoit.boottalk.notification.type.NotificationType.*;
 
 import java.util.List;
@@ -19,7 +21,6 @@ import com.icandoit.boottalk.bootcamp.entity.enums.CertificationStatus;
 import com.icandoit.boottalk.bootcamp.repository.BootcampCertificationRepository;
 import com.icandoit.boottalk.bootcamp.repository.CourseRepository;
 import com.icandoit.boottalk.libs.exception.CustomException;
-import com.icandoit.boottalk.libs.exception.ErrorCode;
 import com.icandoit.boottalk.notification.dto.NotificationRequestDto;
 import com.icandoit.boottalk.notification.service.SseEmitterService;
 import com.icandoit.boottalk.notification.type.NotificationType;
@@ -40,28 +41,29 @@ public class BootcampCertificationService {
 	// 수료증 등록
 	@Transactional
 	public CertificationResponseDto createCertification(Long userId, CertificationCreationRequestDto request) {
-		Course course = courseRepository.findById(request.courseId())
-			.orElseThrow(() -> new CustomException(ErrorCode.COURSE_NOT_FOUND));
 
+		Long courseId = request.courseId();
+
+		Course course = findCourseById(courseId);
 		User user = userRepository.getReferenceById(userId);
 
 		// 해당 부트캠프에 승인됐거나 요청한 적이 있으면 에러 발생, 거절되었을때는 다시 신청 가능
-		if (bootcampCertificationRepository.existsByUserAndCourseAndStatusNot(user, course, CertificationStatus.REJECTED)) {
-			throw new CustomException(ErrorCode.DUPLICATE_CERTIFICATION_EXIST);
+		if (hasActiveCertification(user, course)) {
+			throw new CustomException(DUPLICATE_CERTIFICATION_EXIST);
 		}
 
-		BootcampCertification certification =
-			BootcampCertification.of(user, course, request.fileUrl());
+		BootcampCertification certification = BootcampCertification.of(user, course, request.fileUrl());
 
-		BootcampCertification savedCertification = bootcampCertificationRepository.save(certification);
-
-		return CertificationResponseDto.from(savedCertification);
+		return CertificationResponseDto.from(bootcampCertificationRepository.save(certification));
 	}
+
+
 
 	public List<GetCertificationResponseDto> getMyCertifications(Long userId) {
 		User user = userRepository.getReferenceById(userId);
 
-		List<BootcampCertification> certifications = bootcampCertificationRepository.findAllByUserAndStatus(user, CertificationStatus.APPROVED);
+		List<BootcampCertification> certifications = bootcampCertificationRepository.findAllByUserAndStatus(user,
+			APPROVED);
 
 		return certifications.stream()
 			.map(GetCertificationResponseDto::from)
@@ -70,7 +72,8 @@ public class BootcampCertificationService {
 
 	// 승인 대기중인 요청 모두 조회
 	public List<GetPendingCertificationResponseDto> getPendingCertifications() {
-		List<BootcampCertification> certifications = bootcampCertificationRepository.findAllByStatus(CertificationStatus.PENDING);
+		List<BootcampCertification> certifications = bootcampCertificationRepository.findAllByStatus(PENDING);
+
 		return certifications.stream()
 			.map(GetPendingCertificationResponseDto::from)
 			.toList();
@@ -78,16 +81,14 @@ public class BootcampCertificationService {
 
 	// 수료증 정보 조회
 	public GetCertificationInfoDto findById(Long certificationId) {
-		BootcampCertification certification = bootcampCertificationRepository.getReferenceById(certificationId);
-
-		return GetCertificationInfoDto.from(certification);
+		return GetCertificationInfoDto.from(bootcampCertificationRepository.getReferenceById(certificationId));
 	}
 
 	// 수료증 승인 거절 로직
 	public CertificationResponseDto updateCertification(CertificationUpdateRequestDto request) {
 		BootcampCertification certification = bootcampCertificationRepository.getReferenceById(request.certificationId());
 
-		CertificationStatus newStatus = request.isTrue() ? CertificationStatus.APPROVED : CertificationStatus.REJECTED;
+		CertificationStatus newStatus = request.isTrue() ? APPROVED : REJECTED;
 		certification.updateStatus(newStatus);
 
 		BootcampCertification savedCertification = bootcampCertificationRepository.save(certification);
@@ -98,12 +99,20 @@ public class BootcampCertificationService {
 
 		sendCertificationNotification(userId, type);
 
-
 		return CertificationResponseDto.from(savedCertification);
 	}
 
 	// 수료증 인증 승인 거절 알림 발송
 	public void sendCertificationNotification(Long userId, NotificationType type) {
 		sseEmitterService.sendToClient(userId, NotificationRequestDto.ofType(type));
+	}
+
+	private Course findCourseById(Long courseId) {
+		return courseRepository.findById(courseId)
+			.orElseThrow(() -> new CustomException(COURSE_NOT_FOUND));
+	}
+
+	private boolean hasActiveCertification(User user, Course course) {
+		return bootcampCertificationRepository.existsByUserAndCourseAndStatusNot(user, course, REJECTED);
 	}
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/BootcampService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/BootcampService.java
@@ -1,9 +1,6 @@
 package com.icandoit.boottalk.bootcamp.service;
 
-import static com.icandoit.boottalk.libs.exception.ErrorCode.*;
-
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -17,7 +14,6 @@ import com.icandoit.boottalk.bootcamp.entity.Bootcamp;
 import com.icandoit.boottalk.bootcamp.entity.enums.BootcampCategoryType;
 import com.icandoit.boottalk.bootcamp.repository.BootcampQueryRepository;
 import com.icandoit.boottalk.bootcamp.repository.BootcampRepository;
-import com.icandoit.boottalk.libs.exception.CustomException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -28,21 +24,17 @@ public class BootcampService {
 	private final BootcampRepository bootcampRepository;
 	private final BootcampQueryRepository bootcampQueryRepository;
 
+	// 부트캠프 저장
 	@Transactional
 	public Bootcamp save(Bootcamp bootcamp) {
 		return bootcampRepository.save(bootcamp);
 	}
 
 	// 부트캠프 단일 조회
-	@Transactional(readOnly = true)
 	public BootcampDetailResponseDto findById(Long id) {
-		Optional<Bootcamp> bootcamp = bootcampRepository.findById(id);
+		Bootcamp bootcamp = bootcampRepository.getReferenceById(id);
 
-		if (bootcamp.isEmpty()) {
-			throw new CustomException(BOOTCAMP_NOT_FOUND);
-		}
-
-		return BootcampDetailResponseDto.from(bootcamp.get());
+		return BootcampDetailResponseDto.from(bootcamp);
 	}
 
 	// 부트캠프 필터링, 검색 조회

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/BootcampService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/BootcampService.java
@@ -32,9 +32,7 @@ public class BootcampService {
 
 	// 부트캠프 단일 조회
 	public BootcampDetailResponseDto findById(Long id) {
-		Bootcamp bootcamp = bootcampRepository.getReferenceById(id);
-
-		return BootcampDetailResponseDto.from(bootcamp);
+		return BootcampDetailResponseDto.from(bootcampRepository.getReferenceById(id));
 	}
 
 	// 부트캠프 필터링, 검색 조회

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/RedisService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/RedisService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
 import com.icandoit.boottalk.bootcamp.entity.enums.BootcampCategoryType;
+import com.icandoit.boottalk.common.RedisKeyPrefix;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,8 +20,6 @@ import lombok.extern.slf4j.Slf4j;
 public class RedisService {
 
 	private final RedisTemplate<String, String> redisTemplate;
-
-	public static final String BOOTCAMP_KEY_PREFIX = "new:bootcamp:";
 
 	// redis 에서 pattern 에 해당하는 key 값 조회
 	public Set<String> getKeys(String pattern) {
@@ -42,7 +41,7 @@ public class RedisService {
 
 	// redis 에 key 와 value 값 저장
 	public void storeNewBootcampInfo(String bootcampId, BootcampCategoryType categoryType) {
-		String redisKey = BOOTCAMP_KEY_PREFIX + categoryType.name();
+		String redisKey = RedisKeyPrefix.bootcamp(categoryType.name());
 		redisTemplate.opsForList().rightPush(redisKey, bootcampId);
 		redisTemplate.expire(redisKey, Duration.ofHours(2));
 	}

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/TrainingCenterService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/TrainingCenterService.java
@@ -1,15 +1,10 @@
 package com.icandoit.boottalk.bootcamp.service;
 
-import static com.icandoit.boottalk.libs.exception.ErrorCode.*;
-
-import java.util.Optional;
-
 import org.springframework.stereotype.Service;
 
 import com.icandoit.boottalk.bootcamp.dto.TrainingCenterResponseDto;
 import com.icandoit.boottalk.bootcamp.entity.TrainingCenter;
 import com.icandoit.boottalk.bootcamp.repository.TrainingCenterRepository;
-import com.icandoit.boottalk.libs.exception.CustomException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -20,12 +15,8 @@ public class TrainingCenterService {
 	private final TrainingCenterRepository trainingCenterRepository;
 
 	public TrainingCenterResponseDto findById(Long id) {
-		Optional<TrainingCenter> trainingCenter = trainingCenterRepository.findById(id);
+		TrainingCenter trainingCenter = trainingCenterRepository.getReferenceById(id);
 
-		if(trainingCenter.isEmpty()) {
-			throw new CustomException(TRAINING_CENTER_NOT_FOUND);
-		}
-
-		return TrainingCenterResponseDto.from(trainingCenter.get());
+		return TrainingCenterResponseDto.from(trainingCenter);
 	}
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/common/RedisKeyPrefix.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/common/RedisKeyPrefix.java
@@ -1,4 +1,4 @@
-package com.icandoit.boottalk.stomp_chat.common;
+package com.icandoit.boottalk.common;
 
 public class RedisKeyPrefix {
     // Prefix constants
@@ -7,6 +7,7 @@ public class RedisKeyPrefix {
     private static final String CHAT_MESSAGES_PREFIX = "chat:messages:";
     private static final String ROOM_INFO_PREFIX = "chat:room:info:";
     private static final String ENTERED_STATUS_PREFIX = "chat:entered:";
+    private static final String BOOTCAMP_KEY_PREFIX = "new:bootcamp:";
 
     // 채팅방에 속한 유저들 (Set)
     public static String roomUsers(String roomUuid) {
@@ -31,5 +32,14 @@ public class RedisKeyPrefix {
     // 사용자의 입장 상태 저장
     public static String enteredStatus(String roomUuid, Long userId) {
         return ENTERED_STATUS_PREFIX + roomUuid + ":" + userId;
+    }
+
+    // 신규 부트캠프 저장
+    public static String bootcamp(String categoryName) {
+        return BOOTCAMP_KEY_PREFIX + categoryName;
+    }
+
+    public static String bootcamp(){
+        return BOOTCAMP_KEY_PREFIX;
     }
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/review/service/ReviewService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/review/service/ReviewService.java
@@ -143,8 +143,7 @@ public class ReviewService {
 	}
 
 	private Bootcamp getBootcamp(Long id) {
-		return bootcampRepository.findById(id)
-			.orElseThrow(() -> new CustomException(BOOTCAMP_NOT_FOUND));
+		return bootcampRepository.getReferenceById(id);
 	}
 
 	// 비관적 락을 사용해 course 조회
@@ -159,5 +158,4 @@ public class ReviewService {
 		int newReviewCount = course.getReviewCount() + deltaCount;
 		course.updateReviewStats(newTotalScore, newReviewCount);
 	}
-
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/repository/RedisChatMessageRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/repository/RedisChatMessageRepository.java
@@ -1,6 +1,6 @@
 package com.icandoit.boottalk.stomp_chat.repository;
 
-import static com.icandoit.boottalk.stomp_chat.common.RedisKeyPrefix.chatMessages;
+import static com.icandoit.boottalk.common.RedisKeyPrefix.chatMessages;
 
 import com.icandoit.boottalk.stomp_chat.dto.ChatMessageResponseDto;
 import java.time.Duration;

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/repository/RedisChatRoomRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/repository/RedisChatRoomRepository.java
@@ -1,6 +1,6 @@
 package com.icandoit.boottalk.stomp_chat.repository;
 
-import static com.icandoit.boottalk.stomp_chat.common.RedisKeyPrefix.roomInfo;
+import static com.icandoit.boottalk.common.RedisKeyPrefix.roomInfo;
 
 import com.icandoit.boottalk.stomp_chat.dto.ChatRoomResponseDto;
 import java.time.Duration;

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/repository/RedisChatUserRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/repository/RedisChatUserRepository.java
@@ -1,6 +1,6 @@
 package com.icandoit.boottalk.stomp_chat.repository;
 
-import static com.icandoit.boottalk.stomp_chat.common.RedisKeyPrefix.enteredStatus;
+import static com.icandoit.boottalk.common.RedisKeyPrefix.enteredStatus;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/service/component/ChatRoomRedisManager.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/service/component/ChatRoomRedisManager.java
@@ -1,6 +1,6 @@
 package com.icandoit.boottalk.stomp_chat.service.component;
 
-import com.icandoit.boottalk.stomp_chat.common.RedisKeyPrefix;
+import com.icandoit.boottalk.common.RedisKeyPrefix;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/controller/ManageController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/controller/ManageController.java
@@ -6,11 +6,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.icandoit.boottalk.bootcamp.dto.CertificationCreationRequestDto;
+import com.icandoit.boottalk.bootcamp.dto.CertificationResponseDto;
 import com.icandoit.boottalk.bootcamp.dto.GetCertificationResponseDto;
 import com.icandoit.boottalk.bootcamp.service.BootcampCertificationService;
 import com.icandoit.boottalk.point_history.service.CreatePointHistoryService;
@@ -30,16 +33,15 @@ public class ManageController {
 
 	private final ManageService manageService;
 	private final CreatePointHistoryService createPointHistoryService;
-	private final BootcampCertificationService bootcampCertificationService;
+	private final BootcampCertificationService certificationService;
 
 	@GetMapping
 	public ResponseEntity<UserInfoDto> getUser(@AuthenticationPrincipal CustomOAuth2User user) {
 		Long userId = user.getServiceUserId();
 
+		int currentPoint = createPointHistoryService.getCurrentPointToNavi(userId);
 		UserDto userDto = manageService.getUser(userId);
-		List<GetCertificationResponseDto> myCertifications
-			= bootcampCertificationService.getMyCertifications(userId);
-		int currentPoint = createPointHistoryService.getCurrentPointToNavi(user.getServiceUserId());
+		List<GetCertificationResponseDto> myCertifications = certificationService.getMyCertifications(userId);
 
 		return ResponseEntity.ok(UserInfoDto.from(userDto, myCertifications, currentPoint));
 	}
@@ -65,5 +67,13 @@ public class ManageController {
 		return ResponseEntity.ok("회원 탈퇴되었습니다.");
 	}
 
-
+	// 부트캠프 수료증 등록
+	@PostMapping("/certification")
+	public ResponseEntity<CertificationResponseDto> createCertification(
+		@AuthenticationPrincipal CustomOAuth2User user,
+		@RequestBody CertificationCreationRequestDto request
+	) {
+		Long userId = user.getServiceUserId();
+		return ResponseEntity.ok(certificationService.createCertification(userId, request));
+	}
 }


### PR DESCRIPTION
## 🔍 주요 변경 사항
- BootcampCategoryType
    - isValidKoreanName에서 잘못된 이름 입력 시 곧바로 예외 발생하도록 변경
    - fromKoreanName 로직 단순화

- 인증/권한 로직 정리
    - 기존 사용자용 수료증 컨트롤러 제거, /api/admin/certification 경로의 관리용 컨트롤러로 통합
    - 불필요한 @AuthenticationPrincipal 및 @PreAuthorize 어노테이션 정리
   
- BootcampCertificationService
    - 중복 인증 검사 로직을 hasActiveCertification 메서드로 추출하여 가독성 향상
    
- JPA 조회 방식 통일
    - findById(...).orElseThrow → getReferenceById 사용으로 레퍼런스 조회 통일 및 퍼포먼스 최적화
    
- 리포지토리/서비스 정리
    - CourseRepository 불필요 메서드 제거 및 쿼리 메서드 네이밍 정리
    - ReviewService, TrainingCenterService 등에서 Optional 예외 처리 일관화
    - ManageController에서 사용자 정보·내비게이션·수료증 조회·회원 탈퇴 기능만 남기고 중복 로직 제거

---

## 💡 변경 이유
- 코드 중복·불필요 인증 로직 제거로 유지보수성 개선
- 관리(Admin)와 사용자(User) API 책임 분리로 역할 명확화
- JPA 레퍼런스 조회 방식 통일로 성능·안정성 강화
- 예외 처리 일관화로 오류 대응 편의성 증대

---

## 🚀 개선 결과
- 관리용·사용자용 API가 분리되어 직관적인 구조 확보
- enum 변환 로직 안정성 강화로 잘못된 입력 방지
- 서비스·컨트롤러 책임이 명확해져 향후 기능 확장 용이
- 코드베이스 경량화 및 가독성 대폭 향상

---

## 📂 관련 클래스 및 변경 파일
- `BootcampCategoryType`
- `BootcampCertificationController (Admin)`
- `BootcampCertificationService`
- `BootcampService`
- `CourseRepository`
- `ManageController`
- `ReviewService`
- `TrainingCenterService`
