### PR TITLE
fix: 커피챗 신청 취소 URL 변경 및 상태 변경 시 푸시 알림 조건 수정

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatApplicationController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/controller/CoffeeChatApplicationController.java
@@ -81,7 +81,7 @@ public class CoffeeChatApplicationController {
     }
 
     // 커피챗 신청 취소
-    @DeleteMapping("/{coffeeChatAppId}")
+    @PutMapping("/{coffeeChatAppId}/cancel")
     public ResponseEntity<Void> cancelCoffeeChatApp(
         @AuthenticationPrincipal CustomOAuth2User user,
         @PathVariable Long coffeeChatAppId

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/entity/enums/StatusType.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/entity/enums/StatusType.java
@@ -27,6 +27,10 @@ public enum StatusType {
         return this == APPROVED;
     }
 
+    public boolean isCompleted() {
+        return this == COMPLETED;
+    }
+
     public NotificationType toNotificationType() {
         return switch (this) {
             case APPROVED -> NotificationType.COFFEE_CHAT_REQUEST_APPROVED;

--- a/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatReceivedService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/coffeeChat/service/CoffeeChatReceivedService.java
@@ -90,11 +90,13 @@ public class CoffeeChatReceivedService {
 
         coffeeChatApp.setStatus(changeStatus); // 상태 변경
 
-        // 멘토에게 커피챗 수락/거절/취소 알림 전송
-        eventPublisher.publishEvent(new NotificationEvent(
-            menteeId,
-            NotificationRequestDto.ofType(changeStatus.toNotificationType())
-        ));
+        if (!changeStatus.isCompleted()) {
+            // 멘토에게 커피챗 수락/거절/취소 알림 전송
+            eventPublisher.publishEvent(new NotificationEvent(
+                menteeId,
+                NotificationRequestDto.ofType(changeStatus.toNotificationType())
+            ));
+        }
 
         return CoffeeChatAppStatusResponseDto.from(coffeeChatApp);
 


### PR DESCRIPTION
## 🔍 주요 변경 사항
- (멘티가) 커피챗 취소 요청은 데이터가 삭제되지 않고, 상태만 '취소'로 변경되는 것이므로 DELETE 보다 PUT 이 적절하다고 판단되어 변경
   - DELETE /api/coffee-chats/applications/{coffeeChatAppId} 
   -> PUT /api/coffee-chats/applications/{coffeeChatAppId}/cancel
- 커피챗 신청 상태 변경 시, changeStatus 가 COMPLETED 가 아니라면 푸시알림 전송되도록 수정



