### PR TITLE
Refactor/empoloy24 service

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/Employ24ApiService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/Employ24ApiService.java
@@ -48,6 +48,7 @@ public class Employ24ApiService {
 	private final CourseRepository courseRepository;
 
 	private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+	private final BootcampService bootcampService;
 
 	// 주어진 카테고리와 NCS 코드로 리스트 조회 후 저장 처리
 	public void processCategoryAndNcs(String categoryCode, String ncsCode) {
@@ -88,7 +89,7 @@ public class Employ24ApiService {
 		Course course = saveOrGetCourse(dto, center, category);
 		Bootcamp bootcamp = createBootcampEntity(center, course, dto, category, detail);
 
-		bootcampRepository.save(bootcamp);
+		bootcampService.save(bootcamp);
 
 		try {
 			redisService.storeNewBootcampInfo(String.valueOf(bootcamp.getBootcampId()), bootcamp.getBootcampCategoryType());

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/Employ24ApiService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/Employ24ApiService.java
@@ -52,19 +52,16 @@ public class Employ24ApiService {
 
 	private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
 
-	@Getter
-	private final Set<String> failedCategoryNames = new HashSet<>();
-
 	// 주어진 카테고리와 NCS 코드로 리스트 조회 후 저장 처리
 	public void processCategoryAndNcs(String categoryCode, String ncsCode) {
 		try {
 			log.info("API 호출 시작 - categoryCode: {}, ncsCode: {}", categoryCode, ncsCode);
 			List<BootcampListResponseDto> list = fetchBootcampList(categoryCode, ncsCode);
 			log.info("API 호출 완료 - 수신된 항목 수: {}", list.size());
+
 			processBootcampList(list);
 		} catch (Exception e) {
 			log.warn("데이터 수집 실패: categoryCode={}, ncsCode={}, message={}", categoryCode, ncsCode, e.getMessage());
-			e.printStackTrace();
 		}
 	}
 
@@ -84,40 +81,43 @@ public class Employ24ApiService {
 		BootcampDetailResponseDto detail = fetchBootcampDetail(dto.bootcampId(), dto.bootcampDegree(), dto.trainingCenterId());
 
 		String categoryName = detail.ncsName();
+
 		if (!BootcampCategoryType.isValidKoreanName(categoryName)) {
-			failedCategoryNames.add(categoryName);
 			return;
 		}
 
 		TrainingCenter center = saveOrGetTrainingCenter(dto, detail);
 		BootcampCategoryType category = BootcampCategoryType.fromKoreanName(categoryName);
-
 		Course course = saveOrGetCourse(dto, center, category);
-
 		Bootcamp bootcamp = createBootcampEntity(center, course, dto, category, detail);
 
 		bootcampRepository.save(bootcamp);
 
-		redisService.storeNewBootcampInfo(String.valueOf(bootcamp.getBootcampId()), bootcamp.getBootcampCategoryType());
+		try {
+			redisService.storeNewBootcampInfo(String.valueOf(bootcamp.getBootcampId()), bootcamp.getBootcampCategoryType());
+		} catch (Exception e) {
+			log.error("Redis 저장 실패: bootcampId={}, category={}, 원인={}", bootcamp.getBootcampId(), categoryName, e.getMessage());
+		}
+
 		log.info("저장 성공: {}", bootcamp.getBootcampName());
 	}
 
-	// TrainingCenter가 존재하지 않으면 저장, 있으면 조회해서 반환
+	// TrainingCenter 가 존재하지 않으면 저장, 있으면 조회해서 반환
 	private TrainingCenter saveOrGetTrainingCenter(BootcampListResponseDto dto, BootcampDetailResponseDto detail) {
 		String address1 = (detail.address1() != null) ? detail.address1() : "";
 		String address2 = (detail.address2() != null) ? detail.address2() : "";
 		String fullAddress = address1 + " " + address2;
 
+		TrainingCenter trainingCenter = TrainingCenter.of(
+			dto.trainingCenterName(),
+			detail.trainingCenterEmail(),
+			fullAddress,
+			detail.trainingCenterUrl(),
+			detail.trainingCenterTelephoneNumber()
+		);
+
 		return trainingCenterRepository.findByTrainingCenterName(dto.trainingCenterName())
-			.orElseGet(() -> trainingCenterRepository.save(
-				TrainingCenter.of(
-					dto.trainingCenterName(),
-					detail.trainingCenterEmail(),
-					fullAddress,
-					detail.trainingCenterUrl(),
-					detail.trainingCenterTelephoneNumber()
-				)
-			));
+			.orElseGet(() -> trainingCenterRepository.save(trainingCenter));
 	}
 
 	// Course 가 존재하지 않으면 저장, 있으면 조회해서 반환

--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/Employ24ApiService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/service/Employ24ApiService.java
@@ -6,9 +6,7 @@ import static com.icandoit.boottalk.libs.exception.ErrorCode.*;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
@@ -27,7 +25,6 @@ import com.icandoit.boottalk.bootcamp.repository.CourseRepository;
 import com.icandoit.boottalk.bootcamp.repository.TrainingCenterRepository;
 import com.icandoit.boottalk.libs.exception.CustomException;
 
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -123,9 +120,7 @@ public class Employ24ApiService {
 	// Course 가 존재하지 않으면 저장, 있으면 조회해서 반환
 	private Course saveOrGetCourse(BootcampListResponseDto dto, TrainingCenter center, BootcampCategoryType category) {
 		return courseRepository.findByTrainingProgramId(dto.bootcampId())
-			.orElseGet(() -> courseRepository.save(
-				Course.of(dto.bootcampId(), dto.bootcampName(), category, center)
-			));
+			.orElseGet(() -> courseRepository.save(Course.of(dto.bootcampId(), dto.bootcampName(), category, center)));
 	}
 
 	// Bootcamp Entity 생성


### PR DESCRIPTION
## 🔍 주요 변경 사항
- failedCategoryNames 필드 및 관련 로직 제거
- saveBootcamp() 내 카테고리 유효성 체크 시 유효하지 않으면 즉시 return하도록 단순화
- Redis 저장(redisService.storeNewBootcampInfo) 호출을 try–catch로 감싸, 예외 발생 시에도 전체 배치가 중단되지 않도록 예외 처리 추가
- 불필요한 스택트레이스 출력 제거하고, 로그 메시지만 남기도록 경고 레벨(log.warn)으로 변경

---

## 💡 변경 이유
- 카테고리 유효하지 않은 이름을 모아두던 기능(failedCategoryNames)이 실제 사용되지 않아 제거함으로써 코드 간결화
- Redis 장애 시 전체 배치 작업이 실패하는 문제를 방지하기 위해, Redis 저장 실패를 개별적으로 처리하도록 개선
- 로그를 간소화하여 운영환경에서 불필요한 스택트레이스 과다 출력 방지

---

## 🚀 개선 결과
- 카테고리 유효성 검사 로직이 간결해지고 불필요한 상태 관리가 사라짐
- Redis 연결 문제에도 배치 프로세스가 중단되지 않아, 다른 카테고리·NCS 코드 처리에 영향이 없음
- 운영 로그가 깔끔해지고, 장애 상황 시 핵심 원인만 빠르게 파악 가능

---

## 📂 관련 클래스 및 변경 파일
- `Employ24ApiService`

