### PR TITLE
fix : typing 시 요구하는 request, response 수정

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/type/NotificationType.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/type/NotificationType.java
@@ -18,7 +18,7 @@ public enum NotificationType {
 	CERTIFICATE_REJECTED("/mypage?tab=certificates", "수료증 인증이 거절되었습니다."),// 수료증 인증 반려 알림
 	NEW_BOOT_CAMP("/bootcamps", "관심있는 직군의 새로운 부트캠프가 등록되었습니다."),// 새로운 부트캠프 등록
     COFFEE_CHAT_REMINDER_30_MINUTES_AHEAD("/chat-rooms", "곧 커피챗이 시작됩니다. 늦지 않게 준비하시기 바랍니다!"),
-	CHAT_MESSAGE_RECEIVED("/chat.message", "상대방이 메시지를 보냈어요. 커피챗을 이어가볼까요? ☕");
+	CHAT_MESSAGE_RECEIVED("/chat", "상대방이 메시지를 보냈어요. 커피챗을 이어가볼까요? ☕");
 
 	private final String urlFormat;
 	private final String message;

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/SecurityConfiguration.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/SecurityConfiguration.java
@@ -61,7 +61,7 @@ public class SecurityConfiguration {
 			.authorizeHttpRequests(auth -> auth
 				// 경로에 대한 접근 권한 설정
 				// TODO  : 추후에 접근 가능한 페이지 설정
-				.requestMatchers("/", "/swagger-ui/**", "/v3/api-docs/**", "/api/oauth2/authorization/**", "/login/**", "/api/bootcamps/**", "/api/reviews/**", "/api/test/**", "/connection").permitAll()
+				.requestMatchers("/", "/swagger-ui/**", "/v3/api-docs/**", "/api/oauth2/authorization/**", "/login/**", "/api/bootcamps/**", "/api/reviews/**", "/api/test/**", "/connection", "/api/sse-connect").permitAll()
 				.anyRequest().authenticated())
 			.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
 			//oauth2 로그인 설정

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/controller/ChatWebSocketController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/controller/ChatWebSocketController.java
@@ -50,10 +50,13 @@ public class ChatWebSocketController {
 
     // todo: 테스트 해보고 인증 Principal -> Authentication 변경 예정
     @MessageMapping("/chat.typing")
-    public void typing(@Payload ChatTypingRequestDto requestDto, Principal principal) {
-        Long senderId = Long.parseLong(principal.getName());
+    public void typing(@Payload ChatTypingRequestDto requestDto, Authentication authentication) {
+        if (authentication == null) {
+            log.error("인증 정보가 없습니다.");
+            throw new AccessDeniedException("인증되지 않은 사용자");
+        }
 
-        chatWebsocketService.sendTypingStatus(senderId, requestDto);
+        chatWebsocketService.sendTypingStatus(requestDto);
     }
 
     // 사용자 ID를 추출하는 공통 메서드

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/dto/stompDto/ChatTypingResponseDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/dto/stompDto/ChatTypingResponseDto.java
@@ -1,6 +1,6 @@
 package com.icandoit.boottalk.stomp_chat.dto.stompDto;
 
 public record ChatTypingResponseDto(
-    Long senderId,
+    Long receiverId,
     boolean typing
 ) {}

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/service/ChatWebsocketService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/service/ChatWebsocketService.java
@@ -113,9 +113,9 @@ public class ChatWebsocketService {
         messageSender.sendMessage(requestDto.receiverId(), messageToCache);
     }
 
-    public void sendTypingStatus(Long senderId, ChatTypingRequestDto requestDto) {
+    public void sendTypingStatus(ChatTypingRequestDto requestDto) {
 
-        ChatTypingResponseDto response = new ChatTypingResponseDto(senderId, requestDto.typing());
+        ChatTypingResponseDto response = new ChatTypingResponseDto(requestDto.receiverId(), requestDto.typing());
 
         String destination = "/queue/chat/" + requestDto.roomUuid() + "/" + requestDto.receiverId();
         template.convertAndSend(destination, response);


### PR DESCRIPTION
## 🔍 주요 변경 사항
- 채팅 시 채팅 작성중 안뜨는 부분 프론트엔드와 response, request 맞춤


---

## 💡 변경 이유
- 요구하는 내용과 일치하지 않아 필요한 데이터를 주고 받지 못함

---

## 🚀 개선 결과
- 실제 채팅이 오고 갈 시에 서로의 타이핑 상태를 확인이 가능


---

## 📂 관련 클래스 및 변경 파일
- `ChatWebSocketController.java`
- `ChatTypingResponseDto`
- `ChatWebsocketService`

