### PR TITLE
fix : userName이 멘토 이름으로 고정 되어있던 부분 수정

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/controller/ChatWebSocketController.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/controller/ChatWebSocketController.java
@@ -41,9 +41,11 @@ public class ChatWebSocketController {
             throw new CustomException(ErrorCode.UNAUTHORIZED_USER);
         }
 
-        Long userId = extractUserId(authentication);
+        CustomOAuth2User user = (CustomOAuth2User) authentication.getPrincipal();
+        Long userId = user.getServiceUserId();
+        String userName = user.getName();
         log.info("채팅 입장: userId = {}", userId);
-        chatWebsocketService.handleUserEnter(userId, roomUuid);
+        chatWebsocketService.handleUserEnter(userId, userName, roomUuid);
     }
 
     @MessageMapping("/chat.typing")

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/service/ChatWebsocketService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/service/ChatWebsocketService.java
@@ -51,7 +51,7 @@ public class ChatWebsocketService {
     private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
-    public void handleUserEnter(Long userId, String roomUuid) {
+    public void handleUserEnter(Long userId, String userName, String roomUuid) {
         LocalDateTime enterTime = LocalDateTime.now();
 
         // 입장한 유저상태 저장
@@ -65,7 +65,7 @@ public class ChatWebsocketService {
         // 읽음 처리
         markUnreadMessagesAsRead(roomUuid, userId, enterTime);
 
-        messageSender.sendEnterMessage(userId, roomUuid);
+        messageSender.sendEnterMessage(userId, userName, roomUuid);
 
         redisChatUserRepository.resetNotificationStatus(roomUuid, userId);
     }

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/service/component/ChatMessageSender.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/service/component/ChatMessageSender.java
@@ -7,6 +7,8 @@ import com.icandoit.boottalk.stomp_chat.entity.ChatRoom;
 import com.icandoit.boottalk.stomp_chat.entity.enums.MessageType;
 import com.icandoit.boottalk.stomp_chat.repository.ChatRoomRepository;
 import com.icandoit.boottalk.stomp_chat.repository.RedisChatUserRepository;
+import com.icandoit.boottalk.user.domain.repository.UserRepository;
+
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,7 +23,7 @@ public class ChatMessageSender {
     private final ChatRoomRepository chatRoomRepository;
     private final RedisChatUserRepository redisChatUserRepository;
     private final SimpMessageSendingOperations template;
-
+    private final UserRepository userRepository;
 
     // 입장 메시지 전송
     public void sendEnterMessage(Long userId, String roomUuid) {
@@ -37,7 +39,8 @@ public class ChatMessageSender {
             ? chatRoom.getMentee().getUserId()
             : chatRoom.getMentor().getUserId();
 
-        String senderName = chatRoom.getMentor().getUserName();
+        String senderName = userRepository.getReferenceById(userId).getUserName();
+
         String systemContent = senderName + "님이 입장하였습니다.";
         ChatMessageResponseDto enterMessage = new ChatMessageResponseDto(
             roomUuid, 0L, receiverId, systemContent, MessageType.SYSTEM, LocalDateTime.now(), false

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/service/component/ChatMessageSender.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/service/component/ChatMessageSender.java
@@ -1,5 +1,10 @@
 package com.icandoit.boottalk.stomp_chat.service.component;
 
+import java.time.LocalDateTime;
+
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Component;
+
 import com.icandoit.boottalk.libs.exception.CustomException;
 import com.icandoit.boottalk.libs.exception.ErrorCode;
 import com.icandoit.boottalk.stomp_chat.dto.ChatMessageResponseDto;
@@ -7,13 +12,9 @@ import com.icandoit.boottalk.stomp_chat.entity.ChatRoom;
 import com.icandoit.boottalk.stomp_chat.entity.enums.MessageType;
 import com.icandoit.boottalk.stomp_chat.repository.ChatRoomRepository;
 import com.icandoit.boottalk.stomp_chat.repository.RedisChatUserRepository;
-import com.icandoit.boottalk.user.domain.repository.UserRepository;
 
-import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
-import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
 @Component
@@ -23,10 +24,9 @@ public class ChatMessageSender {
     private final ChatRoomRepository chatRoomRepository;
     private final RedisChatUserRepository redisChatUserRepository;
     private final SimpMessageSendingOperations template;
-    private final UserRepository userRepository;
 
     // 입장 메시지 전송
-    public void sendEnterMessage(Long userId, String roomUuid) {
+    public void sendEnterMessage(Long userId, String userName, String roomUuid) {
         // Redis에서 사용자가 입장했는지 확인
 
         if (!redisChatUserRepository.isUserEnteredInCache(roomUuid, userId)) {
@@ -40,9 +40,7 @@ public class ChatMessageSender {
             ? chatRoom.getMentee().getUserId()
             : chatRoom.getMentor().getUserId();
 
-        String senderName = userRepository.getReferenceById(userId).getUserName();
-
-        String systemContent = senderName + "님이 입장하였습니다.";
+        String systemContent = userName + "님이 입장하였습니다.";
         ChatMessageResponseDto enterMessage = new ChatMessageResponseDto(
             roomUuid, 0L, receiverId, systemContent, MessageType.SYSTEM, LocalDateTime.now(), false
         );


### PR DESCRIPTION
## 🔍 주요 변경 사항
- 입장자가 mentor Name으로 고정되어있던 부분 userId를 통해 user 조회 후 이름 반환


---

## 💡 변경 이유
- 1:1 채팅에서 입장시 자신의 이름이 아닌 채팅방 멘토의 아이디가 계속 출력되는 현상이 있어서 수정


---

## 🚀 개선 결과
- 정확히 입장한 유저의 이름이 출력됨으로 인해 정확한 정보 전달 가능


---

## 📂 관련 클래스 및 변경 파일
- ChatMessageSender


