### PR TITLE
refactor : NotificationType 의 url 수정

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/type/NotificationType.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/type/NotificationType.java
@@ -6,15 +6,15 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public enum NotificationType {
-	COFFEE_CHAT_REQUEST_RECEIVED( "/coffee-chats/applications/received", "커피챗 신청이 들어왔습니다."),    // 멘티로부터 커피챗 신청 도착 알림
-	COFFEE_CHAT_REQUEST_CANCELLED_FROM_MENTEE("/coffee-chats/applications/received","취소된 커피챗 신청이 있습니다."),    // 커피챗 신청 취소 알림
-	COFFEE_CHAT_REQUEST_APPROVED("/coffee-chats", "신청한 커피챗이 수락되었습니다."),    // 멘토로부터 커피챗 신청 수락 알림
-	COFFEE_CHAT_REQUEST_REJECTED("/coffee-chats", "신청한 커피챗이 거절되었습니다."),           // 커피챗 거절 알림
-	COFFEE_CHAT_REQUEST_CANCELLED_FROM_MENTOR("/coffee-chats/applications/received","신청한 커피챗이 취소되었습니다."),    // 커피챗 취소 알림
-	CHAT_SUSPENDED("/coffee-chats", "커피챗 활동이 정지되었습니다."),		//등록된 커피챗 정지 알림
-	COFFEE_CHAT_AUTO_REFUND("/coffee-chats/applications", "신청한 커피챗이 만료되어 자동 환불되었습니다."),	// 커피챗 자동 환불 알림
-	CERTIFICATE_VERIFIED("/users/my", "수료증 인증이 완료되었습니다."),       // 수료증 인증 완료 알림
-	CERTIFICATE_REJECTED("/users/my", "수료증 인증이 거절되었습니다."),// 수료증 인증 반려 알림
+	COFFEE_CHAT_REQUEST_RECEIVED( "/coffee-chat/my/received", "커피챗 신청이 들어왔습니다."),    // 멘티로부터 커피챗 신청 도착 알림
+	COFFEE_CHAT_REQUEST_CANCELLED_FROM_MENTEE("/coffee-chat/my/received","취소된 커피챗 신청이 있습니다."),    // 커피챗 신청 취소 알림
+	COFFEE_CHAT_REQUEST_APPROVED("/coffee-chat/my/sent", "신청한 커피챗이 수락되었습니다."),    // 멘토로부터 커피챗 신청 수락 알림
+	COFFEE_CHAT_REQUEST_REJECTED("/coffee-chat/my/sent", "신청한 커피챗이 거절되었습니다."),           // 커피챗 거절 알림
+	COFFEE_CHAT_REQUEST_CANCELLED_FROM_MENTOR("/coffee-chat/my/sent","신청한 커피챗이 취소되었습니다."),    // 커피챗 취소 알림
+	CHAT_SUSPENDED("", "커피챗 활동이 정지되었습니다."),		//등록된 커피챗 정지 알림
+	COFFEE_CHAT_AUTO_REFUND("/coffee-chat/my/sent", "신청한 커피챗이 만료되어 자동 환불되었습니다."),	// 커피챗 자동 환불 알림
+	CERTIFICATE_VERIFIED("/mypage?tab=profile", "수료증 인증이 완료되었습니다."),       // 수료증 인증 완료 알림
+	CERTIFICATE_REJECTED("/mypage?tab=certificates", "수료증 인증이 거절되었습니다."),// 수료증 인증 반려 알림
 	NEW_BOOT_CAMP("/bootcamps", "관심있는 직군의 새로운 부트캠프가 등록되었습니다.");// 새로운 부트캠프 등록
 
 	private final String urlFormat;


### PR DESCRIPTION
## 🔍 주요 변경 사항
- Notification Type의 url변경


---

## 💡 변경 이유
- Notification Type의 엔드포인트가 프론트 엔드의 엔드포인트와 일치 하지 않음


---

## 🚀 개선 결과
- 알림 확인시 해당하는 url로 이동이 가능


---

## 📂 관련 클래스 및 변경 파일
- `NotificationType.java`

