### PR TITLE
Fix/ 이벤트 리스너 @TransactionalEventListener에 옵션추가

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/service/SseEmitterService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/service/SseEmitterService.java
@@ -86,14 +86,14 @@ public class SseEmitterService {
 
 	@Async
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-	public void HandlePointEvent(CreatePointEvent createPointEvent) {
+	public void handlePointEvent(CreatePointEvent createPointEvent) {
 		sendPointNotification(createPointEvent.userId());
 	}
 
 	@Async
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
-	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-	public void HandleNotificationEvent(NotificationEvent notificationEvent) {
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+	public void handleNotificationEvent(NotificationEvent notificationEvent) {
 		sendToClient(notificationEvent.userId(), notificationEvent.notificationRequestDto());
 	}
 


### PR DESCRIPTION

## 🔍 주요 변경 사항

- 기존 SseEmitterService 내 이벤트 리스너 메서드인 handleNotificationEvent @TransactionalEventListener에 fallbackExecution = true 옵션 추가

---

## 💡 변경 이유

- 기존 @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT) 어노테이션 기능은 트랜잭션 내에서 발행한 이벤트일 경우에만 해당 리스너가 동작하여 sendToClient 메서드를 실행함
- 그러나 새로운 부트캠프 등록 알림 전송 작업은 트랜잭션으로 관리되지 않음. 따라서 fallbackExecution = true 옵션을 추가함으로써 트랜잭션 내에서 발행된 이벤트가 아니더라도 이벤트 리스너가 동작되도록함.

---

## 🚀 개선 결과

- 모든 알림 전송 작업을 이벤트 발행을 통해 관리함으로써 이벤트 발행자와 리스너 간 직접적인 의존성을 제거 
- 알림 전송 작업이 필요할 때 때 이벤트 발행만 추가하면 됨. 해당 이벤트는 비동기적으로 처리되어 메인 프로세스에 영향을 주지 않음.

---

## 📂 관련 클래스 및 변경 파일

- SseEmitterService

---



