### PR TITLE
Refactor/ 사용자 인증 시 쿠키 사용으로 변경

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/controller/SseController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/controller/SseController.java
@@ -29,12 +29,11 @@ public class SseController {
 
 	@GetMapping(value = "/sse-connect", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
 	public SseEmitter sseConnect (
-		@RequestHeader(value = "Last-Event-ID", required = false) String lastEventId,
-		@RequestParam("token") String token) {
+		@AuthenticationPrincipal CustomOAuth2User oauth2User,
+		@RequestHeader(value = "Last-Event-ID", required = false) String lastEventId) {
 
 		// TODO : cookie 에서 userId 전송받기
-		String userId = jwtProvider.getUserIdFromToken(token);
-		log.info("sseconnect : userId={}", userId);
-		return sseEmitterService.subscribe(Long.valueOf(userId), lastEventId);
+		log.info("sseconnect : userId={}", oauth2User.getServiceUserId());
+		return sseEmitterService.subscribe( oauth2User.getServiceUserId(), lastEventId);
 	}
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/controller/SseController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/controller/SseController.java
@@ -1,13 +1,10 @@
 package com.icandoit.boottalk.notification.controller;
 
 import org.springframework.http.MediaType;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/config/AuthHandshakeInterceptor.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/config/AuthHandshakeInterceptor.java
@@ -1,6 +1,9 @@
 package com.icandoit.boottalk.stomp_chat.config;
 
 import com.icandoit.boottalk.social_login.jwt.JwtProvider;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.server.ServerHttpRequest;
@@ -23,7 +26,10 @@ public class AuthHandshakeInterceptor implements HandshakeInterceptor {
 		WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
 
 		if (request instanceof ServletServerHttpRequest servletRequest) {
-			String token = servletRequest.getServletRequest().getParameter("token");
+
+			HttpServletRequest httpServletRequest = servletRequest.getServletRequest();
+			String token = extractTokenFromRequest(httpServletRequest);
+
 			log.info("[Handshake] 받은 토큰: {}", token);
 
 			if (token != null && jwtProvider.validateToken(token)) {
@@ -42,5 +48,17 @@ public class AuthHandshakeInterceptor implements HandshakeInterceptor {
 	public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response,
 		WebSocketHandler wsHandler, Exception exception) {
 		// 생략
+	}
+
+	private String extractTokenFromRequest(HttpServletRequest request) {
+		Cookie[] cookies = request.getCookies();
+		if (cookies != null) {
+			for (Cookie cookie : cookies) {
+				if ("Authorization".equals(cookie.getName())) {
+					return cookie.getValue();
+				}
+			}
+		}
+		return null;
 	}
 }


### PR DESCRIPTION
## 🔍 주요 변경 사항

- SSE 연결, WebSocket 연결 시 쿠키에 있는 토큰을 이용하여 사용자 인증
- 웹소켓 최초 연결 요청시 `extractTokenFromRequest`를 이용하여 쿠키에서 토큰을 가져와 웹소켓 세션에 사용자 정보를 저장

---

## 💡 변경 이유

- 기존 CORS 문제로 쿠키 전달이 되지 않아 임시방편으로 url을 통해 토큰을 전달하여 해당 토큰으로 사용자 인증을 진행했었음
- 프록시 서버를 통해 쿠키 전달이 가능해져 다시 쿠키에 있는 토큰을 사용하여 사용자 인증을 할 수 있도록 함.

---

## 🚀 개선 결과

- Js에서 쿠키에 접근할 수 없어 보안 강화

---

## 📂 관련 클래스 및 변경 파일

- SseController
- AuthHandshakeInterceptor



