### PR TITLE
Fix/ 로그아웃 시 쿠키에 담긴 토큰 제거

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/SecurityConfiguration.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/SecurityConfiguration.java
@@ -81,10 +81,11 @@ public class SecurityConfiguration {
 					.successHandler(customSuccessHandler) // 로그인 성공 시 토큰을 발급하는 클래스
 					.clientRegistrationRepository(customClientRegistrationRepository.clientRegistrationRepository());
 			}) // 부트톡 서버와 네이버 서버간 인증코드와 엑세스 토큰을 주고 받기 위한 설정이 저장된 클래스
-			.logout(logout -> logout.logoutUrl("/logout")
+			.logout(logout -> logout.logoutUrl("/api/logout")
 				.logoutSuccessHandler((request, response, auth) -> {
 					response.sendRedirect(BASE_URL); // 로그아웃 성공 시 메인페이지로 이동
 				})
+				.deleteCookies("JSESSIONID", "Authorization") // 삭제할 쿠키 이름들 지정
 				.clearAuthentication(true));
 
 		return http.build();


### PR DESCRIPTION
## 🔍 주요 변경 사항

- 로그아웃 시 쿠키에 담긴 토큰 값 제거

---

## 💡 변경 이유

- 기존 로그아웃 요청시 쿠키에 있는 토큰이 삭제되지 않아 로그아웃을 해도 로그인이 계속 유지되었음.
- SecurityFilterChain의 logout 설정에서 .deleteCookies("JSESSIONID", "Authorization") 를 통해 쿠키에서 Authorization 토큰을 제거해 로그인이 풀리도록 함.

---

## 🚀 개선 결과

- 로그아웃 기능 정상 작동

---

## 📂 관련 클래스 및 변경 파일

- SecurityConfiguration



