### PR TITLE
fix: 커피챗 신청 조회 시 REJECTED 상태도 제외하도록 조건 추가

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/repository/CoffeeChatApplicationRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/repository/CoffeeChatApplicationRepository.java
@@ -73,7 +73,7 @@ public interface CoffeeChatApplicationRepository extends JpaRepository<CoffeeCha
 		WHERE ca.coffeeChatInfo.coffeeChatInfoId = :coffeeChatInfoId
 		AND ca.coffeeChatStartTime BETWEEN
 		:startTime AND :endTime
-		AND ca.status != "CANCELED"
+		AND ca.status NOT IN ('CANCELED', 'REJECTED')
 	""")
 	List<LocalDateTime> findStartTimesByCoffeeChatInfoIdAndPeriod(
 		@Param("coffeeChatInfoId") Long coffeeChatInfoId,


### PR DESCRIPTION
## 🔍 주요 변경 사항
- 커피챗 신청 조회 시 REJECTED 상태도 제외하도록 조건 추가

---

## 💡 변경 이유
- 커피챗 신청을 멘토가 거절하면 해당 시간대를 다시 조회할 수 있어야 하므로 쿼리 조건문 수정

