### PR TITLE
Feat/chatroom  scheduling enhancement : Quartz Job 개선 

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/libs/exception/ErrorCode.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/libs/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
 
     /* 403 FORBIDDEN */
     FORBIDDEN(403, "권한이 없습니다."),
+    UNAUTHORIZED_USER(403, "사용자 인증 정보가 없습니다."),
     INVALID_AUTHENTICATION_TYPE(403,"oAuth2 인증 방식이 아닙니다." ),
     NOT_REVIEW_OWNER(403, "사용자가 작성한 리뷰가 아닙니다."),
     NOT_COFFEE_CHAT_APPLICATION_OWNER(403, "사용자가 작성한 커피챗 신청 내역이 아닙니다."),

--- a/boottalk/src/main/java/com/icandoit/boottalk/libs/exception/ErrorCode.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/libs/exception/ErrorCode.java
@@ -71,7 +71,9 @@ public enum ErrorCode {
     TOKEN_PARSING_ERROR(500, "토큰 파싱 과정에서 오류가 발생했습니다."),
     DATA_FETCH_ERROR(500, "데이터 요청 중 오류가 발생했습니다."),
     DATA_PARSING_ERROR(500, "API 응답 데이터 파싱에 실패했습니다."),
-    FILE_UPLOAD_FAILED(500, "파일 업로드에 실패했습니다.");
+    FILE_UPLOAD_FAILED(500, "파일 업로드에 실패했습니다."),
+    SCHEDULER_START_JOB_ERROR(500, "시작 스케줄러 작업 중 오류가 발생했습니다."),
+    SCHEDULER_END_JOB_ERROR(500, "종료 스케쥴러 작업 중 오류가 발생했습니다.");
 
     private final Integer httpStatus;
     private final String message;

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/controller/ChatRoomController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/controller/ChatRoomController.java
@@ -2,7 +2,6 @@ package com.icandoit.boottalk.stomp_chat.controller;
 
 import com.icandoit.boottalk.social_login.dto.CustomOAuth2User;
 import com.icandoit.boottalk.stomp_chat.dto.ChatMessageResponseDto;
-import com.icandoit.boottalk.stomp_chat.dto.ChatRoomCreateResponse;
 import com.icandoit.boottalk.stomp_chat.dto.ChatRoomResponseDto;
 import com.icandoit.boottalk.stomp_chat.service.ChatRoomService;
 import java.util.List;
@@ -11,7 +10,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/controller/ChatWebSocketController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/controller/ChatWebSocketController.java
@@ -6,13 +6,11 @@ import com.icandoit.boottalk.social_login.dto.CustomOAuth2User;
 import com.icandoit.boottalk.stomp_chat.dto.stompDto.ChatMessageRequestDto;
 import com.icandoit.boottalk.stomp_chat.dto.stompDto.ChatTypingRequestDto;
 import com.icandoit.boottalk.stomp_chat.service.ChatWebsocketService;
-import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 
@@ -27,7 +25,7 @@ public class ChatWebSocketController {
     public void send(@Payload ChatMessageRequestDto requestDto, Authentication authentication) {
         if (authentication == null) {
             log.error("인증 정보가 없습니다.");
-            throw new AccessDeniedException("인증되지 않은 사용자");
+            throw new CustomException(ErrorCode.UNAUTHORIZED_USER);
         }
 
         Long userId = extractUserId(authentication);
@@ -40,7 +38,7 @@ public class ChatWebSocketController {
     public void enter(@DestinationVariable String roomUuid, Authentication authentication) {
         if (authentication == null) {
             log.error("인증 정보가 없습니다.");
-            throw new AccessDeniedException("인증되지 않은 사용자");
+            throw new CustomException(ErrorCode.UNAUTHORIZED_USER);
         }
 
         Long userId = extractUserId(authentication);
@@ -48,12 +46,11 @@ public class ChatWebSocketController {
         chatWebsocketService.handleUserEnter(userId, roomUuid);
     }
 
-    // todo: 테스트 해보고 인증 Principal -> Authentication 변경 예정
     @MessageMapping("/chat.typing")
     public void typing(@Payload ChatTypingRequestDto requestDto, Authentication authentication) {
         if (authentication == null) {
             log.error("인증 정보가 없습니다.");
-            throw new AccessDeniedException("인증되지 않은 사용자");
+            throw new CustomException(ErrorCode.UNAUTHORIZED_USER);
         }
 
         chatWebsocketService.sendTypingStatus(requestDto);

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/repository/RedisChatUserRepository.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/repository/RedisChatUserRepository.java
@@ -27,7 +27,7 @@ public class RedisChatUserRepository {
 
 
     // 사용자 알림 수신
-    public boolean shouldSendNotification(String roomUuid, Long receiverId) {
+    public boolean isNotificationNecessaryAndSend(String roomUuid, Long receiverId) {
 
         Boolean alreadySent = redisTemplate.hasKey(chatNotice(roomUuid, receiverId));
         if (Boolean.TRUE.equals(alreadySent)) {

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/scheduler/ChatQuartzSchedulerService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/scheduler/ChatQuartzSchedulerService.java
@@ -5,6 +5,7 @@ import com.icandoit.boottalk.libs.exception.ErrorCode;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.quartz.Job;
 import org.quartz.JobBuilder;
 import org.quartz.JobDetail;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ChatQuartzSchedulerService {
 
     private final Scheduler scheduler;
@@ -23,9 +25,16 @@ public class ChatQuartzSchedulerService {
     public void scheduleStartAndEndJobs(String roomUuid, LocalDateTime startTime, LocalDateTime endTime) {
         try {
             scheduleJob(roomUuid, startTime, StartCoffeeChatJob.class, "start");
+        } catch (SchedulerException e) {
+            log.error("시작 스케쥴러 작업 실패 - roomUuid : {}", roomUuid, e);
+            throw new CustomException(ErrorCode.SCHEDULER_START_JOB_ERROR);
+        }
+
+        try {
             scheduleJob(roomUuid, endTime, EndCoffeeChatJob.class, "end");
         } catch (SchedulerException e) {
-            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+            log.error("종료 스케쥴러 작업 실패 - roomUuid : {}", roomUuid, e);
+            throw new CustomException(ErrorCode.SCHEDULER_END_JOB_ERROR);
         }
     }
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/scheduler/EndCoffeeChatJob.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/scheduler/EndCoffeeChatJob.java
@@ -1,9 +1,7 @@
 package com.icandoit.boottalk.stomp_chat.scheduler;
 
-import com.icandoit.boottalk.libs.exception.CustomException;
-import com.icandoit.boottalk.libs.exception.ErrorCode;
-import com.icandoit.boottalk.stomp_chat.entity.ChatRoom;
-import com.icandoit.boottalk.stomp_chat.repository.ChatRoomRepository;
+
+import com.icandoit.boottalk.stomp_chat.service.ChatRoomService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.JobExecutionContext;
@@ -16,17 +14,11 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class EndCoffeeChatJob extends QuartzJobBean {
 
-    private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomService chatRoomService;
 
     @Override
     protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
         String roomUuid = context.getMergedJobDataMap().getString("roomUuid");
-
-        ChatRoom room = chatRoomRepository.findByRoomUuid(roomUuid)
-            .orElseThrow(() -> new CustomException(ErrorCode.CHAT_ROOM_NOT_FOUND));
-
-        room.getRoomStatus().setActive(false);
-        chatRoomRepository.save(room);
-        log.info("채팅방 비활성화 완료: {}", roomUuid);
+        chatRoomService.endCoffeeChat(roomUuid);
     }
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/scheduler/EndCoffeeChatJob.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/scheduler/EndCoffeeChatJob.java
@@ -18,7 +18,12 @@ public class EndCoffeeChatJob extends QuartzJobBean {
 
     @Override
     protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
-        String roomUuid = context.getMergedJobDataMap().getString("roomUuid");
-        chatRoomService.endCoffeeChat(roomUuid);
+        try {
+            String roomUuid = context.getMergedJobDataMap().getString("roomUuid");
+            chatRoomService.endCoffeeChat(roomUuid);
+        } catch (Exception e) {
+            // 예외가 발생하면 RuntimeException을 던진다.
+            throw new JobExecutionException("Error while ending coffee chat", e);
+        }
     }
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/scheduler/StartCoffeeChatJob.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/scheduler/StartCoffeeChatJob.java
@@ -17,8 +17,11 @@ public class StartCoffeeChatJob extends QuartzJobBean {
 
     @Override
     protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
-        String roomUuid = context.getMergedJobDataMap().getString("roomUuid");
-
-        chatRoomService.activateChatRoom(roomUuid);
+        try {
+            String roomUuid = context.getMergedJobDataMap().getString("roomUuid");
+            chatRoomService.activateChatRoom(roomUuid);
+        } catch (Exception e) {
+            throw new JobExecutionException("Error while starting coffee chat", e);
+        }
     }
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/scheduler/StartCoffeeChatJob.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/scheduler/StartCoffeeChatJob.java
@@ -1,9 +1,6 @@
 package com.icandoit.boottalk.stomp_chat.scheduler;
 
-import com.icandoit.boottalk.libs.exception.CustomException;
-import com.icandoit.boottalk.libs.exception.ErrorCode;
-import com.icandoit.boottalk.stomp_chat.entity.ChatRoom;
-import com.icandoit.boottalk.stomp_chat.repository.ChatRoomRepository;
+import com.icandoit.boottalk.stomp_chat.service.ChatRoomService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.JobExecutionContext;
@@ -16,17 +13,12 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class StartCoffeeChatJob extends QuartzJobBean {
 
-    private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomService chatRoomService;
 
     @Override
     protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
         String roomUuid = context.getMergedJobDataMap().getString("roomUuid");
 
-        ChatRoom room = chatRoomRepository.findByRoomUuid(roomUuid)
-            .orElseThrow(() -> new CustomException(ErrorCode.CHAT_ROOM_NOT_FOUND));
-
-        room.getRoomStatus().setActive(true);
-        chatRoomRepository.save(room);
-        log.info("채팅방 활성화 완료: {}", roomUuid);
+        chatRoomService.activateChatRoom(roomUuid);
     }
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/service/ChatRoomService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/service/ChatRoomService.java
@@ -1,7 +1,6 @@
 package com.icandoit.boottalk.stomp_chat.service;
 
 import com.icandoit.boottalk.coffeeChat.entity.CoffeeChatApplication;
-import com.icandoit.boottalk.coffeeChat.repository.CoffeeChatApplicationRepository;
 import com.icandoit.boottalk.libs.exception.CustomException;
 import com.icandoit.boottalk.libs.exception.ErrorCode;
 import com.icandoit.boottalk.stomp_chat.dto.ChatMessageResponseDto;

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/service/ChatRoomService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/service/ChatRoomService.java
@@ -56,11 +56,6 @@ public class ChatRoomService {
         ChatRoomStatus chatRoomStatus = getChatRoomStatus(roomUuid);
         ChatRoom chatRoom = chatRoomStatus.getChatRoom();
 
-        // 비활성화된 채팅방인 경우 예외 발생
-        if (!chatRoomStatus.isActive()) {
-            throw new CustomException(ErrorCode.CHAT_ROOM_NOT_ACTIVE);
-        }
-
         validateChatRoomEntry(chatRoom, userId);
 
         List<ChatMessage> chatMessages = chatMessageRepository.findByRoomUuid(roomUuid);

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/service/ChatRoomService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/service/ChatRoomService.java
@@ -1,6 +1,7 @@
 package com.icandoit.boottalk.stomp_chat.service;
 
 import com.icandoit.boottalk.coffeeChat.entity.CoffeeChatApplication;
+import com.icandoit.boottalk.coffeeChat.entity.enums.StatusType;
 import com.icandoit.boottalk.libs.exception.CustomException;
 import com.icandoit.boottalk.libs.exception.ErrorCode;
 import com.icandoit.boottalk.stomp_chat.dto.ChatMessageResponseDto;
@@ -64,6 +65,24 @@ public class ChatRoomService {
             .toList();
     }
 
+    // 방 생성(isActive = true)
+    @Transactional
+    public void activateChatRoom(String roomUuid) {
+        ChatRoom room = chatRoomRepository.findByRoomUuid(roomUuid)
+            .orElseThrow(() -> new CustomException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        room.getRoomStatus().setActive(true);
+    }
+
+    @Transactional
+    public void endCoffeeChat(String roomUuid) {
+        ChatRoom chatRoom = chatRoomRepository.findByRoomUuid(roomUuid)
+            .orElseThrow(() -> new CustomException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        chatRoom.getRoomStatus().setActive(false);
+        chatRoom.getCoffeeChatApplication().setStatus(StatusType.COMPLETED);
+        log.info("커피챗 종료- 상태 변경 완료, roomUuid {}", roomUuid);
+    }
 
     // ChatRoomStatus 조회
     private ChatRoomStatus getChatRoomStatus(String roomUuid) {

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/service/ChatWebsocketService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/service/ChatWebsocketService.java
@@ -82,11 +82,12 @@ public class ChatWebsocketService {
 
         // 커피챗 예약 시간 내에만 채팅 가능하도록 체크
         checkChatRoomWithinAllowedTime(roomUuid);
-        boolean isReceiverInRoom = redisChatUserRepository.isUserEnteredInCache(roomUuid,
-            requestDto.receiverId());
+
+        boolean isReceiverInRoom = isUserInChatRoom(roomUuid, requestDto.receiverId());
+        boolean isNotificationNeeded = handleNotificationForUser(roomUuid, requestDto.receiverId());
+
         log.info("senderId: {}, receiverId: {}", senderId, requestDto.receiverId());
 
-        // 메시지를 DTO로 변환
         ChatMessageResponseDto messageToCache = new ChatMessageResponseDto(
             roomUuid,
             senderId,
@@ -97,9 +98,8 @@ public class ChatWebsocketService {
             isReceiverInRoom
         );
 
-        if (!isReceiverInRoom && redisChatUserRepository.shouldSendNotification(roomUuid,
-            requestDto.receiverId())) {
-
+        // 유저가 입장하지 않고, 알림을 처음 받는 경우 
+        if (!isReceiverInRoom && isNotificationNeeded) {
             eventPublisher.publishEvent(new NotificationEvent(
                 requestDto.receiverId(),
                 NotificationRequestDto.ofType(NotificationType.CHAT_MESSAGE_RECEIVED)
@@ -115,10 +115,21 @@ public class ChatWebsocketService {
 
     public void sendTypingStatus(ChatTypingRequestDto requestDto) {
 
-        ChatTypingResponseDto response = new ChatTypingResponseDto(requestDto.receiverId(), requestDto.typing());
+        ChatTypingResponseDto response = new ChatTypingResponseDto(requestDto.receiverId(),
+            requestDto.typing());
 
         String destination = "/queue/chat/" + requestDto.roomUuid() + "/" + requestDto.receiverId();
         template.convertAndSend(destination, response);
+    }
+
+    // 사용자가 해당 채팅방에 입장했는지 확인하는 함수
+    private boolean isUserInChatRoom(String roomUuid, Long receiverId) {
+        return redisChatUserRepository.isUserEnteredInCache(roomUuid, receiverId);
+    }
+
+    // 알림 전송 필요 여부와 상태를 확인하고 처리하는 함수
+    private boolean handleNotificationForUser(String roomUuid, Long receiverId) {
+        return redisChatUserRepository.isNotificationNecessaryAndSend(roomUuid, receiverId);
     }
 
     public void markUnreadMessagesAsRead(String roomUuid, Long userId, LocalDateTime enterTime) {
@@ -126,6 +137,7 @@ public class ChatWebsocketService {
 
         boolean updated = false;
 
+        // 새로 받은 알림이 있다면 updated = true 
         for (ChatMessageResponseDto message : cachedMessages) {
             if (Objects.equals(message.getReceiverId(), userId)
                 && !message.isRead()


### PR DESCRIPTION
## 🔍 주요 변경 사항

- #131 
- 지난 PR 리뷰에서 수정한 사항을 반영하여 새로운 PR을 올립니다!

- Quartz 내부에서 DB 변경을 수행하는 로직을 서비스 레이어와 분리하여 트랜잭션을 처리하였습니다.

- Job 진행 중 발생할 수 있는 예외 처리를 세부적으로 분리하였습니다.

- 종료 Job이 진행될 때, 커피챗 신청 상태를 COMPLETED로 변경하도록 처리하였습니다.

## 💡 변경 이유
- Quartz에서 트랜잭션 처리가 불가능하여 DB 변경을 필요로 하는 Job의 경우, 서비스 레이어에서 트랜잭션을 처리하도록 하여, 실패 시 롤 
백이 가능하도록 하고 정합성을 유지할 수 있게 하였습니다.

- 예외 처리를 세부적으로 분리하여, Job 스케줄러 진행 중 발생할 수 있는 다양한 오류들을 더 구체적으로 추적하고 대응할 수 있게 하였습니다.

- 커피챗 종료 시, 커피챗 신청 상태를 명확하게 COMPLETED로 변경하도록 처리하여, 상태 관리가 보다 명확해졌습니다.

## 🚀 개선 결과
- DB 변경과 트랜잭션 처리가 분리되어 롤백 시, 서비스 정합성이 보다 강화되었습니다.

- 예외 처리가 세분화되어, 오류 발생 시 원인을 더 쉽게 추적하고 디버깅할 수 있게 되었습니다.

- Job 진행 중 상태 변경이 명확히 이루어져 커피챗 관리의 일관성이 보장되었습니다.
