### PR TITLE
Refactor/ 사용자 인증, 권한 확인 실패 시 SecurityFilter에서 커스텀 에러로 처리

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/controller/BootcampCertificationController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/bootcamp/controller/BootcampCertificationController.java
@@ -27,20 +27,17 @@ public class BootcampCertificationController {
 	private final BootcampCertificationService certificationService;
 
 	@GetMapping
-	@PreAuthorize("hasAuthority('ADMIN')")
 	public ResponseEntity<List<GetPendingCertificationResponseDto>> getAllCertifications() {
 		return ResponseEntity.ok(certificationService.getPendingCertifications());
 	}
 
 	@GetMapping("/{certificationId}")
-	@PreAuthorize("hasAuthority('ADMIN')")
 	public ResponseEntity<GetCertificationInfoDto> getCertification(
 		@PathVariable Long certificationId) {
 		return ResponseEntity.ok(certificationService.findById(certificationId));
 	}
 
 	@PutMapping
-	@PreAuthorize("hasAuthority('ADMIN')")
 	public ResponseEntity<CertificationResponseDto> updateCertification(@RequestBody CertificationUpdateRequestDto request){
 		return ResponseEntity.ok(certificationService.updateCertification(request));
 	}

--- a/boottalk/src/main/java/com/icandoit/boottalk/libs/exception/ErrorCode.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/libs/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
 
     /* 401 UNAUTHORIZED */
     INVALID_TOKEN(401, "유효한 토큰이 아닙니다."),
+    AUTHENTICATION_FAILED(401, "사용자 인증에 실패했습니다."),
 
     /* 403 FORBIDDEN */
     FORBIDDEN(403, "권한이 없습니다."),

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/SecurityConfiguration.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/SecurityConfiguration.java
@@ -17,6 +17,8 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import com.icandoit.boottalk.social_login.config.exception.CustomAccessDeniedException;
+import com.icandoit.boottalk.social_login.config.exception.CustomAuthenticationEntryPoint;
 import com.icandoit.boottalk.social_login.jwt.JwtFilter;
 import com.icandoit.boottalk.social_login.oauth2.CustomClientRegistrationRepository;
 import com.icandoit.boottalk.social_login.oauth2.CustomSuccessHandler;
@@ -39,33 +41,31 @@ public class SecurityConfiguration {
 
 	@Value("${server.url}")
 	private String BASE_URL;
-
+	private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+	private final CustomAccessDeniedException customAccessDeniedException;
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		log.info("SecurityFilterChain 설정");
 
 		http
-			.cors(cors ->  cors.configurationSource(corsConfigurationSource()))
+			.cors(cors -> cors.configurationSource(corsConfigurationSource()))
 			.csrf(AbstractHttpConfigurer::disable)
 			.httpBasic(AbstractHttpConfigurer::disable)
 			.formLogin(AbstractHttpConfigurer::disable)
-			// .exceptionHandling(exception -> {
-			// 	log.info("Exception Handling triggered");
-			// 	exception.authenticationEntryPoint((request, response, authException) -> {
-			// 		log.info("Unauthorized access attempt: {}", request.getRequestURI());
-			// 		response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
-			// 	});
-			// })
-
-
-		// 세션 사용하지 않기 때문에
+			.exceptionHandling(exception -> {
+				exception.authenticationEntryPoint(customAuthenticationEntryPoint);
+				exception.accessDeniedHandler(customAccessDeniedException);
+			})
+			// 세션 사용하지 않기 때문에
 			.sessionManagement(session -> session
 				.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.authorizeHttpRequests(auth -> auth
 				// 경로에 대한 접근 권한 설정
 				// TODO  : 추후에 접근 가능한 페이지 설정
-				.requestMatchers("/", "/swagger-ui/**", "/v3/api-docs/**", "/api/oauth2/authorization/**", "/login/**", "/api/bootcamps/**", "/api/reviews/**", "/api/test/**", "/connection", "/api/sse-connect").permitAll()
+				.requestMatchers("/", "/swagger-ui/**", "/v3/api-docs/**", "/api/oauth2/authorization/**",
+					"/login/**", "/api/login/**","/api/bootcamps/**", "/api/reviews/**", "/api/test/**", "/connection").permitAll()
+				.requestMatchers("/api/admin/**").hasAuthority("ADMIN")
 				.anyRequest().authenticated())
 			.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
 			//oauth2 로그인 설정
@@ -93,7 +93,7 @@ public class SecurityConfiguration {
 	@Bean
 	public CorsConfigurationSource corsConfigurationSource() {
 		CorsConfiguration configuration = new CorsConfiguration();
-		configuration.setAllowedOrigins(List.of("http://localhost:3000", "http://127.0.0.1:3000", BASE_URL));
+		configuration.setAllowedOrigins(List.of("http://localhost:3000", BASE_URL));
 		configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
 		configuration.setAllowCredentials(true);
 		configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "X-Requested-With", "Accept"));

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/exception/CustomAccessDeniedException.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/exception/CustomAccessDeniedException.java
@@ -1,0 +1,35 @@
+package com.icandoit.boottalk.social_login.config.exception;
+
+import java.io.IOException;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.icandoit.boottalk.libs.dto.ExceptionResponseDto;
+import com.icandoit.boottalk.libs.exception.ErrorCode;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class CustomAccessDeniedException implements AccessDeniedHandler {
+	@Override
+	public void handle(HttpServletRequest request, HttpServletResponse response,
+		AccessDeniedException accessDeniedException) throws IOException {
+		log.warn("사용자 권한 없음 : {}, URI: {}", accessDeniedException.getMessage(), request.getRequestURI());
+
+		response.setContentType("application/json;charset=UTF-8");
+		response.setStatus(ErrorCode.FORBIDDEN.getHttpStatus());
+
+		ObjectMapper objectMapper = new ObjectMapper();
+		response.getWriter().write(objectMapper.writeValueAsString(
+			ExceptionResponseDto.of(ErrorCode.FORBIDDEN.getHttpStatus(),
+				ErrorCode.FORBIDDEN.getMessage(),
+				null)
+		));
+	}
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/exception/CustomAuthenticationEntryPoint.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/exception/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,50 @@
+package com.icandoit.boottalk.social_login.config.exception;
+
+import java.io.IOException;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.icandoit.boottalk.libs.dto.ExceptionResponseDto;
+import com.icandoit.boottalk.libs.exception.ErrorCode;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException authException) throws IOException, ServletException {
+		log.error("사용자 인증 실패 : {}, URI: {}", authException.getMessage(), request.getRequestURI());
+
+		String uri = request.getRequestURI();
+
+		// OAuth2 인증 관련 경로는 처리하지 않고 반환
+		if (uri.startsWith("/api/oauth2/authorization") ||
+			uri.startsWith("/api/login/oauth2/code") ||
+			uri.equals("/error")) {
+			log.info("OAuth2 관련 경로 감지, 기본 인증 흐름으로 위임: {}", uri);
+			// 기본 AuthenticationEntryPoint로 위임
+			new LoginUrlAuthenticationEntryPoint("/api/oauth2/authorization/naver")
+				.commence(request, response, authException);
+			return;
+		}
+
+		response.setContentType("application/json;charset=UTF-8");
+		response.setStatus(ErrorCode.AUTHENTICATION_FAILED.getHttpStatus());
+
+		ObjectMapper objectMapper = new ObjectMapper();
+		response.getWriter().write(objectMapper.writeValueAsString(
+			ExceptionResponseDto.of(ErrorCode.AUTHENTICATION_FAILED.getHttpStatus(),
+				ErrorCode.AUTHENTICATION_FAILED.getMessage(),
+			null)));
+	}
+}


### PR DESCRIPTION
## 🔍 주요 변경 사항

- 사용자 인증, 권한 확인 실패 시 SecurityFilter에서 커스텀 에러를 발생시킴
 - 사용자 인증 실패 시 CustomAuthenticationEntryPoint 를 통해 커스텀 에러 발생
   - 이 때 소셜 로그인 과정에서 사용자 인증 문제가 발생하지 않도록 oauth2 관련 경로는 인증을 거치지 않도록 설정 
 - 사용자 권한 확인 실패 시 CustomAccessDeniedException 를 통해 커스텀 에러 발생
   - 기존  BootcampCertificationController 에서 @PreAuthority 어노테이션을 통해 권한에 따라 접근을 제한했었는데 SecurityFilter로 책임 이동

---

## 💡 변경 이유
- 기존 인증 실패 시 자동으로 사용자 인증을 위해 네이버 로그인 페이지로 넘어갔었음. 이 경우 한페이지에서 사용자 인증이 필요한 요청과 필요하지 않은 요청이 같은 페이지에서 발생할 때 굳이 네이버 로그인 페이지로 넘어가지 않아도 되는데 넘어갈 수 있음.
- 따라서 이를 방지하기 위해 커스텀 에러륿 발생시켜 로그인 페이지로 넘어가는 것을 방지
- 기존 컨트롤러 레이어에서 권한 확인 하던 것을 SecurityFilter로 옮겨 모든 사용자 인증, 인가 책임을 지게 함으로써 단일 책임 원칙에 충실하도록 함.

---

## 🚀 개선 결과

- 무분별한 로그인 시도 방지
- 단일 책임 원칙 준수

---

## 📂 관련 클래스 및 변경 파일

- BootcampCertificationController
- ErrorCode
- SecurityConfiguration
- CustomAuthenticationEntryPoint
- CustomAccessDeniedException



