### PR TITLE
fix : 대량 알림 전송 시 서버 부하를 줄이기 위해 이벤트 발송을 비동기 처리 구조로 전환

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/batch/scheduler/NotificationQuartzJob.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/batch/scheduler/NotificationQuartzJob.java
@@ -5,15 +5,16 @@ import java.util.Set;
 
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.quartz.QuartzJobBean;
 import org.springframework.stereotype.Component;
 
 import com.icandoit.boottalk.bootcamp.entity.enums.BootcampCategoryType;
 import com.icandoit.boottalk.bootcamp.service.RedisService;
-import com.icandoit.boottalk.notification.dto.NotificationRequestDto;
-import com.icandoit.boottalk.notification.service.SseEmitterService;
-import com.icandoit.boottalk.notification.type.NotificationType;
 import com.icandoit.boottalk.common.RedisKeyPrefix;
+import com.icandoit.boottalk.notification.dto.NotificationRequestDto;
+import com.icandoit.boottalk.notification.event.NotificationEvent;
+import com.icandoit.boottalk.notification.type.NotificationType;
 import com.icandoit.boottalk.user.domain.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -24,63 +25,74 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class NotificationQuartzJob extends QuartzJobBean {
 
-	private final SseEmitterService sseEmitterService;
 	private final RedisService redisService;
 	private final UserRepository userRepository;
+	private final ApplicationEventPublisher eventPublisher;
 
 	@Override
 	protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
+		log.info("Notification Quartz Job 시작: 알림 전송 작업 실행...");
 		try {
-			log.info("Notification Quartz Job 시작: 알림 전송 작업 실행...");
-
 			// redis 키값 받아오고
 			Set<String> keys = redisService.getKeys(RedisKeyPrefix.bootcamp() + "*");
 			// key 값이 존재한다면
-			if(keys != null && !keys.isEmpty()) {
-				for(String redisKey : keys) {
-					// key 값에서 데이터 parsing
-					String categoryString = redisKey.substring(RedisKeyPrefix.bootcamp().length());
-					BootcampCategoryType category;
 
-					// parsing 된 데이터 존재 값 확인
-					try {
-						category = BootcampCategoryType.valueOf(categoryString);
-					} catch (IllegalArgumentException e) {
-						log.warn("알 수 없는 부트캠프 카테고리: {}", categoryString);
-						continue;
-					}
+			if (keys == null || keys.isEmpty()) {
+				log.info("Redis에 부트캠프 알림 데이터 없음.");
+				return;
+			}
 
-					// key 값에 해당하는 value 값 조회
-					List<String> bootcampIds = redisService.getList(redisKey);
-					log.info("Redis key [{}] 의 부트캠프 ID: {}", redisKey, bootcampIds);
-
-					// 해당 직군과 일치하는 userId 리스트 조회
-					List<Long> targetUserIds = userRepository.findByIdsByDesiredCareer(category);
-
-					// 해당 직군 관련 데이터들 notification Service 로 전달
-					for(Long userId : targetUserIds) {
-						for(String bootcampId : bootcampIds) {
-
-							NotificationRequestDto requestDto = new NotificationRequestDto(
-								NotificationType.NEW_BOOT_CAMP,
-								Long.valueOf(bootcampId)
-							);
-
-							sseEmitterService.sendToClient(userId, requestDto);
-						}
-					}
-
-					// 전송 완료된 key 값 삭제
-					redisService.deleteKey(redisKey);
-				}
-			} else {
-				log.info("Redis 에 부트캠프 알림 데이터가 없습니다.");
+			for (String key : keys) {
+				handleBootcampKey(key);
 			}
 
 			log.info("Notification Quartz Job 완료: 알림 전송 작업 종료");
 		} catch (Exception e) {
-			log.error("Notification Quartz Job 실행 실패", e);
+			log.error("Notification Quartz Job 전체 진행 실패", e);
 			throw new JobExecutionException(e);
 		}
+	}
+
+	private void handleBootcampKey(String key) {
+		String categoryString = key.substring(RedisKeyPrefix.bootcamp().length());
+
+		BootcampCategoryType category;
+		try {
+			category = BootcampCategoryType.valueOf(categoryString);
+		} catch (IllegalArgumentException e) {
+			log.warn("알 수 없는 부트캠프 카테고리: {}", categoryString);
+			return;
+		}
+
+		List<String> bootcampIds = redisService.getList(key);
+		if (bootcampIds.isEmpty()) {
+			log.info("Redis key [{}]에 부트캠프 ID 없음", key);
+			return;
+		}
+
+		List<Long> targetUserIds = userRepository.findByIdsByDesiredCareer(category);
+
+		for (Long userId : targetUserIds) {
+			for (String bootcampId : bootcampIds) {
+				try {
+					publishNotificationEvent(userId, bootcampId);
+				} catch (Exception e) {
+					log.error("알림 발송 실패 - userId: {}, bootcampId: {}, error: {}", userId, bootcampId, e.getMessage());
+				}
+			}
+		}
+
+		redisService.deleteKey(key);
+		log.info("처리 완료된 Redis key 삭제: {}", key);
+	}
+
+	private void publishNotificationEvent(Long userId, String bootcampId) {
+		NotificationRequestDto requestDto = new NotificationRequestDto(
+			NotificationType.NEW_BOOT_CAMP,
+			Long.valueOf(bootcampId)
+		);
+
+		eventPublisher.publishEvent(new NotificationEvent(userId, requestDto));
+		log.info("알림 발송 완료 - userId: {}, bootcampId: {}", userId, bootcampId);
 	}
 }

