### PR TITLE
fix:최근 알림 읽음 처리를 위한 jpa 쿼리 수정

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/repository/NotificationRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/repository/NotificationRepository.java
@@ -23,6 +23,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 	@Modifying
 	@Transactional
 	@Query("UPDATE Notification n SET n.checked = true " +
-		"WHERE n.userId = :userId AND n.checked = false AND n.createdAt < :time")
+		"WHERE n.userId = :userId AND n.checked = false AND n.createdAt <= :time")
 	int checkedAllNotification(@Param("userId") long userId, @Param("time") LocalDateTime time);
 }


### PR DESCRIPTION
## 🔍 주요 변경 사항

- 알림 읽음 처리를 하는 checkedAllNotification jpa 메서드 수정

---

## 💡 변경 이유

- 알림창을 닫을 때 알림 확인 처리하는 요청을 보내 가장 최근 알림이 온 시간을 기준으로 모두 확인처리 되게 했었음.
- 기존 쿼리문이 `@Query("UPDATE Notification n SET n.checked = true " +"WHERE n.userId = :userId AND n.checked = false AND n.createdAt < :time")` 이었는데 `n.createdAt < :time`  때문에 최근알림은 확인처리가 되지 않았었음.
- 따라서 계속 새로운 알림으로 인식됨.
---

## 🚀 개선 결과

- 알림창 닫을 때 최근 알림까지 확인처리 됨.

---

## 📂 관련 클래스 및 변경 파일

- `NotificationRepository`

---

## ✅ 테스트 시나리오(예정) 

- 새로운 알림이 도착
- 알림창에서 새로운 알림 확인 후 알림창 닫음
- 다시 열었을 때 해당 알림 확인처리됨.

---

## 💡 참고 블로그



--- 

## 🖼️ 스크린샷



