### PR TITLE
Fix/사용자 정보 수정 시 desiredCareer 타입 처리

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/entity/User.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/entity/User.java
@@ -52,9 +52,9 @@ public class User extends BaseEntity {
 	private boolean admin;
 
 
-	public User updateOf(UpdateForm form) {
-		this.profileImage = form.profileImage();
-		this.desiredCareer = form.desiredCareer();
+	public User updateOf(String profileImage, BootcampCategoryType desiredCareer) {
+		this.profileImage = profileImage;
+		this.desiredCareer = desiredCareer;
 		return this;
 	}
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/entity/User.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/entity/User.java
@@ -5,8 +5,6 @@ import java.sql.Timestamp;
 import com.icandoit.boottalk.bootcamp.entity.enums.BootcampCategoryType;
 import com.icandoit.boottalk.libs.entity.BaseEntity;
 
-import com.icandoit.boottalk.user.domain.form.UpdateForm;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/form/UpdateForm.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/form/UpdateForm.java
@@ -7,6 +7,6 @@ import lombok.Builder;
 @Builder
 public record UpdateForm(
     String profileImage,
-    BootcampCategoryType desiredCareer
+    String desiredCareer
 ) {
 }

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/domain/form/UpdateForm.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/domain/form/UpdateForm.java
@@ -1,7 +1,5 @@
 package com.icandoit.boottalk.user.domain.form;
 
-import com.icandoit.boottalk.bootcamp.entity.enums.BootcampCategoryType;
-
 import lombok.Builder;
 
 @Builder

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/service/AddUserInfoService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/service/AddUserInfoService.java
@@ -1,11 +1,14 @@
 package com.icandoit.boottalk.user.service;
 
+import static com.icandoit.boottalk.libs.exception.ErrorCode.*;
+
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.icandoit.boottalk.bootcamp.entity.enums.BootcampCategoryType;
 import com.icandoit.boottalk.libs.exception.CustomException;
 import com.icandoit.boottalk.libs.exception.ErrorCode;
 import com.icandoit.boottalk.point_history.domain.type.EventType;
@@ -29,11 +32,16 @@ public class AddUserInfoService {
 		User user = userRepository.findById(userId).orElseThrow(
 			() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
+		if(!BootcampCategoryType.isValidKoreanName(form.desiredCareer())) {
+			throw new CustomException(INVALID_CATEGORY_NAME);
+		}
+
 		// 신규회원, 탈퇴한지 6개월이 지난 회원인 경우에만
 		// 포인트 적립
 		canReceivePoint(user);
 
-		user.updateOf(form);
+		user.updateOf(form.profileImage(),
+			BootcampCategoryType.fromKoreanName(form.desiredCareer()));
 	}
 
 	private void canReceivePoint(User user) {

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/service/ManageService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/service/ManageService.java
@@ -2,7 +2,9 @@ package com.icandoit.boottalk.user.service;
 
 import static com.icandoit.boottalk.libs.exception.ErrorCode.*;
 
+import com.icandoit.boottalk.bootcamp.entity.enums.BootcampCategoryType;
 import com.icandoit.boottalk.libs.exception.CustomException;
+import com.icandoit.boottalk.libs.exception.ErrorCode;
 import com.icandoit.boottalk.user.domain.dto.UserDto;
 import com.icandoit.boottalk.user.domain.entity.User;
 import com.icandoit.boottalk.user.domain.form.UpdateForm;
@@ -28,8 +30,12 @@ public class ManageService {
 
 	@Transactional
 	public UserDto updateUser(Long userId, UpdateForm form) {
+		if(!BootcampCategoryType.isValidKoreanName(form.desiredCareer())) {
+			throw new CustomException(INVALID_CATEGORY_NAME);
+		}
 
-		return UserDto.from(getUserInfo(userId).updateOf(form));
+		return UserDto.from(getUserInfo(userId).updateOf(form.profileImage(),
+			BootcampCategoryType.fromKoreanName(form.desiredCareer())));
 	}
 
 	@Transactional

--- a/boottalk/src/main/java/com/icandoit/boottalk/user/service/ManageService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/user/service/ManageService.java
@@ -2,19 +2,20 @@ package com.icandoit.boottalk.user.service;
 
 import static com.icandoit.boottalk.libs.exception.ErrorCode.*;
 
+import java.sql.Timestamp;
+import java.time.Instant;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.icandoit.boottalk.bootcamp.entity.enums.BootcampCategoryType;
 import com.icandoit.boottalk.libs.exception.CustomException;
-import com.icandoit.boottalk.libs.exception.ErrorCode;
 import com.icandoit.boottalk.user.domain.dto.UserDto;
 import com.icandoit.boottalk.user.domain.entity.User;
 import com.icandoit.boottalk.user.domain.form.UpdateForm;
 import com.icandoit.boottalk.user.domain.repository.UserRepository;
 
-import java.sql.Timestamp;
-import java.time.Instant;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor


### PR DESCRIPTION
## 🔍 주요 변경 사항

- 사용자 정보(프로필 이미지, 관심직군)를 받을 때 프론트엔드에서 전송한 관심직군 데이터를 String 타입으로 먼저 수신한 후 백엔드에서 Enum으로 변환하는 방식으로 변경
- 서비스 레이어에서 String → Enum 변환 처리 로직 추가
- Enum 값과 한글 표현 간의 매핑 로직 구현

---

## 💡 변경 이유

- 기존 방식에서는 RequestBody 형식으로 UpdateForm 을 이용, 이 때  BootcampCategoryType desiredCareer 로 바로 이넘타입으로 받고 있었음. 그러나 백엔드에서 enum 값은 영문으로 정의되어 있었음. 
- 이에 따라 프론트엔드에서 desiredCareer 데이터를 한글로 넘겨주면서 호환성 문제 발생 

---

## 🚀 개선 결과

- 프론트엔드에서 한글로 데이터를 전송해도 오류 없이 정상 처리 가능
- 프론트엔드 개발자가 별도의 변환 작업 없이 자연스러운 한글 인터페이스 구현 가능
- 백엔드 시스템 내부에서는 여전히 영문 Enum을 사용하여 일관성 유지

---

## 📂 관련 클래스 및 변경 파일

- User
- UpdateForm
- AddUserInfoService
- ManageService

---


