### PR TITLE
fix : bootcamp notification 이 하루에도 수십개씩 가는거 한개로 수정

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/batch/scheduler/NotificationQuartzJob.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/batch/scheduler/NotificationQuartzJob.java
@@ -73,12 +73,10 @@ public class NotificationQuartzJob extends QuartzJobBean {
 		List<Long> targetUserIds = userRepository.findByIdsByDesiredCareer(category);
 
 		for (Long userId : targetUserIds) {
-			for (String bootcampId : bootcampIds) {
-				try {
-					publishNotificationEvent(userId, bootcampId);
-				} catch (Exception e) {
-					log.error("알림 발송 실패 - userId: {}, bootcampId: {}, error: {}", userId, bootcampId, e.getMessage());
-				}
+			try {
+				publishNotificationEvent(userId);
+			} catch (Exception e) {
+				log.error("알림 발송 실패 - userId: {}, error: {}", userId, e.getMessage());
 			}
 		}
 
@@ -86,13 +84,13 @@ public class NotificationQuartzJob extends QuartzJobBean {
 		log.info("처리 완료된 Redis key 삭제: {}", key);
 	}
 
-	private void publishNotificationEvent(Long userId, String bootcampId) {
+	private void publishNotificationEvent(Long userId) {
 		NotificationRequestDto requestDto = new NotificationRequestDto(
 			NotificationType.NEW_BOOT_CAMP,
-			Long.valueOf(bootcampId)
+			null
 		);
 
 		eventPublisher.publishEvent(new NotificationEvent(userId, requestDto));
-		log.info("알림 발송 완료 - userId: {}, bootcampId: {}", userId, bootcampId);
+		log.info("알림 발송 완료 - userId: {}", userId);
 	}
 }


### PR DESCRIPTION
## 🔍 주요 변경 사항
- Redis에 저장된 부트캠프 정보가 존재할 경우, 모든 부트캠프 ID에 대해 반복적으로 알림을 보내던 방식을 → 유저 1명당 알림 1회 전송 방식으로 변경
- 알림 생성 시 bootcampId를 null로 설정하여 일반적인 알림 메시지 전송
- Redis 키 삭제 로직은 그대로 유지하여 중복 알림 방지


---

## 💡 변경 이유
- 기존 로직은 Redis에 여러 부트캠프 ID가 등록되었을 경우, 유저 1명당 중복 알림이 여러 번 전송되는 문제가 있었음
- 실제 사용자 경험 측면에서 한 번의 일반적인 알림만 필요하기 때문에, 이를 간결하게 수정하여 사용자 피로도를 낮춤


---

## 🚀 개선 결과
- 유저 한 명에게 중복 알림 없이 알림이 한 번만 전달됨
- Redis 키는 처리 후 삭제되므로 중복 전송 위험 없음
- Redis에 부트캠프 정보가 존재할 때만 알림 전송되므로 불필요한 작업 방지
- 코드 간결성 및 유지보수성 향상


---

## 📂 관련 클래스 및 변경 파일
- NotificationQuartzJob.java