--- a/boottalk/src/test/java/com/icandoit/boottalk/batch/scheduler/FetchBootcampQuartzJobTest.java
+++ b/boottalk/src/test/java/com/icandoit/boottalk/batch/scheduler/FetchBootcampQuartzJobTest.java
@@ -12,16 +12,16 @@ import org.junit.jupiter.api.Test;
 import org.quartz.JobDataMap;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
+import org.springframework.context.ApplicationEventPublisher;
 
 import com.icandoit.boottalk.bootcamp.entity.enums.BootcampCategoryType;
 import com.icandoit.boottalk.bootcamp.service.RedisService;
-import com.icandoit.boottalk.notification.dto.NotificationRequestDto;
-import com.icandoit.boottalk.notification.service.SseEmitterService;
+import com.icandoit.boottalk.notification.event.NotificationEvent;
 import com.icandoit.boottalk.user.domain.repository.UserRepository;
 
 class FetchBootcampQuartzJobTest {
 	private NotificationQuartzJob notificationQuartzJob;
-	private SseEmitterService sseEmitterService;
+	private ApplicationEventPublisher eventPublisher;
 	private RedisService redisService;
 	private UserRepository userRepository;
 	private JobExecutionContext context;
@@ -30,10 +30,10 @@ class FetchBootcampQuartzJobTest {
 
 	@BeforeEach
 	void setUp() {
-		sseEmitterService = mock(SseEmitterService.class);
+		eventPublisher = mock(ApplicationEventPublisher.class);
 		redisService = mock(RedisService.class);
 		userRepository = mock(UserRepository.class);
-		notificationQuartzJob = new NotificationQuartzJob(sseEmitterService, redisService, userRepository);
+		notificationQuartzJob = new NotificationQuartzJob(redisService, userRepository, eventPublisher);
 
 		// JobExecutionContext 도 목 객체로 설정
 		context = mock(JobExecutionContext.class);
@@ -63,7 +63,7 @@ class FetchBootcampQuartzJobTest {
 		notificationQuartzJob.executeInternal(context);
 
 		// 각 사용자와 각 부트캠프 ID 조합에 대해 알림 전송이 2 * 2 = 4번 호출되어야 함
-		verify(sseEmitterService, times(4)).sendToClient(anyLong(), any(NotificationRequestDto.class));
+		verify(eventPublisher, times(4)).publishEvent(any(NotificationEvent.class));
 		// 전송 완료 후, 해당 Redis 키 삭제 호출 확인
 		verify(redisService, times(1)).deleteKey(redisKey);
 	}


### PR DESCRIPTION
## 🔍 주요 변경 사항
- NotificationQuartzJob이 직접 SseEmitterService.sendToClient()를 호출하던 구조를 변경하여 ApplicationEventPublisher를 통해 NotificationEvent를 발행하는 방식으로 수정
- 알림 발송 시마다 try-catch 블록을 걸어, 개별 사용자/부트캠프 조합 단위로 실패해도 전체 작업이 중단되지 않도록 방어
- handleBootcampKey() 메서드 분리로 핵심 흐름과 개별 키 처리 로직을 명확히 구분하여 가독성과 유지보수성 개선


---

## 💡 변경 이유
- 대량 알림 전송 시 서버 부하를 줄이기 위해, 직접 전송이 아닌 이벤트 발행 → 비동기 처리 구조로 전환
- 다중 for문 안에서 한 번이라도 예외가 발생할 경우 전체 배치가 중단될 위험을 방지
- 향후 알림 처리 방식(예: SQS 큐 처리 등)으로 유연하게 확장할 수 있도록 느슨한 결합 구조로 변경
- Quartz Job 자체는 "이벤트 발행"만 담당하고, 실제 알림 전송 로직은 별도 서비스(SseEmitterService)에서 관리하도록 역할을 명확히 분리


---

## 🚀 개선 결과
- 대규모 대상 알림 발송에도 서버 과부하 없이 안정적인 배치 실행 가능
- 개별 발송 실패가 전체 Job 실패로 이어지지 않음 → 알림 전송 누락 최소화
- 코드 가독성과 분리도가 개선되어 추후 기능 추가/변경 시 수정 범위 최소화
- 단위 테스트(verify eventPublisher.publishEvent) 작성이 가능해져 품질 보증 강화


---

## 📂 관련 클래스 및 변경 파일
- NotificationQuartzJob
- NotificationEvent

---

