### PR TITLE
Feat/chat 읽음 처리 기능 추가 

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/dto/ChatMessageResponseDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/dto/ChatMessageResponseDto.java
@@ -3,16 +3,22 @@ package com.icandoit.boottalk.stomp_chat.dto;
 import com.icandoit.boottalk.stomp_chat.entity.ChatMessage;
 import com.icandoit.boottalk.stomp_chat.entity.enums.MessageType;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-public record ChatMessageResponseDto(
-    String roomUuid,
-    Long senderId,
-    Long receiverId,
-    String message,
-    MessageType type,
-    LocalDateTime sentAt,
-    boolean isRead
-) {
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class ChatMessageResponseDto {
+
+    private String roomUuid;
+    private Long senderId;
+    private Long receiverId;
+    private String message;
+    private MessageType type;
+    private LocalDateTime sentAt;
+    private boolean isRead;
 
     public static ChatMessageResponseDto from(ChatMessage chatMessage) {
         return new ChatMessageResponseDto(
@@ -36,5 +42,9 @@ public record ChatMessageResponseDto(
             .type(type)
             .sentAt(sentAt)
             .build();
+    }
+
+    public void markAsRead() {
+        this.isRead = true;
     }
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/dto/ChatRoomResponseDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/dto/ChatRoomResponseDto.java
@@ -10,7 +10,8 @@ public record ChatRoomResponseDto(
     ChatUserDto mentee,
     LocalDateTime reservationAt,
     LocalDateTime endAt,
-    LocalDateTime expiresAt
+    LocalDateTime expiresAt,
+    boolean isActive
 ) {
 
     public static ChatRoomResponseDto from(ChatRoom chatRoom) {
@@ -21,7 +22,8 @@ public record ChatRoomResponseDto(
             ChatUserDto.from(chatRoom.getMentee()),
             chatRoom.getReservationAt(),
             chatRoom.getEndAt(),
-            chatRoom.getExpiresAt()
+            chatRoom.getExpiresAt(),
+            chatRoom.getRoomStatus().isActive()
         );
     }
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/repository/ChatRoomRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/repository/ChatRoomRepository.java
@@ -15,10 +15,10 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     @Query("""
     SELECT c
     FROM ChatRoom c
+    JOIN FETCH c.roomStatus
     JOIN c.coffeeChatApplication app
     JOIN app.coffeeChatInfo info
     WHERE app.mentee.userId = :userId OR info.mentor.userId = :userId
-    
 """)
     List<ChatRoom> findChatRoomsByUserId(@Param("userId") Long userId);
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/repository/RedisChatMessageRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/repository/RedisChatMessageRepository.java
@@ -6,6 +6,7 @@ import com.icandoit.boottalk.stomp_chat.dto.ChatMessageResponseDto;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
@@ -14,10 +15,10 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class RedisChatMessageRepository {
 
-    private final RedisTemplate<String, ChatMessageResponseDto> chatMessageDtoRedisTemplate;
+    private final RedisTemplate<String, ChatMessageResponseDto> redisTemplate;
 
     public List<ChatMessageResponseDto> getMessages(String roomUuid) {
-        List<ChatMessageResponseDto> cached = chatMessageDtoRedisTemplate
+        List<ChatMessageResponseDto> cached = redisTemplate
             .opsForList()
             .range(chatMessages(roomUuid), 0, -1);
 
@@ -27,26 +28,40 @@ public class RedisChatMessageRepository {
     // 단일 메시지 저장 + TTL 설정
     public void save(String roomUuid, ChatMessageResponseDto message, Duration ttl) {
         String key = chatMessages(roomUuid);
-        chatMessageDtoRedisTemplate.opsForList().rightPush(key, message);
-        chatMessageDtoRedisTemplate.expire(key, ttl);
+        String messageId = generateMessageId(message);
+        redisTemplate.opsForHash().put(key, messageId, message);
+        redisTemplate.expire(key, ttl);
     }
 
     public void saveAll(String roomUuid, List<ChatMessageResponseDto> messages, Duration ttl) {
         String key = chatMessages(roomUuid);
         for (ChatMessageResponseDto msg : messages) {
-            chatMessageDtoRedisTemplate.opsForList().rightPush(key, msg);
+            redisTemplate.opsForList().rightPush(key, msg);
         }
-        chatMessageDtoRedisTemplate.expire(key, ttl);
+        redisTemplate.expire(key, ttl);
+    }
+
+    public Map<Object, Object> findAllByRoomUuid(String redisKey) {
+        return redisTemplate.opsForHash().entries(redisKey);
+    }
+
+    private String generateMessageId(ChatMessageResponseDto message) {
+        return message.getSenderId() + "-" + message.getSentAt().toString();
+    }
+
+    public void updateMessage(String redisKey, String messageId, ChatMessageResponseDto message) {
+        redisTemplate.opsForHash().put(redisKey, messageId, message);
     }
 
     // 메시지 일부 삭제 (리스트 앞 부분 자르기)
     public void deleteMessages(String roomUuid, int count) {
-        chatMessageDtoRedisTemplate.opsForList().trim(chatMessages(roomUuid), count, -1);
+        redisTemplate.opsForList().trim(chatMessages(roomUuid), count, -1);
     }
+
 
     // 특정 채팅방의 메시지를 일부 배치로 가져오는 메서드
     public List<ChatMessageResponseDto> getMessagesForBatch(String roomUuid) {
-        List<ChatMessageResponseDto> cachedMessages = chatMessageDtoRedisTemplate
+        List<ChatMessageResponseDto> cachedMessages = redisTemplate
             .opsForList()
             .range(chatMessages(roomUuid), 0, 100);
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/service/ChatWebsocketService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/service/ChatWebsocketService.java
@@ -49,7 +49,7 @@ public class ChatWebsocketService {
 
     @Transactional
     public void handleUserEnter(Long userId, String roomUuid) {
-
+        LocalDateTime enterTime = LocalDateTime.now();
         // 메시지 조회 및 전송
         messageLoader.loadAndSendMessages(userId, roomUuid);
 
@@ -57,7 +57,7 @@ public class ChatWebsocketService {
         statusUpdater.updateChatRoomStatusOnEnter(userId, roomUuid);
 
         // 읽음 처리
-        markUnreadMessagesAsRead(roomUuid, userId);
+        markUnreadMessagesAsRead(roomUuid, userId, enterTime);
 
         CompletableFuture.runAsync(() -> messageSender.sendEnterMessage(userId, roomUuid), taskExecutor);
     }
@@ -101,7 +101,7 @@ public class ChatWebsocketService {
         template.convertAndSend(destination, response);
     }
 
-    public void markUnreadMessagesAsRead(String roomUuid, Long userId) {
+    public void markUnreadMessagesAsRead(String roomUuid, Long userId, LocalDateTime enterTime) {
         String redisKey = "chat:messages:" + roomUuid;
 
         Map<Object, Object> messagesMap = redisChatRepository.findAllByRoomUuid(redisKey);
@@ -109,7 +109,9 @@ public class ChatWebsocketService {
         for (Map.Entry<Object, Object> entry : messagesMap.entrySet()) {
             ChatMessageResponseDto message = (ChatMessageResponseDto) entry.getValue();
 
-            if (Objects.equals(message.getReceiverId(), userId) && !message.isRead()) {
+            if (Objects.equals(message.getReceiverId(), userId)
+                && !message.isRead()
+                && message.getSentAt().isBefore(enterTime)) {
                 message.markAsRead();
                 redisChatRepository.updateMessage(redisKey, entry.getKey().toString(), message);
             }

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/service/ChatWebsocketService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/service/ChatWebsocketService.java
@@ -18,6 +18,8 @@ import com.icandoit.boottalk.stomp_chat.service.component.ChatRoomStatusUpdater;
 import com.icandoit.boottalk.stomp_chat.service.component.MessageLoader;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -54,10 +56,13 @@ public class ChatWebsocketService {
         // 채팅방 상태 갱신
         statusUpdater.updateChatRoomStatusOnEnter(userId, roomUuid);
 
+        // 읽음 처리
+        markUnreadMessagesAsRead(roomUuid, userId);
+
         CompletableFuture.runAsync(() -> messageSender.sendEnterMessage(userId, roomUuid), taskExecutor);
     }
 
-    // Listener 호출(퇴장 시) 호출되는 매서드
+    // Listener 호출(퇴장 시 호출되는 매서드)
     @Transactional
     public void handleUserLeave(Long userId) {
         statusUpdater.updateChatRoomStatusOnLeave(userId);
@@ -96,6 +101,24 @@ public class ChatWebsocketService {
         template.convertAndSend(destination, response);
     }
 
+    public void markUnreadMessagesAsRead(String roomUuid, Long userId) {
+        String redisKey = "chat:messages:" + roomUuid;
+
+        Map<Object, Object> messagesMap = redisChatRepository.findAllByRoomUuid(redisKey);
+
+        for (Map.Entry<Object, Object> entry : messagesMap.entrySet()) {
+            ChatMessageResponseDto message = (ChatMessageResponseDto) entry.getValue();
+
+            if (Objects.equals(message.getReceiverId(), userId) && !message.isRead()) {
+                message.markAsRead();
+                redisChatRepository.updateMessage(redisKey, entry.getKey().toString(), message);
+            }
+        }
+
+        log.info("입장 시 읽음 처리 완료 for userId={}, roomUuid={}", userId, roomUuid);
+    }
+
+
 
     private void checkChatRoomWithinAllowedTime(String roomUuid) {
         // Redis에서 채팅방 정보 조회
@@ -123,7 +146,7 @@ public class ChatWebsocketService {
     public void saveMessageWithFallback(ChatMessageResponseDto message) {
         boolean isSavedToRedis = false;
         try {
-            redisChatRepository.save(message.roomUuid(), message, Duration.ofMinutes(30));
+            redisChatRepository.save(message.getRoomUuid(), message, Duration.ofMinutes(30));
             isSavedToRedis = true;
         } catch (RedisConnectionFailureException ex) {
             log.error("Redis 장애 발생: 메시지를 Redis에 저장하지 못했습니다. DB에 저장합니다.");

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/service/ChatWebsocketService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/service/ChatWebsocketService.java
@@ -42,7 +42,7 @@ public class ChatWebsocketService {
     private final MessageLoader messageLoader;
     private final SimpMessagingTemplate template;
 
-    private ThreadPoolTaskExecutor taskExecutor;
+    private final ThreadPoolTaskExecutor taskExecutor;
 
 
     @Transactional

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/service/component/ChatMessageSender.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/service/component/ChatMessageSender.java
@@ -47,7 +47,7 @@ public class ChatMessageSender {
 
     // WebSocket으로 전송하는 공통 로직
     public void sendMessage(Long receiverId, ChatMessageResponseDto chatMessageResponseDto) {
-        String roomUuid = chatMessageResponseDto.roomUuid();
+        String roomUuid = chatMessageResponseDto.getRoomUuid();
 
         String destination = "/queue/chat/" + roomUuid + "/" + receiverId;
         template.convertAndSend(destination, chatMessageResponseDto);


### PR DESCRIPTION
## 🔍 주요 변경 사항

ChatMessageResponseDto를 record에서 class로 변경

DTO에 markAsRead() 메서드 추가하여 읽음 상태 변경 가능하게 함

유저 입장 시 본인이 수신한 미읽음 메시지를 읽음 처리하는 로직 추가 (markUnreadMessagesAsRead)

---
💡 변경 이유
Redis 캐시 기반 읽음 처리를 도입함에 따라, DTO 내 isRead 필드 값을 동적으로 변경할 필요가 생김

record는 불변 객체이기 때문에, isRead 상태 변경 시마다 새로운 객체를 생성해야 하는 비효율적인 구조

이를 해결하기 위해 DTO를 클래스로 전환하고, 읽음 처리 메서드를 통해 필드 값을 직접 변경할 수 있도록 구조 변경

---
🚀 개선 결과
Redis 캐시에 저장된 메시지에 대해 불필요한 객체 생성 없이 읽음 상태 변경 가능




