### PR TITLE
Fix/알림 전송 기능 스레드 풀 제한

### DIFF
--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/config/AsyncConfig.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/config/AsyncConfig.java
@@ -1,0 +1,23 @@
+package com.icandoit.boottalk.notification.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+@EnableConfigurationProperties
+public class AsyncConfig {
+
+	@Bean(name = "notificationTaskExecutor")
+	@ConfigurationProperties(prefix = "spring.task.execution")
+	public ThreadPoolTaskExecutor notificationTaskExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setWaitForTasksToCompleteOnShutdown(true);
+		executor.setAwaitTerminationSeconds(60);
+		return executor;
+	}
+}

--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/service/SseEmitterService.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/service/SseEmitterService.java
@@ -84,13 +84,13 @@ public class SseEmitterService {
 
 	// 이벤트를 발행한 트랜잭션이 성공적으로 커밋된 후에만 해당 이벤트 핸들러들이 실행됨.
 
-	@Async
+	@Async("notificationTaskExecutor")
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void handlePointEvent(CreatePointEvent createPointEvent) {
 		sendPointNotification(createPointEvent.userId());
 	}
 
-	@Async
+	@Async("notificationTaskExecutor")
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
 	public void handleNotificationEvent(NotificationEvent notificationEvent) {

--- a/boottalk/src/main/java/com/icandoit/boottalk/notification/type/NotificationType.java
+++ b/boottalk/src/main/java/com/icandoit/boottalk/notification/type/NotificationType.java
@@ -17,7 +17,7 @@ public enum NotificationType {
 	CERTIFICATE_VERIFIED("/mypage?tab=profile", "수료증 인증이 완료되었습니다."),       // 수료증 인증 완료 알림
 	CERTIFICATE_REJECTED("/mypage?tab=certificates", "수료증 인증이 거절되었습니다."),// 수료증 인증 반려 알림
 	NEW_BOOT_CAMP("/bootcamps", "관심있는 직군의 새로운 부트캠프가 등록되었습니다."),// 새로운 부트캠프 등록
-    COFFEE_CHAT_REMINDER_30_MINUTES_AHEAD("/chat-rooms", "곧 커피챗이 시작됩니다. 늦지 않게 준비하시기 바랍니다!"),
+    COFFEE_CHAT_REMINDER_30_MINUTES_AHEAD("/chat", "곧 커피챗이 시작됩니다. 늦지 않게 준비하시기 바랍니다!"),
 	CHAT_MESSAGE_RECEIVED("/chat", "상대방이 메시지를 보냈어요. 커피챗을 이어가볼까요? ☕");
 
 	private final String urlFormat;

--- a/boottalk/src/main/resources/application.yml
+++ b/boottalk/src/main/resources/application.yml
@@ -7,6 +7,12 @@ spring:
     url: jdbc:mysql://localhost:3306/boottalk_db
     username: user
     password: 1234
+    hikari:
+      maximum-pool-size: 30
+      minimum-idle: 5
+      idle-timeout: 10000      # 10초 이상 안 쓰면 반환
+      max-lifetime: 1800000    # 30분 이상 연결된 커넥션 제거
+      connection-timeout: 30000
   jpa:
     hibernate:
       ddl-auto: update
@@ -37,6 +43,14 @@ spring:
       host: 43.200.67.27
       port: 6379
 
-#추 후 프록시 서버로 변경
+  task:
+    execution:
+      pool:
+        core-size: 5
+        max-size: 5
+        queue-capacity: 500
+      thread-name-prefix: notification-
+
+
 server:
   url: "http://43.200.67.27:4000"


### PR DESCRIPTION
## 🔍 주요 변경 사항

- AsyncConfig 를 추가하여 비동기적으로 실행되는 알림 전송 기능의 스레드 풀 제한
- application.yml 파일에 스레드 생성 설정을 추가해 AsyncConfig에 적용될 수 있도록 함. 

---

## 💡 변경 이유

- 현재 알림 전송은 비동기적으로 실행되는데 이때 알림 전송이 너무 증가해버리면 알림 전송 작업을 처리하는 스레드의 개수가 제한 없이 증가해 서버가 다운되는 문제가 발생함.  

---

## 🚀 개선 결과

- 알림 전송이 급증하더라도 스레드 풀 제한 설정으로 서버다운 방지

---

## 📂 관련 클래스 및 변경 파일

- `AsyncConfig`
- `application.yml`

---




