### PR TITLE
Refactor/프록시 서버 관리를 위한 BASE_URL 환경변수 추가

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/SecurityConfiguration.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/SecurityConfiguration.java
@@ -3,6 +3,7 @@ package com.icandoit.boottalk.social_login.config;
 import java.util.Arrays;
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -36,6 +37,9 @@ public class SecurityConfiguration {
 	private final CustomUserService customUserService;
 	private final JwtFilter jwtFilter;
 
+	@Value("${server.url}")
+	private String BASE_URL;
+
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -68,6 +72,8 @@ public class SecurityConfiguration {
 			.oauth2Login(oauth2 -> {
 				log.info("OAuth2 로그인 설정");
 				oauth2
+					.redirectionEndpoint(endPoint -> endPoint
+						.baseUri("/api/login/oauth2/code/*"))
 					.authorizationEndpoint(endpoint -> endpoint. // 프론트엔드쪽에서 로그인 버튼을 눌렀을 때
 						baseUri("/api/oauth2/authorization")) // 해당 엔드포인트로 요청을 보내면 네이버 로그인 페이지로 리디렉션
 					.userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig
@@ -77,7 +83,7 @@ public class SecurityConfiguration {
 			}) // 부트톡 서버와 네이버 서버간 인증코드와 엑세스 토큰을 주고 받기 위한 설정이 저장된 클래스
 			.logout(logout -> logout.logoutUrl("/logout")
 				.logoutSuccessHandler((request, response, auth) -> {
-					response.sendRedirect("http://localhost:3000/"); // 로그아웃 성공 시 메인페이지로 이동
+					response.sendRedirect(BASE_URL); // 로그아웃 성공 시 메인페이지로 이동
 				})
 				.clearAuthentication(true));
 
@@ -87,7 +93,7 @@ public class SecurityConfiguration {
 	@Bean
 	public CorsConfigurationSource corsConfigurationSource() {
 		CorsConfiguration configuration = new CorsConfiguration();
-		configuration.setAllowedOrigins(List.of("http://localhost:3000", "http://127.0.0.1:3000"));
+		configuration.setAllowedOrigins(List.of("http://localhost:3000", "http://127.0.0.1:3000", BASE_URL));
 		configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
 		configuration.setAllowCredentials(true);
 		configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "X-Requested-With", "Accept"));

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/oauth2/CustomSuccessHandler.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/oauth2/CustomSuccessHandler.java
@@ -54,8 +54,6 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 		createCookie(response ,"Authorization"
 			, token);
 
-		Long userId = userDetails.getServiceUserId();
-
 		// 신규회원인 경우,추가정보 입력 url로 리다이렉션
 		if (UserRole.valueOf(role).equals(UserRole.NEW_USER)) {
 			response.sendRedirect(BASE_URL + "/social-register");

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/oauth2/CustomSuccessHandler.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/oauth2/CustomSuccessHandler.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
@@ -27,6 +28,9 @@ import lombok.extern.slf4j.Slf4j;
 public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
 	private final JwtProvider jwtProvider;
+
+	@Value("${server.url}")
+	private String BASE_URL;
 
 	@Override
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -54,24 +58,13 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
 		// 신규회원인 경우,추가정보 입력 url로 리다이렉션
 		if (UserRole.valueOf(role).equals(UserRole.NEW_USER)) {
-			response.sendRedirect("http://localhost:3000/social-register?token=" + token + "&userId=" + userId);
+			response.sendRedirect(BASE_URL + "/social-register");
 		} else {
 			// 기존 회원의 경우, 메인페이지로 리다이렉션
-			response.sendRedirect("http://localhost:3000?token=" + token + "&userId=" + userId);
+			response.sendRedirect(BASE_URL);
 		}
 	}
 
-	// 쿠키 생성
-	// private Cookie createCookie(String key, String value) {
-	//
-	// 	Cookie cookie = new Cookie(key, value);
-	// 	cookie.setMaxAge(60*60*60);
-	// 	//cookie.setSecure(true);
-	// 	cookie.setPath("/");
-	// 	cookie.setHttpOnly(true);
-	//
-	// 	return cookie;
-	// }
 	private void createCookie(HttpServletResponse response, String key, String value) {
 
 		ResponseCookie responseCookie = ResponseCookie.from(key, value)
@@ -81,12 +74,6 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 			.secure(false)
 			.sameSite("Lax")
 			.build();
-
-		// Cookie cookie = new Cookie(key, value);
-		// cookie.setMaxAge(60*60*60);
-		// // cookie.setSecure(true); 실제 서비스 배포시에 활성화 (https 에서만 해당 쿠키가 전달되게 함)
-		// cookie.setPath("/");
-		// cookie.setHttpOnly(true);
 
 		response.addHeader(HttpHeaders.SET_COOKIE, responseCookie.toString());
 	}

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/oauth2/SocialClientRegistration.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/oauth2/SocialClientRegistration.java
@@ -19,6 +19,9 @@ public class SocialClientRegistration {
 	@Value("${spring.security.oauth2.registration.naver.client-secret}")
 	private String clientSecret;
 
+	@Value("${server.url}")
+	private String BASE_URL;
+
 
 	//네이버 인증 서버에서 사용자로부터 권한 승인을 받으면 그로부터 인증 코드가 발급되고
 	//해당 코드로 다시 엑세스토큰을 발급받아 네이버 api를 통해 네이버 사용자 정보를 가져올 수 있도록 함.
@@ -28,7 +31,7 @@ public class SocialClientRegistration {
 		return ClientRegistration.withRegistrationId("naver")
 			.clientId(clientId)
 			.clientSecret(clientSecret)
-			.redirectUri("http://43.200.67.27:8080/login/oauth2/code/naver")
+			.redirectUri(BASE_URL + "/api/login/oauth2/code/naver")
 			.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
 			.scope("name", "email")
 			.authorizationUri("https://nid.naver.com/oauth2.0/authorize")

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/oauth2/SocialClientRegistration.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/oauth2/SocialClientRegistration.java
@@ -6,9 +6,6 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.stereotype.Component;
 
-import jakarta.annotation.PostConstruct;
-import lombok.RequiredArgsConstructor;
-
 //
 @Component
 public class SocialClientRegistration {

--- a/boottalk/src/main/resources/application.yml
+++ b/boottalk/src/main/resources/application.yml
@@ -37,6 +37,7 @@ spring:
       host: 43.200.67.27
       port: 6379
 
+#추 후 프록시 서버로 변경
 server:
-  url: "http://localhost:3000"
+  url: "http://localhost:4000"
 


### PR DESCRIPTION
## 🔍 주요 변경 사항

- BASE_URL 변수를 통해 요청 서버를 환경변수로 관리
- `SecurityFilterChain` oauth2 설정에서 `redirectionEndpoint` 메서드 추가

---

## 💡 변경 이유

- 프론트엔드 서버에서 백엔드 서버로 요청을 보낼 때 브라우저 정책으로 인해 http 환경에서 쿠키가 전달되지 않음
- 위 문제를 해결하기 위해  프록시 서버를 통해 클라이언트가 항상 같은 도메인에 요청을 보내도록 함. 
- 이 때 백엔드에서 요청 서버 관리를 용이하게 하기 위해 `BASE_URL` 변수를 추가하여 환경변수로 관리하도록 함.
---
- 소셜 로그인 인증 과정에서 리다이렉션 시 oauth2에서 기본url 설정이 `/login/oauth2/code/{소셜}`로 되어 있음. 따라서 프록시 서버를 통해 리다이렉션 되지 않아 에러가 발생했었음.

---

## 🚀 개선 결과

- 요청 서버관리 용이
- 소셜 로그인 에러 해결

---

## 📂 관련 클래스 및 변경 파일

- application.yml
- CustomSuccessHandler
- SecurityConfiguration
- SocialClientRegistration

---

## ✅ 테스트 시나리오(예정) 



---

## 💡 참고 블로그



--- 

## 🖼️ 스크린샷



