### PR TITLE
Refactor/notification base url remove

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/dto/NotificationResponseDto.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/dto/NotificationResponseDto.java
@@ -17,7 +17,7 @@ public record NotificationResponseDto(
 	LocalDateTime createdAt
 ) {
 
-	public static NotificationResponseDto from(Notification notification, String baseUrl) {
+	public static NotificationResponseDto from(Notification notification) {
 		String url = notification.getType().getUrlFormat();
 
 		if (notification.getTargetId() != null) {
@@ -28,7 +28,7 @@ public record NotificationResponseDto(
 			notification.getNotificationId(),
 			notification.getType(),
 			notification.getType().getMessage(),
-			baseUrl + url,
+			url,
 			notification.isChecked(),
 			notification.getCreatedAt()
 		);

--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/service/NotificationService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/service/NotificationService.java
@@ -21,14 +21,11 @@ public class NotificationService {
 
 	private final NotificationRepository notificationRepository;
 
-	@Value("${server.url}")
-	private String BASE_URL;
-
 	// 알림조회창에 들어갈 알림내역과 확인하지 않은 알림 개수 반환
 	public AllNotificationResponseDto getNotifications(long userId) {
 		return AllNotificationResponseDto.from(notificationRepository.findAllNotificationByUserId(userId)
-			.stream().map((Notification notification) ->
-				NotificationResponseDto.from(notification, BASE_URL)).collect(Collectors.toList()));
+			.stream().map(NotificationResponseDto::from)
+			.toList());
 	}
 
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/service/SseEmitterService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/service/SseEmitterService.java
@@ -7,7 +7,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -40,9 +39,6 @@ public class SseEmitterService {
 	//SSE eventId를 LocalDateTime 으로 설정하기 위한 포맷
 	private final DateTimeFormatterUtil dateTimeFormatter;
 
-	@Value("${server.url}")
-	private String BASE_URL;
-
 	private final SseEmitterRepository emitterRepository;
 	private final NotificationRepository notificationRepository;
 	private final CreatePointHistoryService createPointHistoryService;
@@ -70,7 +66,7 @@ public class SseEmitterService {
 							SseEmitter.event()
 								.id(dateTimeFormatter.formatTime(notification.getCreatedAt()))
 								.name("notification")
-								.data(NotificationResponseDto.from(notification, BASE_URL))
+								.data(NotificationResponseDto.from(notification))
 						);
 					} catch (IOException e) {
 						log.error("SSE 알림 전송 실패: 대상자 Id: {}, 원인: {}", userId, e.getMessage());
@@ -105,7 +101,7 @@ public class SseEmitterService {
 	public void sendToClient(Long userId, NotificationRequestDto requestDto) {
 		// 먼저 알림을 보내기 전 알림 저장
 		NotificationResponseDto responseDto = NotificationResponseDto
-			.from(notificationRepository.save(Notification.of(userId, requestDto)), BASE_URL);
+			.from(notificationRepository.save(Notification.of(userId, requestDto)));
 
 		SseEmitter sseEmitter = findById(userId);
 		if (sseEmitter == null) {

--- a/boottalk/src/main/resources/application.yml
+++ b/boottalk/src/main/resources/application.yml
@@ -37,6 +37,3 @@ spring:
       host: 43.200.67.27
       port: 6379
 
-server:
-  url: "http://localhost:3000"
-


### PR DESCRIPTION
## 🔍 주요 변경 사항
- NotificationResponseDto.from() 메서드의 파라미터에서 baseUrl 제거
- 서버의 BASE_URL 값을 @Value로 주입받아 알림 URL을 조합하던 기존 방식을 삭제
- 알림 URL을 상대 경로로만 설정하여 반환하도록 수정
- NotificationService, SseEmitterService 등에서
NotificationResponseDto.from(notification, BASE_URL) → NotificationResponseDto.from(notification) 단일 호출로 변경


---

## 💡 변경 이유
- 프론트엔드 요청으로 인해 서버가 절대경로(예: http://localhost:3000/bootcamps)를 반환하는 대신 상대 경로(예: /bootcamps) 만 내려주기로 방침 변경
- 서버가 BASE_URL 을 직접 관리하고 삽입할 필요가 없어짐 → 책임 분리(Separation of Concerns) 향상
- URL의 호스트 주소(도메인/포트)는 프론트엔드가 환경에 맞게 동적으로 조립하게 하여 서버/프론트 간 유연성과 배포 이식성 확보
- 서버 코드도 단순화됨: BASE_URL 주입, 조합 코드 모두 제거 가능
- NotificationResponseDto가 서버 URL에 종속되지 않아 테스트 편의성과 확장성이 증가함


---

## 🚀 개선 결과
- 서버는 고정된 절대 주소를 포함하지 않고, 경로만 내려주므로 프론트엔드가 운영/개발 환경에 따라 자유롭게 도메인 설정 가능
- NotificationResponseDto 생성 과정이 간단해지고, 중복 의존성(BASE_URL)이 사라짐
- SseEmitterService, NotificationService 같은 비즈니스 로직 코드가 더 가볍고 명확해짐
- 나중에 도메인 변경, 포트 변경이 일어나도 서버 코드 수정 없이 프론트엔드만 수정하면 됨 → 유지보수성 향상

---

## 📂 관련 클래스 및 변경 파일
- NotificationResponseDto
- NotificationService
- SseEmitterService



