### PR TITLE
Fix/ CORS 설정에서 "Last-Event-ID" 헤더 허용

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/common/config/CorsConfig.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/common/config/CorsConfig.java
@@ -16,7 +16,7 @@ public class CorsConfig {
 				registry.addMapping("/**")
 					.allowedOrigins("http://localhost:3000") // 정확한 Origin 명시
 					.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-					.allowedHeaders("Content-Type", "Authorization")
+					.allowedHeaders("Content-Type", "Authorization", "Last-Event-ID")
 					.exposedHeaders("Set-Cookie")
 					.allowCredentials(true);
 			}

--- a/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/SecurityConfiguration.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/social_login/config/SecurityConfiguration.java
@@ -97,7 +97,7 @@ public class SecurityConfiguration {
 		configuration.setAllowedOrigins(List.of("http://localhost:3000", BASE_URL));
 		configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
 		configuration.setAllowCredentials(true);
-		configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "X-Requested-With", "Accept"));
+		configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "X-Requested-With", "Accept", "Last-Event-ID"));
 		configuration.setExposedHeaders(Arrays.asList("Authorization", "Set-Cookie"));
 		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
 		source.registerCorsConfiguration("/**", configuration);


### PR DESCRIPTION
## 🔍 주요 변경 사항

- CORS 설정에서 "Last-Event-ID" 헤더를 허용하도록 함.

---

## 💡 변경 이유

- SSE 연결이 비정상적으로 끊겼을 때 프론트엔드 측에서 다시 재시도를 하는데 이때 Last-Event-ID 헤더에 가장 최근에 받았던 메세지의 ID를 담아 전달함. 백엔드 측에서는 해당 헤더에 담긴 ID값을 기준으로 그 후의 메세지부터 알림을 전송함. 
- 따라서 CORS 설정에서 Last-Event-ID 헤더를 허용해줄 필요가 있음.

---

## 🚀 개선 결과

- 비정상적으로 sse 연결이 종료되고 다시 재연결을 시도할 때 Last-Event-ID 값을 받아 해당 ID를 기준으로 다시 메세지를 전송할 수 있음.

---

## 📂 관련 클래스 및 변경 파일

- CorsConfig
- SecurityConfiguration

---



