### PR TITLE
Fix/chatroom quartz config : Job 자동실행 되지 않아 커피챗 진행되지 않은 문제 해결 

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/config/QuartzConfig.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/config/QuartzConfig.java
@@ -1,0 +1,38 @@
+package com.icandoit.boottalk.stomp_chat.config;
+
+import org.quartz.spi.TriggerFiredBundle;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.quartz.SchedulerFactoryBean;
+import org.springframework.scheduling.quartz.SpringBeanJobFactory;
+
+@Configuration
+public class QuartzConfig {
+
+    private final AutowireCapableBeanFactory beanFactory;
+
+    public QuartzConfig(AutowireCapableBeanFactory beanFactory) {
+        this.beanFactory = beanFactory;
+    }
+
+    @Bean
+    public SchedulerFactoryBean schedulerFactoryBean() {
+        SchedulerFactoryBean factory = new SchedulerFactoryBean();
+        factory.setJobFactory(springBeanJobFactory());
+        return factory;
+    }
+
+    @Bean
+    public SpringBeanJobFactory springBeanJobFactory() {
+        return new SpringBeanJobFactory() {
+            @Override
+            protected Object createJobInstance(TriggerFiredBundle bundle) throws Exception {
+                Object job = super.createJobInstance(bundle);
+                beanFactory.autowireBean(job);
+                return job;
+            }
+        };
+    }
+}
+

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/config/QuartzConfig.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/config/QuartzConfig.java
@@ -1,5 +1,8 @@
 package com.icandoit.boottalk.stomp_chat.config;
 
+import lombok.RequiredArgsConstructor;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
 import org.quartz.spi.TriggerFiredBundle;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.context.annotation.Bean;
@@ -8,17 +11,15 @@ import org.springframework.scheduling.quartz.SchedulerFactoryBean;
 import org.springframework.scheduling.quartz.SpringBeanJobFactory;
 
 @Configuration
+@RequiredArgsConstructor
 public class QuartzConfig {
 
     private final AutowireCapableBeanFactory beanFactory;
 
-    public QuartzConfig(AutowireCapableBeanFactory beanFactory) {
-        this.beanFactory = beanFactory;
-    }
-
     @Bean
     public SchedulerFactoryBean schedulerFactoryBean() {
         SchedulerFactoryBean factory = new SchedulerFactoryBean();
+        factory.setAutoStartup(true);
         factory.setJobFactory(springBeanJobFactory());
         return factory;
     }
@@ -33,6 +34,11 @@ public class QuartzConfig {
                 return job;
             }
         };
+    }
+
+    @Bean
+    public Scheduler scheduler(SchedulerFactoryBean schedulerFactoryBean) throws SchedulerException {
+        return schedulerFactoryBean.getScheduler();
     }
 }
 

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/scheduler/ChatQuartzSchedulerService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/scheduler/ChatQuartzSchedulerService.java
@@ -27,6 +27,7 @@ public class ChatQuartzSchedulerService {
 
         try {
             scheduleJob(roomUuid, startTime, StartCoffeeChatJob.class, "start");
+            log.info("Start job scheduled: {}", startTime);
         } catch (SchedulerException e) {
             log.error("시작 스케쥴러 작업 실패 - roomUuid : {}", roomUuid, e);
             throw new CustomException(ErrorCode.SCHEDULER_START_JOB_ERROR);
@@ -34,6 +35,7 @@ public class ChatQuartzSchedulerService {
 
         try {
             scheduleJob(roomUuid, endTime, EndCoffeeChatJob.class, "end");
+            log.info("End job scheduled: {}", endTime);
         } catch (SchedulerException e) {
             log.error("종료 스케쥴러 작업 실패 - roomUuid : {}", roomUuid, e);
             throw new CustomException(ErrorCode.SCHEDULER_END_JOB_ERROR);

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/scheduler/ChatQuartzSchedulerService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/scheduler/ChatQuartzSchedulerService.java
@@ -27,7 +27,7 @@ public class ChatQuartzSchedulerService {
 
         try {
             scheduleJob(roomUuid, startTime, StartCoffeeChatJob.class, "start");
-            log.info("Start job scheduled: {}", startTime);
+            log.info("Start job scheduled: {}, roomUuid: {}", startTime, roomUuid);
         } catch (SchedulerException e) {
             log.error("시작 스케쥴러 작업 실패 - roomUuid : {}", roomUuid, e);
             throw new CustomException(ErrorCode.SCHEDULER_START_JOB_ERROR);
@@ -35,7 +35,7 @@ public class ChatQuartzSchedulerService {
 
         try {
             scheduleJob(roomUuid, endTime, EndCoffeeChatJob.class, "end");
-            log.info("End job scheduled: {}", endTime);
+            log.info("End job scheduled: {}, roomUuid:{}", endTime, roomUuid);
         } catch (SchedulerException e) {
             log.error("종료 스케쥴러 작업 실패 - roomUuid : {}", roomUuid, e);
             throw new CustomException(ErrorCode.SCHEDULER_END_JOB_ERROR);

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/scheduler/EndCoffeeChatJob.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/scheduler/EndCoffeeChatJob.java
@@ -19,6 +19,7 @@ public class EndCoffeeChatJob extends QuartzJobBean {
     protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
         try {
             String roomUuid = context.getMergedJobDataMap().getString("roomUuid");
+            log.info("EndCoffeeChatJob 실행됨 - roomUuid: {}", roomUuid);
             chatRoomService.endCoffeeChat(roomUuid);
         } catch (Exception e) {
             // 예외가 발생하면 RuntimeException을 던진다.

--- a/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/scheduler/StartCoffeeChatJob.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/stomp_chat/scheduler/StartCoffeeChatJob.java
@@ -19,6 +19,7 @@ public class StartCoffeeChatJob extends QuartzJobBean {
     protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
         try {
             String roomUuid = context.getMergedJobDataMap().getString("roomUuid");
+            log.info("StartCoffeeChatJob 실행됨 - roomUuid: {}", roomUuid);
             chatRoomService.activateChatRoom(roomUuid);
         } catch (Exception e) {
             throw new JobExecutionException("Error while starting coffee chat", e);


### PR DESCRIPTION
## 🔍 주요 변경 사항
-`QuartzConfig` 클래스의 `schedulerFactoryBean` 메서드에 `setAutoStartup(true)` 설정 추가
- 스케줄러가 애플리케이션 시작 시 자동으로 시작되도록 수정
---

## 💡 변경 이유

- Quartz 스케줄러가 자동으로 시작되지 않아 예약된 채팅방 시작/종료 작업이 실행되지 않는 문제가 발생하여 코드 수정. 