### PR TITLE
feat : Quartz 스케줄러를 활용한 채팅방 활성화 상태 자동 관리 구현

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/repository/RedisChatUserRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/repository/RedisChatUserRepository.java
@@ -16,12 +16,12 @@ public class RedisChatUserRepository {
 
 
     // 사용자 입장 여부 체크
-    public boolean hasUserEntered(String roomUuid, Long userId) {
+    public boolean isUserEnteredInCache(String roomUuid, Long userId) {
         return redisTemplate.opsForValue().get(enteredStatus(roomUuid, userId)) != null;
     }
 
     // 사용자의 입장 여부 저장
-    public void saveUserEnterStatus(String roomUuid, Long userId) {
+    public void cacheUserEntryInRoom(String roomUuid, Long userId) {
         redisTemplate.opsForValue().set(enteredStatus(roomUuid, userId), true);
     }
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/scheduler/ChatMessageSchedulerService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/scheduler/ChatMessageSchedulerService.java
@@ -1,4 +1,4 @@
-package com.icandoit.boottalk.stomp_chat.service;
+package com.icandoit.boottalk.stomp_chat.scheduler;
 
 import com.icandoit.boottalk.stomp_chat.dto.ChatMessageResponseDto;
 import com.icandoit.boottalk.stomp_chat.entity.ChatMessage;
@@ -30,17 +30,14 @@ public class ChatMessageSchedulerService {
         }
 
         for (String roomUuid : roomUuids) {
-            // DTO로 가져오기
             List<ChatMessageResponseDto> messagesToFlushDto = redisChatRepository.getMessagesForBatch(
                 roomUuid);
 
             if (!messagesToFlushDto.isEmpty()) {
-                // DTO → Entity 변환
                 List<ChatMessage> messagesToFlush = messagesToFlushDto.stream()
                     .map(ChatMessageResponseDto::toEntity)
                     .toList();
 
-                // DB 저장
                 chatMessageRepository.saveAll(messagesToFlush);
 
                 // Redis에서 앞부분 잘라내기 (DTO 기준으로)

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/scheduler/ChatQuartzSchedulerService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/scheduler/ChatQuartzSchedulerService.java
@@ -1,0 +1,45 @@
+package com.icandoit.boottalk.stomp_chat.scheduler;
+
+import com.icandoit.boottalk.libs.exception.CustomException;
+import com.icandoit.boottalk.libs.exception.ErrorCode;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.quartz.Job;
+import org.quartz.JobBuilder;
+import org.quartz.JobDetail;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatQuartzSchedulerService {
+
+    private final Scheduler scheduler;
+
+    public void scheduleStartAndEndJobs(String roomUuid, LocalDateTime startTime, LocalDateTime endTime) {
+        try {
+            scheduleJob(roomUuid, startTime, StartCoffeeChatJob.class, "start");
+            scheduleJob(roomUuid, endTime, EndCoffeeChatJob.class, "end");
+        } catch (SchedulerException e) {
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        }
+    }
+
+    private void scheduleJob(String roomUuid, LocalDateTime time, Class<? extends Job> jobClass, String type) throws SchedulerException {
+        JobDetail jobDetail = JobBuilder.newJob(jobClass)
+            .withIdentity(type + "_" + roomUuid)
+            .usingJobData("roomUuid", roomUuid)
+            .build();
+
+        Trigger trigger = TriggerBuilder.newTrigger()
+            .withIdentity(type + "_trigger_" + roomUuid)
+            .startAt(Timestamp.valueOf(time))
+            .build();
+
+        scheduler.scheduleJob(jobDetail, trigger);
+    }
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/scheduler/EndCoffeeChatJob.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/scheduler/EndCoffeeChatJob.java
@@ -1,0 +1,32 @@
+package com.icandoit.boottalk.stomp_chat.scheduler;
+
+import com.icandoit.boottalk.libs.exception.CustomException;
+import com.icandoit.boottalk.libs.exception.ErrorCode;
+import com.icandoit.boottalk.stomp_chat.entity.ChatRoom;
+import com.icandoit.boottalk.stomp_chat.repository.ChatRoomRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.scheduling.quartz.QuartzJobBean;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EndCoffeeChatJob extends QuartzJobBean {
+
+    private final ChatRoomRepository chatRoomRepository;
+
+    @Override
+    protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
+        String roomUuid = context.getMergedJobDataMap().getString("roomUuid");
+
+        ChatRoom room = chatRoomRepository.findByRoomUuid(roomUuid)
+            .orElseThrow(() -> new CustomException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        room.getRoomStatus().setActive(false);
+        chatRoomRepository.save(room);
+        log.info("채팅방 비활성화 완료: {}", roomUuid);
+    }
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/scheduler/StartCoffeeChatJob.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/scheduler/StartCoffeeChatJob.java
@@ -1,0 +1,32 @@
+package com.icandoit.boottalk.stomp_chat.scheduler;
+
+import com.icandoit.boottalk.libs.exception.CustomException;
+import com.icandoit.boottalk.libs.exception.ErrorCode;
+import com.icandoit.boottalk.stomp_chat.entity.ChatRoom;
+import com.icandoit.boottalk.stomp_chat.repository.ChatRoomRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.scheduling.quartz.QuartzJobBean;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StartCoffeeChatJob extends QuartzJobBean {
+
+    private final ChatRoomRepository chatRoomRepository;
+
+    @Override
+    protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
+        String roomUuid = context.getMergedJobDataMap().getString("roomUuid");
+
+        ChatRoom room = chatRoomRepository.findByRoomUuid(roomUuid)
+            .orElseThrow(() -> new CustomException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        room.getRoomStatus().setActive(true);
+        chatRoomRepository.save(room);
+        log.info("채팅방 활성화 완료: {}", roomUuid);
+    }
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/service/ChatRoomService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/service/ChatRoomService.java
@@ -13,6 +13,7 @@ import com.icandoit.boottalk.stomp_chat.entity.ChatRoomStatus;
 import com.icandoit.boottalk.stomp_chat.repository.ChatMessageRepository;
 import com.icandoit.boottalk.stomp_chat.repository.ChatRoomRepository;
 import com.icandoit.boottalk.stomp_chat.repository.ChatRoomStatusRepository;
+import com.icandoit.boottalk.stomp_chat.scheduler.ChatQuartzSchedulerService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,21 +28,18 @@ public class ChatRoomService {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatRoomStatusRepository chatRoomStatusRepository;
     private final ChatMessageRepository chatMessageRepository;
+    private final ChatQuartzSchedulerService chatQuartzSchedulerService;
 
     // 채팅방 생성
-    // todo: 멘토가 커피챗 신청 승인 시 호출로 변경 시 삭제 예정
     @Transactional
     public ChatRoomCreateResponse createChatRoom(CoffeeChatApplication application) {
 
-        // 이미 생성된 방이 있는지 확인
-        chatRoomRepository.findByCoffeeChatApplication(application)
-            .ifPresent(room -> {
-                log.warn("이미 채팅방이 존재합니다: {}", room.getRoomUuid());
-                throw new CustomException(ErrorCode.COFFEE_CHAT_ALREADY_EXISTS);
-            });
-
         ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.of(application));
-
+        chatQuartzSchedulerService.scheduleStartAndEndJobs(
+            chatRoom.getRoomUuid(),
+            application.getCoffeeChatStartTime(),
+            application.getCoffeeChatEndTime()
+        );
         return ChatRoomCreateResponse.from(chatRoom.getRoomUuid());
     }
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/service/ChatWebsocketService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/service/ChatWebsocketService.java
@@ -55,7 +55,7 @@ public class ChatWebsocketService {
         LocalDateTime enterTime = LocalDateTime.now();
 
         // 입장한 유저상태 저장
-        redisChatUserRepository.saveUserEnterStatus(roomUuid, userId);
+        redisChatUserRepository.cacheUserEntryInRoom(roomUuid, userId);
         // 메시지 조회 및 전송
         messageLoader.loadAndSendMessages(userId, roomUuid);
 
@@ -82,7 +82,7 @@ public class ChatWebsocketService {
 
         // 커피챗 예약 시간 내에만 채팅 가능하도록 체크
         checkChatRoomWithinAllowedTime(roomUuid);
-        boolean isReceiverInRoom = redisChatUserRepository.hasUserEntered(roomUuid,
+        boolean isReceiverInRoom = redisChatUserRepository.isUserEnteredInCache(roomUuid,
             requestDto.receiverId());
         log.info("senderId: {}, receiverId: {}", senderId, requestDto.receiverId());
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/service/component/ChatMessageSender.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/service/component/ChatMessageSender.java
@@ -26,7 +26,7 @@ public class ChatMessageSender {
     // 입장 메시지 전송
     public void sendEnterMessage(Long userId, String roomUuid) {
         // Redis에서 사용자가 입장했는지 확인
-        if (!redisChatUserRepository.hasUserEntered(roomUuid, userId)) {
+        if (!redisChatUserRepository.isUserEnteredInCache(roomUuid, userId)) {
             return;
         }
         ChatRoom chatRoom = chatRoomRepository.findByRoomUuid(roomUuid)
@@ -37,8 +37,10 @@ public class ChatMessageSender {
             ? chatRoom.getMentee().getUserId()
             : chatRoom.getMentor().getUserId();
 
+        String senderName = chatRoom.getMentor().getUserName();
+        String systemContent = senderName + "님이 입장하였습니다.";
         ChatMessageResponseDto enterMessage = new ChatMessageResponseDto(
-            roomUuid, 0L, receiverId, "님이 입장하였습니다.", MessageType.SYSTEM, LocalDateTime.now(), false
+            roomUuid, 0L, receiverId, systemContent, MessageType.SYSTEM, LocalDateTime.now(), false
         );
 
         // 공통화된 메시지 전송 메서드 사용


### PR DESCRIPTION
🔍 주요 변경 사항:
Quartz 사용: 예약된 시간에 맞춰 채팅방의 isActive 상태를 자동으로 변경하는 로직을 추가했습니다.

시작 시간에 isActive=true, 종료 시간에 isActive=false로 상태를 변경합니다.

Quartz 스케줄러를 사용하여 주기적으로 채팅방의 상태를 관리합니다.

💡 변경 이유:
채팅방의 상태를 예약된 시간에 맞춰 자동으로 변경.

🚀 개선 결과:
 시작 시간과 종료 시간에 따라 채팅방의 상태가 자동으로 변경됩니다.

Quartz 스케줄러를 통해 주기적인 상태 변경


✅ 테스트 시나리오 (예정):
채팅방 생성 후 시작 시간 도달:

채팅방 생성 후, 예약된 시작 시간이 되면 isActive=true로 상태가 변경되는지 확인.

채팅방 종료 후 종료 시간 도달:

종료 시간이 되면 isActive=false로 상태가 변경되는지 확인.