### PR TITLE
fix : 유저가 채팅에서 나갔을 시에 userId 가 반환되지 않던 오류 수정

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/service/component/WebSocketEventListener.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/service/component/WebSocketEventListener.java
@@ -1,13 +1,18 @@
 package com.icandoit.boottalk.stomp_chat.service.component;
 
-import com.icandoit.boottalk.stomp_chat.service.ChatWebsocketService;
 import java.util.Map;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import com.icandoit.boottalk.social_login.dto.CustomOAuth2User;
+import com.icandoit.boottalk.stomp_chat.service.ChatWebsocketService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Component
 @RequiredArgsConstructor
@@ -25,32 +30,14 @@ public class WebSocketEventListener {
 
         Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
 
-        if (sessionAttributes == null || sessionAttributes.get("userId") == null) {
-            log.warn("세션에 userId가 없음 - 연결 해제 무시");
+        if (sessionAttributes == null || sessionAttributes.get("auth") == null) {
+            log.warn("세션에 auth 없음 - 연결 해제 무시");
             return;
         }
 
-        // 세션에서 가져온 userId의 타입 확인 및 변환
-        Object userIdObj = sessionAttributes.get("userId");
-        Long userId;
-
-        if (userIdObj instanceof Long) {
-            // 이미 Long 타입인 경우
-            userId = (Long) userIdObj;
-            log.info("if문 테스트 : userId 는 Long 타입입니다. ");
-        } else if (userIdObj instanceof String) {
-            // todo: 테스트 후 제거 예정
-            try {
-                userId = Long.parseLong((String) userIdObj);
-            } catch (NumberFormatException e) {
-                log.error("userId를 Long으로 변환할 수 없습니다: {}", userIdObj);
-                return;
-            }
-        } else {
-            // 다른 타입인 경우
-            log.error("지원되지 않는 userId 타입: {}", userIdObj.getClass().getName());
-            return;
-        }
+        UsernamePasswordAuthenticationToken auth = (UsernamePasswordAuthenticationToken)sessionAttributes.get("auth");
+        CustomOAuth2User user = (CustomOAuth2User)auth.getPrincipal();
+        Long userId = user.getServiceUserId();
 
         log.info("사용자 연결 종료: {}", userId);
         chatWebsocketService.handleUserLeave(userId);


### PR DESCRIPTION
## 🔍 주요 변경 사항
- WebSocketEventListener 클래스 수정
- 유저가 WebSocket 연결 해제(SessionDisconnectEvent) 시
    - 기존: sessionAttributes에서 직접 "userId" 키를 조회하여 Long/String 타입 변환 처리
    - 변경: sessionAttributes에서 "auth"(UsernamePasswordAuthenticationToken)을 꺼내어 CustomOAuth2User를 통해 userId를 안전하게 조회
- 세션에 저장된 인증 객체(auth)를 활용하여 정확하고 일관성 있는 방식으로 userId 추출


---

## 💡 변경 이유
- 기존 방식은 userId를 세션에 별도로 저장한다고 가정했기 때문에, 실제로 WebSocket 핸드셋 핸들러 설정이나 세션 저장 방식이 다를 경우
    - 세션에 userId가 없거나 타입이 달라 NPE 또는 ClassCastException이 발생할 위험이 있었음.
- 현재 시스템은 WebSocket 연결 시 인증(Authentication) 객체를 세션에 "auth" 키로 저장하고 있으므로, UsernamePasswordAuthenticationToken → CustomOAuth2User → userId를 추출하는 것이 인증된 사용자의 정보를 안전하고 확실하게 가져오는 정석적인 방법이었음.
- 따라서, 직접 userId를 세션에 저장하고 가져오는 복잡한 변환과 타입 체크를 제거하고, 표준 Spring Security 인증 흐름에 맞춘 방식으로 개선함.

---

## 🚀 개선 결과
- WebSocket 연결 해제 시 userId를 안정적으로 조회 가능
- 코드 간결성 증가 (타입체크 분기 if-else 제거)
- 모든 WebSocket 세션 처리 시 일관된 사용자 인증 정보 사용
- 유지보수성 향상 (나중에 인증방식 변경해도 auth만 처리하면 됨)

---

## 📂 관련 클래스 및 변경 파일
- `com.icandoit.boottalk.stomp_chat.service.component.WebSocketEventListener`

